### PR TITLE
Use supervisor mount namespace for nfs mount

### DIFF
--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -709,15 +709,15 @@ func (wbs *InWorkspaceServiceServer) MountSysfs(ctx context.Context, req *api.Mo
 
 func (wbs *InWorkspaceServiceServer) MountNfs(ctx context.Context, req *api.MountNfsRequest) (resp *api.MountNfsResponse, err error) {
 	var (
-		reqPID = req.Pid
-		nfsPID uint64
+		reqPID        = req.Pid
+		supervisorPID uint64
 	)
 	defer func() {
 		if err == nil {
 			return
 		}
 
-		log.WithError(err).WithFields(wbs.Session.OWI()).WithField("procPID", nfsPID).WithField("reqPID", reqPID).WithFields(wbs.Session.OWI()).Error("cannot mount nfs")
+		log.WithError(err).WithFields(wbs.Session.OWI()).WithField("procPID", supervisorPID).WithField("reqPID", reqPID).WithFields(wbs.Session.OWI()).Error("cannot mount nfs")
 		if _, ok := status.FromError(err); !ok {
 			err = status.Error(codes.Internal, "cannot mount nfs")
 		}
@@ -737,9 +737,9 @@ func (wbs *InWorkspaceServiceServer) MountNfs(ctx context.Context, req *api.Moun
 		return nil, xerrors.Errorf("cannot find container PID for containerID %v: %w", wscontainerID, err)
 	}
 
-	nfsPID, err = wbs.Uidmapper.findHostPID(containerPID, uint64(req.Pid))
+	supervisorPID, err = wbs.Uidmapper.findSupervisorPID(containerPID)
 	if err != nil {
-		return nil, xerrors.Errorf("cannot map in-container PID %d (container PID: %d): %w", req.Pid, containerPID, err)
+		return nil, xerrors.Errorf("cannot map supervisor PID %d (container PID: %d): %w", req.Pid, containerPID, err)
 	}
 
 	nodeStaging, err := os.MkdirTemp("", "nfs-staging")
@@ -774,7 +774,7 @@ func (wbs *InWorkspaceServiceServer) MountNfs(ctx context.Context, req *api.Moun
 		}
 	}
 
-	err = moveMount(wbs.Session.InstanceID, int(nfsPID), nodeStaging, req.Target)
+	err = moveMount(wbs.Session.InstanceID, int(supervisorPID), nodeStaging, req.Target)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description
Use supervisor mount namespace for nfs mount

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-677

## How to test
- Use this docker compose file
```
volumes:
  efs:
    driver: local
    driver_opts:
      type: nfs4
      o: nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2,noresvport,address=
      device: yoursharename:/

services:
  postgres-15:
    user: 33333:33333
    environment:
      POSTGRES_PASSWORD: admin
      PGDATA: /var/lib/gitpod
    image: postgres
    restart: always
    hostname: postgres
    shm_size: 1g
    ports:
      - "5432:5432"
    volumes:
      - efs:/var/lib/gitpod
```
 - docker compose up
 - Postgres should write its data files to the nfs share

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
