### PR TITLE
Fix incorrect usage of `os.Stat`

### DIFF
--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -1189,7 +1189,9 @@ func linkRemotePlugin(launchCtx *LaunchContext) error {
 func safeLink(source, target string) error {
 	if _, err := os.Stat(target); err == nil {
 		// unlink the old symlink
-		_ = os.RemoveAll(target)
+		if err2 := os.RemoveAll(target); err2 != nil {
+			log.WithError(err).Error("failed to remove old symlink")
+		}
 	}
 	return os.Symlink(source, target)
 }

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -1187,7 +1187,7 @@ func linkRemotePlugin(launchCtx *LaunchContext) error {
 }
 
 func safeLink(source, target string) error {
-	if _, err := os.Stat(target); err == nil {
+	if _, err := os.Lstat(target); err == nil {
 		// unlink the old symlink
 		if err2 := os.RemoveAll(target); err2 != nil {
 			log.WithError(err).Error("failed to remove old symlink")

--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -1186,11 +1186,12 @@ func linkRemotePlugin(launchCtx *LaunchContext) error {
 	return safeLink("/ide-desktop-plugins/gitpod-remote", remotePluginDir)
 }
 
+// safeLink creates a symlink from source to target, removing the old target if it exists
 func safeLink(source, target string) error {
 	if _, err := os.Lstat(target); err == nil {
 		// unlink the old symlink
 		if err2 := os.RemoveAll(target); err2 != nil {
-			log.WithError(err).Error("failed to remove old symlink")
+			log.WithError(err).Error("failed to unlink old symlink")
 		}
 	}
 	return os.Symlink(source, target)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Golang `os.Stat` will follow to link to get stat info of the source file 😬 which is not expected in current usage

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-654

## How to test
<!-- Provide steps to test this PR -->
- Create a repository with https://github.com/mustard-mh/test/blob/repro/ENT-654-2/.gitpod.yml
- Trigger prebuild for branch `repro/ENT-654-2`
- Start a workspace with stable `IntelliJ IDEA` and context `https://github.com/mustard-mh/test/blob/repro/ENT-654-2/.gitpod.yml`
- It should be able to access workspace with IntelliJ IDEA

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-fix-2</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-fix-2.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-fix-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-fix-2-gha.28120</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-fix-2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
