### PR TITLE
[image-builder] Detect "429 - Too Many Request" and bubble up as "Unavailable"

### DIFF
--- a/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
+++ b/components/image-builder-mk3/pkg/orchestrator/orchestrator.go
@@ -624,6 +624,9 @@ func (o *Orchestrator) getAbsoluteImageRef(ctx context.Context, ref string, allo
 		}
 		return "", status.Error(codes.Unauthenticated, "cannot resolve image")
 	}
+	if resolve.TooManyRequestsMatcher(err) {
+		return "", status.Errorf(codes.Unavailable, "upstream registry responds with 'too many request': %v", err)
+	}
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "cannot resolve image: %v", err)
 	}

--- a/components/image-builder-mk3/pkg/resolve/resolve.go
+++ b/components/image-builder-mk3/pkg/resolve/resolve.go
@@ -32,6 +32,14 @@ var (
 
 	// ErrNotFound is returned when we're not authorized to return the reference
 	ErrUnauthorized = xerrors.Errorf("not authorized")
+
+	// TooManyRequestsMatcher returns true if an error is a code 429 "Too Many Requests" error
+	TooManyRequestsMatcher = func(err error) bool {
+		if err == nil {
+			return false
+		}
+		return strings.Contains(err.Error(), "429 Too Many Requests")
+	}
 )
 
 // StandaloneRefResolver can resolve image references without a Docker daemon

--- a/components/image-builder-mk3/pkg/resolve/resolve_test.go
+++ b/components/image-builder-mk3/pkg/resolve/resolve_test.go
@@ -20,14 +20,16 @@ import (
 	"github.com/gitpod-io/gitpod/image-builder/pkg/resolve"
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/opencontainers/go-digest"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 func TestStandaloneRefResolverResolve(t *testing.T) {
 	type Expectation struct {
-		Ref   string
-		Error string
+		Ref          string
+		Error        string
+		ErrorMatcher func(error) bool
 	}
 	type ResolveResponse struct {
 		Error         error
@@ -104,6 +106,16 @@ func TestStandaloneRefResolverResolve(t *testing.T) {
 			},
 			Expectation: Expectation{
 				Error: resolve.ErrUnauthorized.Error(),
+			},
+		},
+		{
+			Name: "dockerhub rate limit",
+			Ref:  "registry-1.docker.io:5000/gitpod/gitpod/workspace-full:latest-pulled-too-often",
+			ResolveResponse: ResolveResponse{
+				Error: errors.New("httpReadSeeker: failed open: unexpected status code https://registry-1.docker.io/v2/gitpod/workspace-full/manifests/sha256:279f925ad6395f11f6b60e63d7efa5c0b26a853c6052327efbe29bbcc0bafd6a: 429 Too Many Requests - Server message: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"),
+			},
+			Expectation: Expectation{
+				ErrorMatcher: resolve.TooManyRequestsMatcher,
 			},
 		},
 		{
@@ -195,7 +207,16 @@ func TestStandaloneRefResolverResolve(t *testing.T) {
 				act.Error = err.Error()
 			}
 
-			if diff := cmp.Diff(test.Expectation, act); diff != "" {
+			// ErrorMatcher?
+			if err != nil && test.Expectation.ErrorMatcher != nil {
+				if test.Expectation.ErrorMatcher(err) {
+					test.Expectation.Error = act.Error
+				} else {
+					test.Expectation.Error = "ErrorMatcher failed"
+				}
+			}
+
+			if diff := cmp.Diff(test.Expectation, act, cmpopts.IgnoreFields(Expectation{}, "ErrorMatcher")); diff != "" {
 				t.Errorf("Resolve() mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
## Description
Make sure that "429" errors are not tagged as `imageBuildFailedUser` in `server`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-644

## How to test
 - check that unit tests are green :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
