### PR TITLE
Remove JetBrains `Rider` supports

### DIFF
--- a/components/dashboard/src/components/IdeOptions.tsx
+++ b/components/dashboard/src/components/IdeOptions.tsx
@@ -112,8 +112,9 @@ export const IdeOptionsModifyModal = ({
         }
         const availableKeys = ideOptions?.map((e) => e.id) || [];
         const editors = new Set([...restrictedEditors].filter((e) => availableKeys.includes(e)));
+        const pinnedVersions = new Map([...pinnedEditorVersions].filter(([k, v]) => availableKeys.includes(k) && !!v));
         updateMutation.mutate(
-            { restrictedEditors: editors, pinnedEditorVersions },
+            { restrictedEditors: editors, pinnedEditorVersions: pinnedVersions },
             {
                 onSuccess: () => {
                     toast({ message: "Editor options updated" });

--- a/components/dashboard/src/onboarding/UserOnboarding.tsx
+++ b/components/dashboard/src/onboarding/UserOnboarding.tsx
@@ -17,6 +17,7 @@ import { useUpdateCurrentUserMutation } from "../data/current-user/update-mutati
 import Alert from "../components/Alert";
 import { useConfetti } from "../contexts/ConfettiContext";
 import { trackEvent } from "../Analytics";
+import { IDESettingsVersion } from "@gitpod/gitpod-protocol/lib/ide-protocol";
 
 // This param is optionally present to force an onboarding flow
 // Can be used if other conditions aren't true, i.e. if user has already onboarded, but we want to force the flow again
@@ -60,7 +61,7 @@ const UserOnboarding: FunctionComponent<Props> = ({ user }) => {
                             onboardedTimestamp: new Date().toISOString(),
                         },
                         ideSettings: {
-                            settingVersion: "2.0",
+                            settingVersion: IDESettingsVersion,
                             defaultIde: ideOptions.ide,
                             useLatestVersion: ideOptions.useLatest,
                         },

--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -290,10 +290,6 @@
                     "$ref": "#/definitions/jetbrainsProduct",
                     "description": "Configure WebStorm integration"
                 },
-                "rider": {
-                    "$ref": "#/definitions/jetbrainsProduct",
-                    "description": "Configure Rider integration"
-                },
                 "clion": {
                     "$ref": "#/definitions/jetbrainsProduct",
                     "description": "Configure CLion integration"

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -112,9 +112,6 @@ type Jetbrains struct {
 	// Configure PyCharm integration
 	Pycharm *JetbrainsProduct `yaml:"pycharm,omitempty" json:"pycharm,omitempty"`
 
-	// Configure Rider integration
-	Rider *JetbrainsProduct `yaml:"rider,omitempty" json:"rider,omitempty"`
-
 	// Configure RubyMine integration
 	Rubymine *JetbrainsProduct `yaml:"rubymine,omitempty" json:"rubymine,omitempty"`
 

--- a/components/gitpod-protocol/src/ide-protocol.ts
+++ b/components/gitpod-protocol/src/ide-protocol.ts
@@ -49,7 +49,7 @@ export namespace IDEOptions {
     }
 }
 
-export const IDESettingsVersion = "2.2";
+export const IDESettingsVersion = "2.3";
 
 export interface IDEClient {
     /**

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -764,7 +764,6 @@ export interface JetBrainsConfig {
     phpstorm?: JetBrainsProductConfig;
     rubymine?: JetBrainsProductConfig;
     webstorm?: JetBrainsProductConfig;
-    rider?: JetBrainsProductConfig;
     clion?: JetBrainsProductConfig;
     rustrover?: JetBrainsProductConfig;
 }

--- a/components/ide/gha-update-image/lib/jb-pin-version.ts
+++ b/components/ide/gha-update-image/lib/jb-pin-version.ts
@@ -29,6 +29,9 @@ export const appendPinVersionsIntoIDEConfigMap = async (updatedIDEs: string[] | 
     const workspaceYaml = await readWorkspaceYaml().then((d) => d.parsedObj);
 
     for (const [ide, versionObject] of Object.entries(latestInstallerVersions.components.workspace.desktopIdeImages)) {
+        if (ide === "rider") {
+            continue;
+        }
         if (
             ide.includes("Latest") ||
             ["codeDesktop", "codeDesktopInsiders", "jbLauncher", "jbBackendPlugin", "jbBackendPluginLatest"].includes(

--- a/components/ide/jetbrains/backend-plugin/hot-deploy.sh
+++ b/components/ide/jetbrains/backend-plugin/hot-deploy.sh
@@ -21,7 +21,7 @@ leeway build -DnoVerifyJBPlugin=true -Dversion="$version" -DimageRepoBase=eu.gcr
 dev_image="$(tar xfO "$bldfn" ./imgnames.txt | head -n1)"
 echo "Dev Image: $dev_image"
 
-ide_list=("intellij" "goland" "pycharm" "phpstorm" "rubymine" "webstorm" "rider" "clion" "rustrover")
+ide_list=("intellij" "goland" "pycharm" "phpstorm" "rubymine" "webstorm" "clion" "rustrover")
 
 if [ "$qualifier" == "stable" ]; then
   prop_list=("pluginImage" "imageLayers[0]")

--- a/components/server/src/ide-service.spec.ts
+++ b/components/server/src/ide-service.spec.ts
@@ -67,6 +67,27 @@ describe("ide-service", function () {
             });
         });
 
+        it("with settingVersion 2.0 should be latest and remove rider", function () {
+            const user: User = {
+                id: "string",
+                creationDate: "string",
+                identities: [],
+                additionalData: {
+                    ideSettings: {
+                        settingVersion: "2.0",
+                        defaultIde: "rider",
+                        useDesktopIde: false,
+                    },
+                },
+            };
+            const result = ideService.migrateSettings(user);
+            expect(result).to.deep.equal({
+                settingVersion: IDESettingsVersion,
+                defaultIde: "code",
+                useLatestVersion: false,
+            });
+        });
+
         it("with settingVersion latest should be undefined", function () {
             const user: User = {
                 id: "string",

--- a/dev/preview/workflow/preview/patch-ide-configmap.js
+++ b/dev/preview/workflow/preview/patch-ide-configmap.js
@@ -18,11 +18,7 @@ function replaceImage2(image) {
 }
 
 for (let ide in json.ideOptions.options) {
-    if (
-        ["clion", "goland", "intellij", "phpstorm", "pycharm", "rider", "rubymine", "webstorm", "rustrover"].includes(
-            ide,
-        )
-    ) {
+    if (["clion", "goland", "intellij", "phpstorm", "pycharm", "rubymine", "webstorm", "rustrover"].includes(ide)) {
         json.ideOptions.options[ide].versions = json.ideOptions.options[ide].versions?.map((version) => {
             version.image = replaceImage(version.image);
             version.imageLayers = version.imageLayers.map(replaceImage);

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -530,59 +530,6 @@
           }
         ]
       },
-      "rider": {
-        "orderKey": "100",
-        "title": "Rider",
-        "type": "desktop",
-        "logo": "{{.IdeLogoBase}}/riderLogo.svg",
-        "image": "{{.Repository}}/ide/rider:{{.WorkspaceVersions.Workspace.DesktopIdeImages.RiderImage.Version}}",
-        "latestImage": "{{.ResolvedJBImageLatest.Rider}}",
-        "pluginImage": "{{.JetBrainsPluginImage}}",
-        "pluginLatestImage": "{{.JetBrainsPluginLatestImage}}",
-        "imageLayers": [
-          "{{.JetBrainsPluginImage}}",
-          "{{.JetBrainsLauncherImage}}"
-        ],
-        "latestImageLayers": [
-          "{{.JetBrainsPluginLatestImage}}",
-          "{{.JetBrainsLauncherImage}}"
-        ],
-        "allowPin": true,
-        "versions": [
-          {
-            "version": "2024.1.3",
-            "image": "{{.Repository}}/ide/rider:commit-c295f8299fd17f99913512ec5db5d8a60a1e5d98",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-c295f8299fd17f99913512ec5db5d8a60a1e5d98",
-              "{{.Repository}}/ide/jb-launcher:commit-c295f8299fd17f99913512ec5db5d8a60a1e5d98"
-            ]
-          },
-          {
-            "version": "2024.1.2",
-            "image": "{{.Repository}}/ide/rider:commit-9823a689c6259339239381e2840e29149fc8d195",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
-              "{{.Repository}}/ide/jb-launcher:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
-            ]
-          },
-          {
-            "version": "2024.1.1",
-            "image": "{{.Repository}}/ide/rider:commit-9382d33ee521e6a72d763f906b24dd53893103df",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
-              "{{.Repository}}/ide/jb-launcher:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
-            ]
-          },
-          {
-            "version": "2024.1",
-            "image": "{{.Repository}}/ide/rider:commit-ef400309563b040b84d9588862805ce2f26d688a",
-            "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
-              "{{.Repository}}/ide/jb-launcher:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
-            ]
-          }
-        ]
-      },
       "clion": {
         "orderKey": "110",
         "title": "CLion",
@@ -712,7 +659,6 @@
           "phpstorm",
           "rubymine",
           "webstorm",
-          "rider",
           "clion",
           "rustrover"
         ],
@@ -729,7 +675,6 @@
           "phpstorm",
           "rubymine",
           "webstorm",
-          "rider",
           "clion",
           "rustrover"
         ],

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -115,23 +115,6 @@ func TestWebStorm(t *testing.T) {
 	testEnv.Test(t, f)
 }
 
-func TestRider(t *testing.T) {
-	BaseGuard(t)
-	t.Parallel()
-	t.Skip("Until ENT-56")
-	f := features.New("Start a workspace using Rider").
-		WithLabel("component", "IDE").
-		WithLabel("ide", "Rider").
-		Assess("it can let JetBrains Gateway connect", func(testCtx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
-			ctx, cancel := context.WithTimeout(testCtx, 30*time.Minute)
-			defer cancel()
-			JetBrainsIDETest(ctx, t, cfg, WithIDE("rider"))
-			return testCtx
-		}).
-		Feature()
-	testEnv.Test(t, f)
-}
-
 func TestCLion(t *testing.T) {
 	BaseGuard(t)
 	t.Parallel()


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Hold this PR to see if we could fix Rider's integration

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
**No Editor option `Rider`**
Check preview env's editor options, there should have no Rider inside

**Editor option compatible**
- Log in preview env and get your organization ID
- Open this PR with Gitpod
- Connect to db and force update some rider inside
   ```
   $ kubectl port-forward svc/mysql 3307:3306
   $ mysql -ugitpod -h127.0.0.1 --port=3307 -p
   # input password
   # with mysql
   mysql> use gitpod;
   mysql> update d_b_org_settings set pinnedEditorVersions='{"rider": "2024.1.3"}', restrictedEditorNames='["rider"]' where orgId='<your_org_id>';
   ```
- Clean local caches: DevTool > Application > Storage > IndexedDB > keyval-store > Click `Delete database`
- Refresh preview env and make sure GetOrganizationSettings API respond with rider stuff inside
- Update org settings (i.e. Restrict Editor and Editor Version Pinning)
- Should have no error and no rider related things in Update request

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-rider</li>
	<li><b>🔗 URL</b> - <a href="https://hw-rider.preview.gitpod-dev.com/workspaces" target="_blank">hw-rider.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-rider-gha.28245</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-rider%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
