### PR TITLE
[TB] Update respond data of joinLink2

### DIFF
--- a/components/ide-service/pkg/server/server.go
+++ b/components/ide-service/pkg/server/server.go
@@ -456,7 +456,11 @@ func (s *IDEServiceServer) ResolveWorkspaceConfig(ctx context.Context, req *api.
 				Name:  "GITPOD_PREFER_TOOLBOX",
 				Value: "true",
 			}
-			resp.Envvars = append(resp.Envvars, &preferToolboxEnv)
+			debuggingEnv := api.EnvironmentVariable{
+				Name:  "GITPOD_TOOLBOX_DEBUGGING",
+				Value: s.experimentsClient.GetStringValue(ctx, "enable_experimental_jbtb_debugging", "", experiments.Attributes{UserID: req.User.Id}),
+			}
+			resp.Envvars = append(resp.Envvars, &preferToolboxEnv, &debuggingEnv)
 		}
 
 		if userIdeName != "" {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-663

## How to test
<!-- Provide steps to test this PR -->
- Create workspace with stable **GoLand**
- It should be able to launch with JetBrains Gateway

✔️ <img width="798" alt="image" src="https://github.com/user-attachments/assets/daf39707-7b98-432a-ba42-654a62fe5cb1">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-tb-2</li>
	<li><b>🔗 URL</b> - <a href="https://hw-tb-2.preview.gitpod-dev.com/workspaces" target="_blank">hw-tb-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-tb-2-gha.28197</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-tb-2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
