### PR TITLE
[JetBrains] force upgrade IntelliJ IDEA to `2024.2`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,7 +13,7 @@ defaultArgs:
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8f10c5febf0162a3c2309076302f770fbad38fde
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.1.4.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.4.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.1.4.tar.gz"
   phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.1.4.tar.gz"

--- a/dev/preview/workflow/preview/patch-ide-configmap.js
+++ b/dev/preview/workflow/preview/patch-ide-configmap.js
@@ -6,10 +6,15 @@ const fs = require("fs");
 let json = JSON.parse(fs.readFileSync(process.argv[2]).toString());
 
 function replaceImage(image) {
-    if (image.includes("jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest")) {
-        return image;
-    }
     return image.replace("gitpod-dev-artifact", "gitpod-core-dev");
+}
+
+// TODO(hw): remove me
+function replaceImage2(image) {
+    if (image.includes("jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest")) {
+        return image.replace("gitpod-dev-artifact", "gitpod-core-dev");
+    }
+    return image
 }
 
 for (let ide in json.ideOptions.options) {
@@ -24,6 +29,18 @@ for (let ide in json.ideOptions.options) {
             return version;
         });
     }
+
+    // TODO(hw): remove me
+    if (
+        ["intellij"].includes(
+            ide,
+        )
+    ) {
+        json.ideOptions.options[ide].pluginImage = replaceImage2(json.ideOptions.options[ide].pluginImage)
+        json.ideOptions.options[ide].imageLayers = json.ideOptions.options[ide].imageLayers.map(replaceImage2)
+    }
+
+    json.ideOptions.options[]
     if (["code", "code1_85"].includes(ide)) {
         json.ideOptions.options[ide].image = replaceImage(json.ideOptions.options[ide].image);
         json.ideOptions.options[ide].imageLayers = json.ideOptions.options[ide].imageLayers.map(replaceImage);

--- a/dev/preview/workflow/preview/patch-ide-configmap.js
+++ b/dev/preview/workflow/preview/patch-ide-configmap.js
@@ -14,7 +14,7 @@ function replaceImage2(image) {
     if (image.includes("jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest")) {
         return image.replace("gitpod-dev-artifact", "gitpod-core-dev");
     }
-    return image
+    return image;
 }
 
 for (let ide in json.ideOptions.options) {
@@ -31,16 +31,11 @@ for (let ide in json.ideOptions.options) {
     }
 
     // TODO(hw): remove me
-    if (
-        ["intellij"].includes(
-            ide,
-        )
-    ) {
-        json.ideOptions.options[ide].pluginImage = replaceImage2(json.ideOptions.options[ide].pluginImage)
-        json.ideOptions.options[ide].imageLayers = json.ideOptions.options[ide].imageLayers.map(replaceImage2)
+    if (["intellij"].includes(ide)) {
+        json.ideOptions.options[ide].pluginImage = replaceImage2(json.ideOptions.options[ide].pluginImage);
+        json.ideOptions.options[ide].imageLayers = json.ideOptions.options[ide].imageLayers.map(replaceImage2);
     }
 
-    json.ideOptions.options[]
     if (["code", "code1_85"].includes(ide)) {
         json.ideOptions.options[ide].image = replaceImage(json.ideOptions.options[ide].image);
         json.ideOptions.options[ide].imageLayers = json.ideOptions.options[ide].imageLayers.map(replaceImage);

--- a/dev/preview/workflow/preview/patch-ide-configmap.js
+++ b/dev/preview/workflow/preview/patch-ide-configmap.js
@@ -6,6 +6,9 @@ const fs = require("fs");
 let json = JSON.parse(fs.readFileSync(process.argv[2]).toString());
 
 function replaceImage(image) {
+    if (image.includes("jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest")) {
+        return image;
+    }
     return image.replace("gitpod-dev-artifact", "gitpod-core-dev");
 }
 

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -167,6 +167,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2 Pre-Release",
+            "image": "{{.Repository}}/ide/intellij:commit-40057c506de0792ed3b0394796f0467ef18e4c03",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest",
+              "{{.Repository}}/ide/jb-launcher:commit-294b37ad7b93bcc347bf970a11e269e2b477f603"
+            ]
+          },
+          {
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/intellij:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",
             "imageLayers": [

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -154,10 +154,10 @@
         "label": "Ultimate",
         "image": "{{.Repository}}/ide/intellij:{{.WorkspaceVersions.Workspace.DesktopIdeImages.IntelliJImage.Version}}",
         "latestImage": "{{.ResolvedJBImageLatest.IntelliJ}}",
-        "pluginImage": "{{.JetBrainsPluginImage}}",
+        "pluginImage": "{{.JetBrainsPluginLatestImage}}",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
         "imageLayers": [
-          "{{.JetBrainsPluginImage}}",
+          "{{.JetBrainsPluginLatestImage}}",
           "{{.JetBrainsLauncherImage}}"
         ],
         "latestImageLayers": [
@@ -166,14 +166,6 @@
         ],
         "allowPin": true,
         "versions": [
-          {
-            "version": "2024.2 Pre-Release",
-            "image": "{{.Repository}}/ide/intellij:commit-40057c506de0792ed3b0394796f0467ef18e4c03",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest",
-              "{{.Repository}}/ide/jb-launcher:commit-294b37ad7b93bcc347bf970a11e269e2b477f603"
-            ]
-          },
           {
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/intellij:commit-294b37ad7b93bcc347bf970a11e269e2b477f603",

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -154,10 +154,10 @@
         "label": "Ultimate",
         "image": "{{.Repository}}/ide/intellij:{{.WorkspaceVersions.Workspace.DesktopIdeImages.IntelliJImage.Version}}",
         "latestImage": "{{.ResolvedJBImageLatest.IntelliJ}}",
-        "pluginImage": "{{.JetBrainsPluginLatestImage}}",
+        "pluginImage": "{{.Repository}}/ide/jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest",
         "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
         "imageLayers": [
-          "{{.JetBrainsPluginLatestImage}}",
+          "{{.Repository}}/ide/jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest",
           "{{.JetBrainsLauncherImage}}"
         ],
         "latestImageLayers": [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-651

## How to test
<!-- Provide steps to test this PR -->
- Wait for last GHA to finished
- Open Preview env, create workspace with stable IntelliJ IDEA
- It should be able to launch and connect using Gateway + IntelliJ IDEA
- GHA's `integration tests` should be passed

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-ij-upgrade</li>
	<li><b>🔗 URL</b> - <a href="https://hw-ij-upgrade.preview.gitpod-dev.com/workspaces" target="_blank">hw-ij-upgrade.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-ij-upgrade-gha.28077</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-ij-upgrade%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
