### PR TITLE
[VS Code Browser] Build stable code `1.92.1`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 6c693cbd752da3e2b2f15517f02efdcfa87ce3c1
-  codeVersion: 1.92.0
+  codeCommit: f89b31db4e103a12b1f2250d16c7ae6ac6384e82
+  codeVersion: 1.92.1
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8f10c5febf0162a3c2309076302f770fbad38fde


### PR DESCRIPTION
## Description

Build code version `1.92.1` (`f89b31db4e103a12b1f2250d16c7ae6ac6384e82`)

Relates ENT-636

## How to test

- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [x] terminals are preserved and resized properly between window reloads
  - [x] WebViews are working
  - [x] extension host process: check language smartness and debugging
  - [x] extension management (installing/uninstalling)
  - [x] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
    - [x] extensions from `.gitpod.yml` are not installed as sync
    - [x] extensions installed as sync are actually synced to all new workspaces
  - [x] settings should not contain any mentions of MS telemetry
  - [x] WebSockets and workers are properly proxied
    - [x] diff editor should be operable
    - [x] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [x] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
  - [x] that a PR view is preloaded when opening a PR URL
  - [x] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data like `vscode_extension_gallery` is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-code-stable</li>
	<li><b>🔗 URL</b> - <a href="https://ide-code-stable.preview.gitpod-dev.com/workspaces" target="_blank">ide-code-stable.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-code-stable-gha.27936</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ide-code-stable%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment
- [x] /werft with-large-vm