### PR TITLE
Update images digests

### DIFF
--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM cgr.dev/chainguard/helm:latest@sha256:9840382ef059a27022a35d9b8eb3d2cd36cea0065075cc1ec1f62fe718a63dbd
+FROM cgr.dev/chainguard/helm:latest@sha256:48c9cb6804dd3db4526067c82032d7d0326642b5ab1d7ae0e06f3a5b0b0d20c9
 
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
 


### PR DESCRIPTION
Update images digests using the latest version available for image/s

## How to test
- [ ] Start a workspace in the preview environment and verify that it functions properly.

<details>
<summary>Preview Environment / Integration Tests</summary>

- [x] /werft with-preview
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=ssh
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
</details>