### PR TITLE
Fix workspace list grid on Safari

### DIFF
--- a/components/dashboard/src/workspaces/WorkspaceEntry.tsx
+++ b/components/dashboard/src/workspaces/WorkspaceEntry.tsx
@@ -70,7 +70,7 @@ export const WorkspaceEntry: FunctionComponent<Props> = ({ info, shortVersion })
             <ItemFieldIcon className="min-w-8">
                 <WorkspaceStatusIndicator status={workspace?.status} />
             </ItemFieldIcon>
-            <div className="flex-grow flex flex-col h-full py-auto truncate">
+            <div className="flex-grow flex flex-col py-auto truncate">
                 <Tooltip content={info.id} allowWrap={true}>
                     <a href={startUrl}>
                         <div className="font-medium text-gray-800 dark:text-gray-200 truncate hover:text-blue-600 dark:hover:text-blue-400">


### PR DESCRIPTION
## Description

Something in our grid column styles are making Safari <18 misbehave and think the workspace list entry is much taller than it actually is. This PR patches that by not letting the element take up all the space available to it.

| Before | After |
|--------|--------|
| <img width="1562" alt="image" src="https://github.com/user-attachments/assets/96d503a0-d2a4-429e-9b65-a11b005180e7"> | <img width="1562" alt="image" src="https://github.com/user-attachments/assets/73845f67-6de9-4822-a941-0872c8b79ae4"> | 

These are the styles that it has problems with, if anyone has any ideas to what the actual cause may be. From the [Safari 18 release notes](https://developer.apple.com/documentation/safari-release-notes/safari-18-release-notes) (that version is no longer affected by this), I could not find anything describing what we're seeing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-486

## How to test

1. Get a machine with macOS<=14
2. Open [the preview](https://ft-safar-ws-list-fix.preview.gitpod-dev.com/workspaces)
3. Start a workspace
4. Get back to the dashboard's workspace list and observe everything's just fine

/hold
