### PR TITLE
[server] Add some tests

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-context-parser.spec.ts
@@ -29,7 +29,7 @@ class TestBitbucketServerContextParser {
     static readonly AUTH_HOST_CONFIG: Partial<AuthProviderParams> = {
         id: "MyBitbucketServer",
         type: "BitbucketServer",
-        host: "bitbucket.gitpod-self-hosted.com",
+        host: "bitbucket.gitpod-dev.com",
     };
 
     public before() {
@@ -83,26 +83,26 @@ class TestBitbucketServerContextParser {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+            "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
         );
 
         expect(result).to.deep.include({
             ref: "master",
             refType: "branch",
-            revision: "9eea1cca9bb98f0caf7ae77c740d5d24548ff33c",
+            revision: "506e5aed317f28023994ecf8ca6ed91430e9c1a4",
             path: "",
             isFile: false,
             repository: {
-                host: "bitbucket.gitpod-self-hosted.com",
-                owner: "FOO",
-                name: "repo123",
-                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
-                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                host: "bitbucket.gitpod-dev.com",
+                owner: "GIT",
+                name: "gitpod-test-repo",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
                 defaultBranch: "master",
                 private: true,
                 repoKind: "projects",
             },
-            title: "FOO/repo123 - master",
+            title: "GIT/gitpod-test-repo - master",
         });
     }
 
@@ -110,79 +110,131 @@ class TestBitbucketServerContextParser {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
+            "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
         );
 
         expect(result).to.deep.include({
             ref: "master",
             refType: "branch",
-            revision: "9eea1cca9bb98f0caf7ae77c740d5d24548ff33c",
+            revision: "506e5aed317f28023994ecf8ca6ed91430e9c1a4",
             path: "",
             isFile: false,
             repository: {
-                host: "bitbucket.gitpod-self-hosted.com",
-                owner: "FOO",
-                name: "repo123",
-                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
-                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                host: "bitbucket.gitpod-dev.com",
+                owner: "GIT",
+                name: "gitpod-test-repo",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
                 defaultBranch: "master",
                 private: true,
                 repoKind: "projects",
             },
-            title: "foo/repo123 - master",
+            title: "git/gitpod-test-repo - master",
         });
     }
 
-    @test async test_tree_context_03() {
+    @test async test_tree_context_03_user_repo() {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://bitbucket.gitpod-self-hosted.com/scm/~alextugarev/tada.git",
+            "https://bitbucket.gitpod-dev.com/scm/~geropl/test-user-repo.git",
         );
 
         expect(result).to.deep.include({
             ref: "main",
             refType: "branch",
-            revision: "d4bdb1459f9fc90756154bdda5eb23c39457a89c",
+            revision: "153ceae2a36f7e0b320ac72b593164efe11cd4ad",
             path: "",
             isFile: false,
             repository: {
-                host: "bitbucket.gitpod-self-hosted.com",
-                owner: "alextugarev",
-                name: "tada",
-                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/~alextugarev/tada.git",
-                webUrl: "https://bitbucket.gitpod-self-hosted.com/users/alextugarev/repos/tada",
+                host: "bitbucket.gitpod-dev.com",
+                owner: "geropl",
+                name: "test-user-repo",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/~geropl/test-user-repo.git",
+                webUrl: "https://bitbucket.gitpod-dev.com/users/geropl/repos/test-user-repo",
                 defaultBranch: "main",
                 private: true,
                 repoKind: "users",
             },
-            title: "alextugarev/tada - main",
+            title: "geropl/test-user-repo - main",
         });
     }
 
-    @test async test_commit_context_01() {
+    @test async test_commit_context_01_user_repo() {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://bitbucket.gitpod-self-hosted.com/users/jan/repos/yolo/commits/ec15264e536e9684034ea8e08f3afc3fd485b613",
+            "https://bitbucket.gitpod-dev.com/users/geropl/repos/test-user-repo/commits/153ceae2a36f7e0b320ac72b593164efe11cd4ad",
         );
 
         expect(result).to.deep.include({
             refType: "revision",
-            revision: "ec15264e536e9684034ea8e08f3afc3fd485b613",
+            revision: "153ceae2a36f7e0b320ac72b593164efe11cd4ad",
             path: "",
             isFile: false,
             repository: {
-                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/~jan/yolo.git",
-                defaultBranch: "master",
-                host: "bitbucket.gitpod-self-hosted.com",
-                name: "YOLO",
-                owner: "jan",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/~geropl/test-user-repo.git",
+                defaultBranch: "main",
+                host: "bitbucket.gitpod-dev.com",
+                name: "test-user-repo",
+                owner: "geropl",
                 private: true,
                 repoKind: "users",
-                webUrl: "https://bitbucket.gitpod-self-hosted.com/users/jan/repos/yolo",
+                webUrl: "https://bitbucket.gitpod-dev.com/users/geropl/repos/test-user-repo",
             },
-            title: "jan/yolo - ec15264e536e9684034ea8e08f3afc3fd485b613",
+            title: "geropl/test-user-repo - 153ceae2a36f7e0b320ac72b593164efe11cd4ad",
+        });
+    }
+
+    @test async test_commit_context_02() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo/commits/506e5aed317f28023994ecf8ca6ed91430e9c1a4",
+        );
+
+        expect(result).to.deep.include({
+            refType: "revision",
+            revision: "506e5aed317f28023994ecf8ca6ed91430e9c1a4",
+            path: "",
+            isFile: false,
+            repository: {
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                defaultBranch: "master",
+                host: "bitbucket.gitpod-dev.com",
+                name: "gitpod-test-repo",
+                owner: "GIT",
+                private: true,
+                repoKind: "projects",
+                webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
+            },
+            title: "GIT/gitpod-test-repo - 506e5aed317f28023994ecf8ca6ed91430e9c1a4",
+        });
+    }
+
+    @test async test_commit_context_03_with_branch_ref() {
+        const result = await this.parser.handle(
+            {},
+            this.user,
+            "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo/commits/506e5aed317f28023994ecf8ca6ed91430e9c1a4#master",
+        );
+
+        expect(result).to.deep.include({
+            refType: "revision",
+            revision: "506e5aed317f28023994ecf8ca6ed91430e9c1a4",
+            path: "",
+            isFile: false,
+            repository: {
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                defaultBranch: "master",
+                host: "bitbucket.gitpod-dev.com",
+                name: "gitpod-test-repo",
+                owner: "GIT",
+                private: true,
+                repoKind: "projects",
+                webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
+            },
+            title: "GIT/gitpod-test-repo - 506e5aed317f28023994ecf8ca6ed91430e9c1a4",
         });
     }
 
@@ -217,21 +269,21 @@ class TestBitbucketServerContextParser {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/pull-requests/1/commits",
+            "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo/pull-requests/1/commits",
         );
 
         expect(result).to.deep.include({
-            title: "Let's do it",
+            title: "1test - DONT TOUCH",
             nr: 1,
-            ref: "foo",
+            ref: "1test",
             refType: "branch",
-            revision: "1384b6842d73b8705feaf45f3e8aa41f00529042",
+            revision: "0d34597386bdd90976ed70991c39f566b290066d",
             repository: {
-                host: "bitbucket.gitpod-self-hosted.com",
-                owner: "FOO",
-                name: "repo123",
-                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
-                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                host: "bitbucket.gitpod-dev.com",
+                owner: "GIT",
+                name: "gitpod-test-repo",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
                 defaultBranch: "master",
                 private: true,
                 repoKind: "projects",
@@ -240,11 +292,11 @@ class TestBitbucketServerContextParser {
                 ref: "master",
                 refType: "branch",
                 repository: {
-                    host: "bitbucket.gitpod-self-hosted.com",
-                    owner: "FOO",
-                    name: "repo123",
-                    cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
-                    webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                    host: "bitbucket.gitpod-dev.com",
+                    owner: "GIT",
+                    name: "gitpod-test-repo",
+                    cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                    webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
                     defaultBranch: "master",
                     private: true,
                     repoKind: "projects",
@@ -257,61 +309,21 @@ class TestBitbucketServerContextParser {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/pull-requests/2/overview",
+            "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo/pull-requests/1/overview",
         );
 
         expect(result).to.deep.include({
-            title: "Let's do it again",
-            nr: 2,
-            ref: "foo",
-            refType: "branch",
-            revision: "1384b6842d73b8705feaf45f3e8aa41f00529042",
-            repository: {
-                host: "bitbucket.gitpod-self-hosted.com",
-                owner: "LAL",
-                name: "repo123",
-                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/lal/repo123.git",
-                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/LAL/repos/repo123",
-                defaultBranch: "master",
-                private: true,
-                repoKind: "projects",
-            },
-            base: {
-                ref: "master",
-                refType: "branch",
-                repository: {
-                    host: "bitbucket.gitpod-self-hosted.com",
-                    owner: "FOO",
-                    name: "repo123",
-                    cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
-                    webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
-                    defaultBranch: "master",
-                    private: true,
-                    repoKind: "projects",
-                },
-            },
-        });
-    }
-
-    @test async test_PR_context_03() {
-        const result = await this.parser.handle(
-            {},
-            this.user,
-            "https://bitbucket.gitpod-self-hosted.com/projects/LAL/repos/repo123/pull-requests/1/overview",
-        );
-
-        expect(result).to.deep.include({
-            title: "U turn",
+            title: "1test - DONT TOUCH",
             nr: 1,
-            ref: "foo",
+            ref: "1test",
             refType: "branch",
-            revision: "1384b6842d73b8705feaf45f3e8aa41f00529042",
+            revision: "0d34597386bdd90976ed70991c39f566b290066d",
             repository: {
-                host: "bitbucket.gitpod-self-hosted.com",
-                owner: "FOO",
-                name: "repo123",
-                cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/foo/repo123.git",
-                webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123",
+                host: "bitbucket.gitpod-dev.com",
+                owner: "GIT",
+                name: "gitpod-test-repo",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
                 defaultBranch: "master",
                 private: true,
                 repoKind: "projects",
@@ -320,11 +332,11 @@ class TestBitbucketServerContextParser {
                 ref: "master",
                 refType: "branch",
                 repository: {
-                    host: "bitbucket.gitpod-self-hosted.com",
-                    owner: "LAL",
-                    name: "repo123",
-                    cloneUrl: "https://bitbucket.gitpod-self-hosted.com/scm/lal/repo123.git",
-                    webUrl: "https://bitbucket.gitpod-self-hosted.com/projects/LAL/repos/repo123",
+                    host: "bitbucket.gitpod-dev.com",
+                    owner: "GIT",
+                    name: "gitpod-test-repo",
+                    cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                    webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
                     defaultBranch: "master",
                     private: true,
                     repoKind: "projects",
@@ -337,30 +349,30 @@ class TestBitbucketServerContextParser {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://bitbucket.gitpod-dev.com/users/filip/repos/repodepo/browse?at=refs%2Ftags%2Fv0.0.1",
+            "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo/browse?at=refs%2Ftags%2Ftest-tag-v1.0.1",
         );
 
         expect(result).to.deep.include({
-            title: "filip/repodepo - v0.0.1",
-            ref: "v0.0.1",
+            title: "GIT/gitpod-test-repo - test-tag-v1.0.1",
+            ref: "test-tag-v1.0.1",
             refType: "tag",
-            revision: "c16d4d0049545e7d8908302c07550f9d325fbed4",
+            revision: "506e5aed317f28023994ecf8ca6ed91430e9c1a4",
             repository: {
                 host: "bitbucket.gitpod-dev.com",
-                owner: "filip",
-                name: "RepoDepo",
-                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/~filip/repodepo.git",
-                webUrl: "https://bitbucket.gitpod-dev.com/users/filip/repos/repodepo",
-                defaultBranch: "main",
+                owner: "GIT",
+                name: "gitpod-test-repo",
+                cloneUrl: "https://bitbucket.gitpod-dev.com/scm/git/gitpod-test-repo.git",
+                webUrl: "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo",
+                defaultBranch: "master",
                 private: true,
-                repoKind: "users",
+                repoKind: "projects",
             },
         });
     }
 
     @test test_toSimpleBranchName() {
         const url = new URL(
-            "https://bitbucket.gitpod-self-hosted.com/projects/FOO/repos/repo123/browse?at=refs%2Fheads%2Ffoo",
+            "https://bitbucket.gitpod-dev.com/projects/GIT/repos/gitpod-test-repo/browse?at=refs%2Fheads%2Ffoo",
         );
         const branchName = this.parser.toSimpleBranchName(url.searchParams.get("at")!);
         expect(branchName).to.equal("foo");

--- a/components/server/src/bitbucket/bitbucket-context-parser.ts
+++ b/components/server/src/bitbucket/bitbucket-context-parser.ts
@@ -45,6 +45,7 @@ export class BitbucketContextParser extends AbstractContextParser implements ICo
                         const isHash = await this.isValidCommitHash(user, owner, repoName, branchTagOrHash);
                         if (isHash) {
                             more.revision = branchTagOrHash;
+                            more.refType = "revision";
                             if (searchParams.has("at")) {
                                 more.ref = searchParams.get("at")!;
                                 more.refType = "branch";

--- a/components/server/src/prebuilds/incremental-workspace-service.ts
+++ b/components/server/src/prebuilds/incremental-workspace-service.ts
@@ -18,7 +18,6 @@ import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { PrebuiltWorkspaceState, WithCommitHistory } from "@gitpod/gitpod-protocol/lib/protocol";
 import { WorkspaceDB } from "@gitpod/gitpod-db/lib";
 import { Config } from "../config";
-import { ConfigProvider } from "../workspace/config-provider";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { ImageSourceProvider } from "../workspace/image-source-provider";
 
@@ -27,7 +26,6 @@ const MAX_HISTORY_DEPTH = 100;
 @injectable()
 export class IncrementalWorkspaceService {
     @inject(Config) protected readonly config: Config;
-    @inject(ConfigProvider) protected readonly configProvider: ConfigProvider;
     @inject(HostContextProvider) protected readonly hostContextProvider: HostContextProvider;
     @inject(ImageSourceProvider) protected readonly imageSourceProvider: ImageSourceProvider;
     @inject(WorkspaceDB) protected readonly workspaceDB: WorkspaceDB;

--- a/components/server/src/workspace/workspace-factory.spec.db.ts
+++ b/components/server/src/workspace/workspace-factory.spec.db.ts
@@ -59,11 +59,9 @@ export class MockImageSourceProvider extends ImageSourceProvider {
 describe("WorkspaceFactory", async () => {
     let container: Container;
     let db: WorkspaceDB;
-    // let mockImageSourceProvider: MockImageSourceProvider;
 
     let owner: User;
     let member: User;
-    // let stranger: User;
     let org: Organization;
     let project: Project;
 
@@ -79,7 +77,6 @@ describe("WorkspaceFactory", async () => {
         } as any as ConfigProvider);
         container.rebind(IncrementalWorkspaceService).to(MockIncrementalWorkspaceService);
         container.rebind(ImageSourceProvider).to(MockImageSourceProvider);
-        // mockImageSourceProvider = container.get(ImageSourceProvider) as MockImageSourceProvider;
         Experiments.configureTestingClient({});
         db = container.get(WorkspaceDB);
         const userService = container.get(UserService);

--- a/components/server/src/workspace/workspace-factory.spec.db.ts
+++ b/components/server/src/workspace/workspace-factory.spec.db.ts
@@ -1,0 +1,255 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { TypeORM, WorkspaceDB } from "@gitpod/gitpod-db/lib";
+import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
+import {
+    CommitContext,
+    Organization,
+    PrebuiltWorkspaceContext,
+    PrebuiltWorkspaceState,
+    Project,
+    User,
+    WithCommitHistory,
+    WithPrebuild,
+    Workspace,
+    WorkspaceConfig,
+    WorkspaceImageSource,
+} from "@gitpod/gitpod-protocol";
+import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import * as chai from "chai";
+import { Container, injectable } from "inversify";
+import "mocha";
+import { OrganizationService } from "../orgs/organization-service";
+import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
+import { ProjectsService } from "../projects/projects-service";
+import { ConfigProvider } from "./config-provider";
+import { UserService } from "../user/user-service";
+import { SYSTEM_USER } from "../authorization/authorizer";
+import { WorkspaceFactory } from "./workspace-factory";
+import { IncrementalWorkspaceService } from "../prebuilds/incremental-workspace-service";
+import { ImageSourceProvider } from "./image-source-provider";
+import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
+
+const expect = chai.expect;
+
+@injectable()
+export class MockIncrementalWorkspaceService extends IncrementalWorkspaceService {
+    public commitHistory: string[];
+    public async getCommitHistoryForContext(context: CommitContext, user: User): Promise<WithCommitHistory> {
+        return {
+            commitHistory: this.commitHistory,
+        };
+    }
+}
+
+@injectable()
+export class MockImageSourceProvider extends ImageSourceProvider {
+    public imageSource: WorkspaceImageSource = { baseImageResolved: "gitpod/workspace-full:latest" };
+    public async getImageSource(
+        ctx: TraceContext,
+        user: User,
+        context: CommitContext,
+        config: WorkspaceConfig,
+    ): Promise<WorkspaceImageSource> {
+        return this.imageSource;
+    }
+}
+
+describe("WorkspaceFactory", async () => {
+    let container: Container;
+    let db: WorkspaceDB;
+    let mockIncrementalWorkspaceService: MockIncrementalWorkspaceService;
+    // let mockImageSourceProvider: MockImageSourceProvider;
+
+    let owner: User;
+    let member: User;
+    // let stranger: User;
+    let org: Organization;
+    let project: Project;
+
+    beforeEach(async () => {
+        container = createTestContainer();
+        // TODO(gpl) Ideally we should be able to factor this out into the API. But to start somewhere, we'll mock it out here.
+        container.rebind(ConfigProvider).toConstantValue({
+            fetchConfig: () => ({
+                config: <WorkspaceConfig>{
+                    image: "gitpod/workspace-full:latest",
+                },
+            }),
+        } as any as ConfigProvider);
+        container.rebind(IncrementalWorkspaceService).to(MockIncrementalWorkspaceService);
+        container.rebind(ImageSourceProvider).to(MockImageSourceProvider);
+        mockIncrementalWorkspaceService = container.get(IncrementalWorkspaceService) as MockIncrementalWorkspaceService;
+        // mockImageSourceProvider = container.get(ImageSourceProvider) as MockImageSourceProvider;
+        Experiments.configureTestingClient({});
+        db = container.get(WorkspaceDB);
+        const userService = container.get(UserService);
+
+        // create the owner
+        owner = await userService.createUser({
+            identity: {
+                authId: "33891423",
+                authName: "owner",
+                authProviderId: "Public-GitHub",
+            },
+        });
+
+        // create the org
+        const orgService = container.get(OrganizationService);
+        org = await orgService.createOrganization(owner.id, "my-org");
+
+        // create and add a member
+        member = await userService.createUser({
+            identity: {
+                authId: "33891424",
+                authName: "member",
+                authProviderId: "Public-GitHub",
+            },
+        });
+        const invite = await orgService.getOrCreateInvite(owner.id, org.id);
+        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
+
+        // create a project
+        const projectService = container.get(ProjectsService);
+        project = await projectService.createProject(
+            {
+                name: "my-project",
+                slug: "my-project",
+                teamId: org.id,
+                cloneUrl: "https://github.com/gitpod-io/gitpod",
+                appInstallationId: "noid",
+            },
+            owner,
+        );
+    });
+
+    afterEach(async () => {
+        // Clean-up database
+        await resetDB(container.get(TypeORM));
+        // Deactivate all services
+        await container.unbindAllAsync();
+    });
+
+    it("createForPrebuiltWorkspace_noPrebuild", async () => {
+        // data
+        const revision = "asdf";
+        const context = <CommitContext>{
+            title: "gitpod",
+            repository: {
+                host: "github.com",
+                owner: "gitpod-io",
+                name: "gitpod",
+                cloneUrl: "https://github.com/gitpod-io/gitpod",
+                defaultBranch: "main",
+                private: false,
+            },
+            revision,
+            ref: "gpl/test",
+            refType: "branch",
+        };
+        const contextURL = "https://github.com/gitpod-io/gitpod/tree/gpl/test";
+
+        // prepare
+        mockIncrementalWorkspaceService.commitHistory = [revision];
+
+        // test
+        const f = container.get(WorkspaceFactory);
+
+        const ws = await f.createForContext({}, owner, org.id, project, context, contextURL);
+        expect(PrebuiltWorkspaceContext.is(ws.context)).to.be.false;
+        expect(CommitContext.is(ws.context)).to.be.true;
+        expect((ws.context as CommitContext).ref).to.equal("gpl/test");
+        expect((ws.context as CommitContext).refType).to.equal("branch");
+    });
+
+    it("createForPrebuiltWorkspace_perfectHit", async () => {
+        // data
+        const revision = "asdf";
+        const context = <CommitContext>{
+            title: "gitpod",
+            repository: {
+                host: "github.com",
+                owner: "gitpod-io",
+                name: "gitpod",
+                cloneUrl: "https://github.com/gitpod-io/gitpod",
+                defaultBranch: "main",
+                private: false,
+            },
+            revision,
+            ref: "gpl/test",
+            refType: "branch",
+        };
+        const contextURL = "https://github.com/gitpod-io/gitpod/tree/gpl/test";
+        const config = <WorkspaceConfig>{
+            image: "gitpod/workspace-full:latest",
+        };
+
+        // prepare prebuild for "perfect hit"
+        mockIncrementalWorkspaceService.commitHistory = [revision];
+        const { pbws } = await createPrebuild({
+            context,
+            contextURL,
+            state: "available",
+            config,
+        });
+        const prebuiltContext = <PrebuiltWorkspaceContext>{
+            title: context.title,
+            originalContext: context,
+            prebuiltWorkspace: pbws,
+        };
+
+        const f = container.get(WorkspaceFactory);
+
+        const ws = await f.createForContext({}, owner, org.id, project, prebuiltContext, contextURL);
+        expect(CommitContext.is(ws.context)).to.be.true;
+        expect(WithPrebuild.is(ws.context)).to.be.true;
+        expect((ws.context as CommitContext).ref).to.equal("gpl/test");
+        expect((ws.context as CommitContext).refType).to.equal("branch");
+    });
+
+    const createPrebuild = async (
+        opts: Pick<Workspace, "context" | "contextURL" | "config"> & { deleted?: true; state: PrebuiltWorkspaceState },
+    ) => {
+        const context = opts.context as CommitContext;
+
+        const creationTime = new Date().toISOString();
+        const ws = await db.store({
+            id: "12345",
+            ownerId: owner.id,
+            organizationId: org.id,
+            projectId: project.id,
+            type: "prebuild",
+            creationTime,
+            description: "some description",
+            contextURL: opts.contextURL,
+            context: opts.context,
+            config: opts.config,
+        });
+        const pbws = await db.storePrebuiltWorkspace({
+            id: "prebuild123",
+            buildWorkspaceId: ws.id,
+            creationTime,
+            cloneURL: context.repository.cloneUrl,
+            commit: context.revision,
+            state: opts.state,
+
+            statusVersion: 0,
+        });
+
+        if (opts.deleted) {
+            const past = new Date(2000, 1, 1).toISOString();
+            await db.updatePartial(ws.id, {
+                deletionEligibilityTime: past,
+                softDeleted: "gc",
+                softDeletedTime: past,
+                contentDeletedTime: past,
+            });
+        }
+
+        return { ws, pbws };
+    };
+});

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -189,23 +189,23 @@ export class WorkspaceService {
             ownerId: workspace.ownerId,
             organizationId: workspace.organizationId,
             projectId: project?.id,
-            projectName: scrubber.scrubValue(project?.name || ""),
+            projectName: scrubValue(project?.name),
             contextURL: workspace.contextURL,
             context: new TrustedValue<Partial<CommitContext & WithPrebuild>>({
-                normalizedContextURL: scrubber.scrubValue(context.normalizedContextURL as string),
+                normalizedContextURL: scrubValue(context.normalizedContextURL),
                 repository: CommitContext.is(context)
                     ? {
-                          cloneUrl: scrubber.scrubValue(context.repository?.cloneUrl as string),
-                          host: scrubber.scrubValue(context.repository?.host as string),
-                          owner: scrubber.scrubValue(context.repository?.owner as string),
-                          name: scrubber.scrubValue(context.repository?.name as string),
-                          private: context.repository?.private,
-                          defaultBranch: scrubber.scrubValue(context.repository?.defaultBranch as string),
+                          cloneUrl: scrubber.scrubValue(context.repository.cloneUrl),
+                          host: scrubber.scrubValue(context.repository.host),
+                          owner: scrubber.scrubValue(context.repository.owner),
+                          name: scrubber.scrubValue(context.repository.name),
+                          private: context.repository.private,
+                          defaultBranch: scrubValue(context.repository.defaultBranch),
                       }
                     : undefined,
-                ref: scrubber.scrubValue(context.ref as string),
+                ref: scrubValue(context.ref),
                 refType: CommitContext.is(context) ? context.refType : undefined,
-                revision: CommitContext.is(context) ? scrubber.scrubValue(context.revision as string) : undefined,
+                revision: CommitContext.is(context) ? scrubValue(context.revision) : undefined,
                 wasPrebuilt: WithPrebuild.is(context) ? context.wasPrebuilt : undefined,
                 forceCreateNewWorkspace: context.forceCreateNewWorkspace,
                 forceImageBuild: context.forceImageBuild,
@@ -456,10 +456,10 @@ export class WorkspaceService {
             });
             log.info(logCtx, "starting prebuild after workspace creation", {
                 projectId: project.id,
-                projectName: scrubber.scrubValue(project.name),
+                projectName: scrubValue(project.name),
                 result: new TrustedValue({
                     prebuildId: new TrustedValue(res.prebuildId),
-                    wsid: scrubber.scrubValue(res.wsid),
+                    wsid: scrubValue(res.wsid),
                     done: res.done,
                 }),
             });
@@ -1418,4 +1418,11 @@ export function mapGrpcError(err: any): Error {
         default:
             return new ApplicationError(ErrorCodes.INTERNAL_SERVER_ERROR, err.details);
     }
+}
+
+function scrubValue(value: string | undefined): string | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    return scrubber.scrubValue(value);
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1840,7 +1840,7 @@ export class WorkspaceStarter {
         } else if (RefType.getRefType(context) === "tag") {
             targetMode = CloneTargetMode.REMOTE_COMMIT;
             cloneTarget = context.revision;
-        } else if (context.ref) {
+        } else if (RefType.getRefType(context) === "branch" && context.ref) {
             targetMode = CloneTargetMode.REMOTE_BRANCH;
             cloneTarget = context.ref;
         } else if (context.revision) {


### PR DESCRIPTION
## Description
Turned out we don't have any gaps in the context parsing/workspace creation behavior with prebuilds.
This PR confirms that with some tests.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-600

## How to test
 - see that all tests are green :heavy_check_mark: 
 - BitBucketServer tests:
![image](https://github.com/user-attachments/assets/d2a5a5e0-53c8-4599-b467-3ce06c39554b)


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
