### PR TITLE
Fix JetBrains integration tests

### DIFF
--- a/dev/jetbrains-test/test.sh
+++ b/dev/jetbrains-test/test.sh
@@ -2,9 +2,10 @@
 
 GATEWAY_PLUGIN_PATH=$(pwd)/gitpod-gateway.zip
 export GATEWAY_PLUGIN_PATH
+HOME=/home/gitpod
 
-mkdir -p ~/.local/share/JetBrains/consentOptions/
-echo -n "rsch.send.usage.stat:1.1:0:1644945193441" > ~/.local/share/JetBrains/consentOptions/accepted
-mkdir -p ~/.config/JetBrains/JetBrainsClient/options
-touch ~/.config/JetBrains/JetBrainsClient/options/ide.general.xml
+mkdir -p $HOME/.local/share/JetBrains/consentOptions/
+echo -n "rsch.send.usage.stat:1.1:0:1644945193441" > $HOME/.local/share/JetBrains/consentOptions/accepted
+mkdir -p $HOME/.config/JetBrains/JetBrainsClient/options
+touch $HOME/.config/JetBrains/JetBrainsClient/options/ide.general.xml
 ./gradlew test -i

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -52,6 +52,7 @@ func TestIntellij(t *testing.T) {
 }
 
 func TestPhpStorm(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using PhpStorm").
@@ -68,6 +69,7 @@ func TestPhpStorm(t *testing.T) {
 }
 
 func TestPyCharm(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using Pycharm").
@@ -84,6 +86,7 @@ func TestPyCharm(t *testing.T) {
 }
 
 func TestRubyMine(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using RubyMine").
@@ -100,6 +103,7 @@ func TestRubyMine(t *testing.T) {
 }
 
 func TestWebStorm(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using WebStorm").
@@ -116,6 +120,7 @@ func TestWebStorm(t *testing.T) {
 }
 
 func TestRider(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	t.Skip("Until ENT-56")
@@ -133,6 +138,7 @@ func TestRider(t *testing.T) {
 }
 
 func TestCLion(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	t.Skip("See EXP-414")
@@ -150,6 +156,7 @@ func TestCLion(t *testing.T) {
 }
 
 func TestRustRover(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using RustRover").
@@ -166,6 +173,7 @@ func TestRustRover(t *testing.T) {
 }
 
 func TestIntellijNotPreconfiguredRepo(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using Intellij with not preconfigured repo").
@@ -188,6 +196,7 @@ func TestIntellijNotPreconfiguredRepo(t *testing.T) {
 var warmupIndexingShell []byte
 
 func TestIntelliJWarmup(t *testing.T) {
+	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using Intellij and imagebuild to test warmup tasks").

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -52,7 +52,6 @@ func TestIntellij(t *testing.T) {
 }
 
 func TestPhpStorm(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using PhpStorm").
@@ -69,7 +68,6 @@ func TestPhpStorm(t *testing.T) {
 }
 
 func TestPyCharm(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using Pycharm").
@@ -86,7 +84,6 @@ func TestPyCharm(t *testing.T) {
 }
 
 func TestRubyMine(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using RubyMine").
@@ -103,7 +100,6 @@ func TestRubyMine(t *testing.T) {
 }
 
 func TestWebStorm(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using WebStorm").
@@ -120,7 +116,6 @@ func TestWebStorm(t *testing.T) {
 }
 
 func TestRider(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	t.Skip("Until ENT-56")
@@ -138,7 +133,6 @@ func TestRider(t *testing.T) {
 }
 
 func TestCLion(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	t.Skip("See EXP-414")
@@ -156,7 +150,6 @@ func TestCLion(t *testing.T) {
 }
 
 func TestRustRover(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using RustRover").
@@ -173,7 +166,6 @@ func TestRustRover(t *testing.T) {
 }
 
 func TestIntellijNotPreconfiguredRepo(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using Intellij with not preconfigured repo").
@@ -196,7 +188,6 @@ func TestIntellijNotPreconfiguredRepo(t *testing.T) {
 var warmupIndexingShell []byte
 
 func TestIntelliJWarmup(t *testing.T) {
-	t.Skip("TODO")
 	BaseGuard(t)
 	t.Parallel()
 	f := features.New("Start a workspace using Intellij and imagebuild to test warmup tasks").


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
`$HOME`, `~` are not the same with what Java wanted (user.home) in `GHA` x `container`

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-635

## How to test
<!-- Provide steps to test this PR -->

See https://github.com/gitpod-io/gitpod/actions/runs/10355357489/job/28663273850

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
