### PR TITLE
[dashboard, server] Fix streaming of image build logs

### DIFF
--- a/components/dashboard/src/components/PrebuildLogs.tsx
+++ b/components/dashboard/src/components/PrebuildLogs.tsx
@@ -100,10 +100,11 @@ export default function PrebuildLogs(props: PrebuildLogsProps) {
                         info: WorkspaceImageBuild.StateInfo,
                         content?: WorkspaceImageBuild.LogContent,
                     ) => {
-                        if (!content) {
+                        if (!content?.data) {
                             return;
                         }
-                        logsEmitter.emit("logs", content.data);
+                        const uintArray = new Uint8Array(content.data);
+                        logsEmitter.emit("logs", uintArray);
                     },
                 }),
             );

--- a/components/dashboard/src/data/workspaces/default-workspace-image-query.ts
+++ b/components/dashboard/src/data/workspaces/default-workspace-image-query.ts
@@ -8,12 +8,16 @@ import { useQuery } from "@tanstack/react-query";
 import { GetWorkspaceDefaultImageResponse } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { workspaceClient } from "../../service/public-api";
 
-export const useWorkspaceDefaultImageQuery = (workspaceId: string) => {
-    return useQuery<GetWorkspaceDefaultImageResponse>({
-        queryKey: ["default-workspace-image-v2", { workspaceId }],
+export const useWorkspaceDefaultImageQuery = (workspaceId?: string) => {
+    return useQuery<GetWorkspaceDefaultImageResponse | null, Error, GetWorkspaceDefaultImageResponse | undefined>({
+        queryKey: ["default-workspace-image-v2", { workspaceId: workspaceId || "undefined" }],
         staleTime: 1000 * 60 * 10, // 10 minute
         queryFn: async () => {
+            if (!workspaceId) {
+                return null; // no workspaceId, no image. Using null because "undefined" is not persisted by react-query
+            }
             return await workspaceClient.getWorkspaceDefaultImage({ workspaceId });
         },
+        select: (data) => data || undefined,
     });
 };

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -132,7 +132,7 @@ function StartError(props: { error: StartWorkspaceError }) {
 }
 
 function WarningView(props: { workspaceId?: string; showLatestIdeWarning?: boolean; error?: StartWorkspaceError }) {
-    const { data: imageInfo } = useWorkspaceDefaultImageQuery(props.workspaceId ?? "");
+    const { data: imageInfo } = useWorkspaceDefaultImageQuery(props.workspaceId);
     let useWarning: "latestIde" | "orgImage" | undefined = props.showLatestIdeWarning ? "latestIde" : undefined;
     if (
         props.error &&

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -791,10 +791,11 @@ function ImageBuildView(props: ImageBuildViewProps) {
                 info: WorkspaceImageBuild.StateInfo,
                 content?: WorkspaceImageBuild.LogContent,
             ) => {
-                if (!content) {
+                if (!content?.data) {
                     return;
                 }
-                logsEmitter.emit("logs", content.data);
+                const chunk = new Uint8Array(content.data);
+                logsEmitter.emit("logs", chunk);
             },
         });
 

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -322,8 +322,8 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         this.setState({ ideOptions });
     }
 
-    private async onWorkspaceUpdate(workspace: Workspace) {
-        if (!workspace.status?.instanceId) {
+    private async onWorkspaceUpdate(workspace?: Workspace) {
+        if (!workspace?.status?.instanceId || !workspace.id) {
             return;
         }
         // Here we filter out updates to instances we haven't started to avoid issues with updates coming in out-of-order

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -974,7 +974,7 @@ export namespace WorkspaceImageBuild {
         maxSteps?: number;
     }
     export interface LogContent {
-        data: Uint8Array;
+        data: number[]; // encode with "Array.from(UInt8Array)"", decode with "new UInt8Array(data)"
     }
     export type LogCallback = (info: StateInfo, content: LogContent | undefined) => void;
     export namespace LogLine {

--- a/components/server/src/workspace/headless-log-controller.ts
+++ b/components/server/src/workspace/headless-log-controller.ts
@@ -12,7 +12,6 @@ import {
     TeamMemberInfo,
     User,
     Workspace,
-    WorkspaceImageBuild,
     WorkspaceInstance,
 } from "@gitpod/gitpod-protocol";
 import { log, LogContext } from "@gitpod/gitpod-protocol/lib/util/logging";
@@ -183,20 +182,14 @@ export class HeadlessLogController {
                         res,
                         "image-build",
                     );
-                    const client = {
-                        onWorkspaceImageBuildLogs: async (
-                            _info: WorkspaceImageBuild.StateInfo,
-                            content?: WorkspaceImageBuild.LogContent,
-                        ) => {
-                            if (!content) return;
-
-                            await writeToResponse(content.data);
-                        },
-                    };
 
                     try {
                         await runWithSubSignal(abortController, async () => {
-                            await this.workspaceService.watchWorkspaceImageBuildLogs(user.id, workspaceId, client);
+                            await this.workspaceService.watchWorkspaceImageBuildLogs(
+                                user.id,
+                                workspaceId,
+                                writeToResponse,
+                            );
                         });
 
                         // Wait until we finished writing all chunks in our queue

--- a/components/server/src/workspace/workspace-service.spec.db.ts
+++ b/components/server/src/workspace/workspace-service.spec.db.ts
@@ -12,7 +12,6 @@ import {
     Project,
     User,
     WorkspaceConfig,
-    WorkspaceImageBuild,
     WorkspaceInstancePort,
 } from "@gitpod/gitpod-protocol";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
@@ -489,24 +488,19 @@ describe("WorkspaceService", async () => {
     it("should watchWorkspaceImageBuildLogs", async () => {
         const svc = container.get(WorkspaceService);
         const ws = await createTestWorkspace(svc, org, owner, project);
-        const client = {
-            onWorkspaceImageBuildLogs: (
-                info: WorkspaceImageBuild.StateInfo,
-                content: WorkspaceImageBuild.LogContent | undefined,
-            ) => {},
-        };
+        const receiver = async (chunk: Uint8Array) => {};
 
-        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, client); // returns without error in case of non-running workspace
+        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, receiver); // returns without error in case of non-running workspace
 
         await expectError(
             ErrorCodes.PERMISSION_DENIED,
-            svc.watchWorkspaceImageBuildLogs(member.id, ws.id, client),
+            svc.watchWorkspaceImageBuildLogs(member.id, ws.id, receiver),
             "should fail for member on not-shared workspace",
         );
 
         await expectError(
             ErrorCodes.NOT_FOUND,
-            svc.watchWorkspaceImageBuildLogs(stranger.id, ws.id, client),
+            svc.watchWorkspaceImageBuildLogs(stranger.id, ws.id, receiver),
             "should fail for stranger on not-shared workspace",
         );
     });
@@ -514,18 +508,13 @@ describe("WorkspaceService", async () => {
     it("should watchWorkspaceImageBuildLogs - shared", async () => {
         const svc = container.get(WorkspaceService);
         const ws = await createTestWorkspace(svc, org, owner, project);
-        const client = {
-            onWorkspaceImageBuildLogs: (
-                info: WorkspaceImageBuild.StateInfo,
-                content: WorkspaceImageBuild.LogContent | undefined,
-            ) => {},
-        };
+        const receiver = async (chunk: Uint8Array) => {};
 
         await svc.controlAdmission(owner.id, ws.id, "everyone");
 
-        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, client); // returns without error in case of non-running workspace
-        await svc.watchWorkspaceImageBuildLogs(member.id, ws.id, client);
-        await svc.watchWorkspaceImageBuildLogs(stranger.id, ws.id, client);
+        await svc.watchWorkspaceImageBuildLogs(owner.id, ws.id, receiver); // returns without error in case of non-running workspace
+        await svc.watchWorkspaceImageBuildLogs(member.id, ws.id, receiver);
+        await svc.watchWorkspaceImageBuildLogs(stranger.id, ws.id, receiver);
     });
 
     it("should sendHeartBeat", async () => {

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -10,7 +10,6 @@ import { RedisPublisher, WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import {
     CommitContext,
     GetWorkspaceTimeoutResult,
-    GitpodClient,
     GitpodServer,
     HeadlessLogUrls,
     PortProtocol,
@@ -1116,7 +1115,7 @@ export class WorkspaceService {
     public async watchWorkspaceImageBuildLogs(
         userId: string,
         workspaceId: string,
-        client: Pick<GitpodClient, "onWorkspaceImageBuildLogs">,
+        receiver: (chunk: Uint8Array) => Promise<void>,
     ): Promise<void> {
         // check access
         await this.getWorkspace(userId, workspaceId);
@@ -1168,9 +1167,7 @@ export class WorkspaceService {
 
                 try {
                     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    client.onWorkspaceImageBuildLogs(undefined as any, {
-                        data: chunk,
-                    });
+                    await receiver(chunk);
                 } catch (err) {
                     log.error("error while streaming imagebuild logs", err);
                     aborted.resolve(true);

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -1166,7 +1166,6 @@ export class WorkspaceService {
                 }
 
                 try {
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
                     await receiver(chunk);
                 } catch (err) {
                     log.error("error while streaming imagebuild logs", err);


### PR DESCRIPTION
## Description
When fixing chunking-issues, we lost sight of some older clients that still use the json-rpc interface, and are constrained by it's limitations. This PR makes sure we only transmit primitive data types.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-618
Fixes ENT-255 (got too annoying while debugging)

## How to test
 - example branch: https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-10mins
 - start a workspace which requires an image build: verify how logs are streamed correctly :heavy_check_mark: 
 - (reset for test by bumping this number: [line](https://github.com/geropl/gitpod-test-repo/blob/gpl/docker-build-10mins/.gitpod/Dockerfile#L3))
 - trigger a prebuild for a workspaces which requires an image build: verify how logs are streamed correctly in the prebuild details view :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
