### PR TITLE
Force upgrade IntelliJ IDEA to `2024.2.0.2`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,7 +13,7 @@ defaultArgs:
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8f10c5febf0162a3c2309076302f770fbad38fde
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.0.2.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.1.4.tar.gz"
   pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.1.4.tar.gz"
   phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.1.4.tar.gz"

--- a/components/ide/gha-update-image/force-upgrade-jb.ts
+++ b/components/ide/gha-update-image/force-upgrade-jb.ts
@@ -1,0 +1,38 @@
+// bun run force-update-jb.ts --ide=intellij --version=2024.2.0.2
+import { parseArgs } from "util";
+import { pathToWorkspaceYaml, readWorkspaceYaml } from "./lib/common";
+import { appendPinVersionsIntoIDEConfigMap } from "./lib/jb-pin-version";
+
+const { values } = parseArgs({
+    args: Bun.argv,
+    options: {
+        ide: {
+            type: "string",
+        },
+        version: {
+            type: "string",
+        },
+    },
+    strict: true,
+    allowPositionals: true,
+});
+
+if (!values.ide || !values.version) {
+    throw new Error("ide and version are required.");
+}
+
+const workspaceYaml = await readWorkspaceYaml();
+
+const oldDownloadurl = workspaceYaml.parsedObj.defaultArgs[`${values.ide}DownloadUrl`];
+
+if (!oldDownloadurl) {
+    throw new Error("ide is not supported");
+}
+
+const newWorkspaceYaml = workspaceYaml.rawText.replace(
+    oldDownloadurl,
+    oldDownloadurl.replace(/-(.*?).tar.gz/, `-${values.version}.tar.gz`),
+);
+await Bun.write(pathToWorkspaceYaml, newWorkspaceYaml);
+
+await appendPinVersionsIntoIDEConfigMap([values.ide]);

--- a/components/ide/gha-update-image/lib/jb-pin-version.ts
+++ b/components/ide/gha-update-image/lib/jb-pin-version.ts
@@ -43,24 +43,29 @@ export const appendPinVersionsIntoIDEConfigMap = async (updatedIDEs: string[] | 
 
         console.debug(`Processing ${ide} ${ideVersion}...`);
 
-        const ideConfigMap = await renderInstallerIDEConfigMap(undefined)
+        const ideConfigMap = await renderInstallerIDEConfigMap(undefined);
 
         if (Object.keys(configmap.ideOptions.options).includes(ide)) {
             const { version: installerImageVersion } = versionObject;
-
-            const previousVersion = await getIDEVersionOfImage(ideConfigMap.ideOptions.options[ide].image);
-            const previousInfo = {
-                version: previousVersion,
-                image: ideConfigMap.ideOptions.options[ide].image.replaceAll("eu.gcr.io/gitpod-core-dev/build", "{{.Repository}}"),
-                imageLayers: ideConfigMap.ideOptions.options[ide].imageLayers.map((e: string) => e.replaceAll("eu.gcr.io/gitpod-core-dev/build", "{{.Repository}}")),
-            };
 
             if (!updatedIDEs || !updatedIDEs.includes(ide)) {
                 console.log(`Ignore latest version (${ide}:${installerImageVersion})`);
                 continue;
             }
+
+            const previousVersion = await getIDEVersionOfImage(ideConfigMap.ideOptions.options[ide].image);
+            const previousInfo = {
+                version: previousVersion,
+                image: ideConfigMap.ideOptions.options[ide].image.replaceAll(
+                    "eu.gcr.io/gitpod-core-dev/build",
+                    "{{.Repository}}",
+                ),
+                imageLayers: ideConfigMap.ideOptions.options[ide].imageLayers.map((e: string) =>
+                    e.replaceAll("eu.gcr.io/gitpod-core-dev/build", "{{.Repository}}"),
+                ),
+            };
             if (!configmap.ideOptions.options[ide].versions) {
-                configmap.ideOptions.options[ide].versions = []
+                configmap.ideOptions.options[ide].versions = [];
             }
             console.log(`Added ${ide} (new ${previousInfo.image})`);
             configmap.ideOptions.options[ide].versions.unshift(previousInfo);

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -167,6 +167,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2",
+            "image": "{{.Repository}}/ide/intellij:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest",
+              "{{.Repository}}/ide/jb-launcher:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7"
+            ]
+          },
+          {
             "version": "2024.1.4",
             "image": "{{.Repository}}/ide/intellij:commit-80f3b3e47fc065d521be745b5795841d5e883667",
             "imageLayers": [


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-test-bump</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-test-bump.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-test-bump.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-test-bump-gha.28243</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-test-bump%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
