### PR TITLE
[OIDC] IDP: use workspace.context.normalizedContextUrl to fill the "sub" and "context" claims of the IDToken

### DIFF
--- a/components/public-api-server/pkg/apiv1/identityprovider.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider.go
@@ -93,7 +93,7 @@ func (srv *IdentityProviderService) GetIDToken(ctx context.Context, req *connect
 	userInfo.SetName(user.Name)
 	userInfo.AppendClaims("user_id", user.ID)
 	userInfo.AppendClaims("org_id", workspace.Workspace.OrganizationId)
-	userInfo.AppendClaims("context", workspace.Workspace.ContextURL)
+	userInfo.AppendClaims("context", getContext(workspace))
 	userInfo.AppendClaims("workspace_id", workspaceID)
 
 	if req.Msg.GetScope() != "" {
@@ -127,7 +127,7 @@ func (srv *IdentityProviderService) getOIDCSubject(ctx context.Context, userInfo
 		UserID: user.ID,
 		TeamID: workspace.Workspace.OrganizationId,
 	})
-	subject := workspace.Workspace.ContextURL
+	subject := getContext(workspace)
 	if len(claimKeys) != 0 {
 		subArr := []string{}
 		for _, key := range claimKeys {
@@ -140,4 +140,13 @@ func (srv *IdentityProviderService) getOIDCSubject(ctx context.Context, userInfo
 		subject = strings.Join(subArr, ":")
 	}
 	return subject
+}
+
+func getContext(workspace *protocol.WorkspaceInfo) string {
+	context := "no-context"
+	if workspace.Workspace.Context != nil && workspace.Workspace.Context.NormalizedContextURL != "" {
+		// using Workspace.Context.NormalizedContextURL to not include prefixes (like "referrer:jetbrains-gateway", or other prefix contexts)
+		context = workspace.Workspace.Context.NormalizedContextURL
+	}
+	return context
 }


### PR DESCRIPTION
## Description
The motivation is to have more uniform URL shapes to match against e.g. across different IDEs.

## Related Issue(s)
Fixes ENT-535

## How to test
 - start a workspace **with Intellij**
 - try verify against an external OIDC handler (how to do that?) and check the shape 
 - check that `sub` and `context` claims don't contain the `referrer:` prefix

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

https://gpl-535-oidc-sub.preview.gitpod-dev.com/workspaces

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
