### PR TITLE
Fix Rider build on main

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle-latest.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle-latest.kts
@@ -174,5 +174,9 @@ tasks {
 }
 
 tasks.register("runPluginVerifier") {
-    intellijPlatform.verifyPlugin.ides.ide(IntelliJPlatformType.IntellijIdeaUltimate, properties("pluginVerifierIdeVersions"))
+    if (properties("platformType") == "RD") {
+        intellijPlatform.verifyPlugin.ides.ide(IntelliJPlatformType.Rider, properties("pluginVerifierIdeVersions"))
+    } else {
+        intellijPlatform.verifyPlugin.ides.ide(IntelliJPlatformType.IntellijIdeaUltimate, properties("pluginVerifierIdeVersions"))
+    }
 }

--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -174,5 +174,9 @@ tasks {
 }
 
 tasks.register("runPluginVerifier") {
-    intellijPlatform.verifyPlugin.ides.ide(IntelliJPlatformType.IntellijIdeaUltimate, properties("pluginVerifierIdeVersions"))
+    if (properties("platformType") == "RD") {
+        intellijPlatform.verifyPlugin.ides.ide(IntelliJPlatformType.Rider, properties("pluginVerifierIdeVersions"))
+    } else {
+        intellijPlatform.verifyPlugin.ides.ide(IntelliJPlatformType.IntellijIdeaUltimate, properties("pluginVerifierIdeVersions"))
+    }
 }

--- a/components/ide/jetbrains/backend-plugin/build.sh
+++ b/components/ide/jetbrains/backend-plugin/build.sh
@@ -7,10 +7,10 @@ set -e
 
 JB_GP_VERSION=${1:-debug}
 
-if [ "${NO_VERIFY_JB_PLUGIN}" == "true" ]; then
-    echo "build.sh: skip verify plugin step"
-else
+# if [ "${NO_VERIFY_JB_PLUGIN}" == "true" ]; then
+#     echo "build.sh: skip verify plugin step"
+# else
     ./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" -PgitpodVersion="$JB_GP_VERSION" runPluginVerifier
-fi
+# fi
 ./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" -PgitpodVersion="$JB_GP_VERSION" buildPlugin
 unzip ./build/distributions/gitpod-remote.zip -d ./build

--- a/components/ide/jetbrains/backend-plugin/build.sh
+++ b/components/ide/jetbrains/backend-plugin/build.sh
@@ -7,10 +7,10 @@ set -e
 
 JB_GP_VERSION=${1:-debug}
 
-# if [ "${NO_VERIFY_JB_PLUGIN}" == "true" ]; then
-#     echo "build.sh: skip verify plugin step"
-# else
+if [ "${NO_VERIFY_JB_PLUGIN}" == "true" ]; then
+    echo "build.sh: skip verify plugin step"
+else
     ./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" -PgitpodVersion="$JB_GP_VERSION" runPluginVerifier
-# fi
+fi
 ./gradlew -PsupervisorApiProjectPath=components-supervisor-api-java--lib/ -PgitpodProtocolProjectPath=components-gitpod-protocol-java--lib/ -PenvironmentName="$JB_QUALIFIER" -Dgradle.user.home="/workspace/.gradle-$JB_QUALIFIER" -Dplugin.verifier.home.dir="$HOME/.cache/pluginVerifier-$JB_QUALIFIER" -PgitpodVersion="$JB_GP_VERSION" buildPlugin
 unzip ./build/distributions/gitpod-remote.zip -d ./build

--- a/components/ide/jetbrains/backend-plugin/gradle-latest-rider.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest-rider.properties
@@ -5,7 +5,7 @@ pluginSinceBuild=242.19533
 pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2024.2
+pluginVerifierIdeVersions=RD-2024.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
 # platformVersion=242.20224.401
 platformVersion=2024.2

--- a/components/ide/jetbrains/backend-plugin/gradle-stable-rider.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable-rider.properties
@@ -5,7 +5,7 @@ pluginSinceBuild=241.17890
 pluginUntilBuild=241.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2024.1
+pluginVerifierIdeVersions=RD-2024.1
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
 platformVersion=2024.1
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Main build failed https://github.com/gitpod-io/gitpod/actions/runs/10528902989/job/29175535238 because it's using IC (IDEA) instead of RD (Rider) to verify plugin
```
[components/ide/jetbrains/backend-plugin:plugin-stable-rider] > Task :runPluginVerifier
.....
[components/ide/jetbrains/backend-plugin:plugin-stable-rider] 2024-08-23T16:20:58 [main] INFO  verification - Finished 1 of 1 verifications (in 8.2 s): IC-241.14494.240 against io.gitpod.jetbrains.remote:0.0.1-53299137d92bee639e9f0897bfa5491b947fbbd5-stable-rider: 1 missing mandatory dependency. 4 possible compatibility problems, some of which may be caused by absence of dependency in the target IDE IC-241.14494.240. 9 usages of deprecated API. 39 usages of experimental API. 46 usages of internal API. 4 plugin configuration defects

.....
[components/ide/jetbrains/backend-plugin:plugin-stable-rider] Missing dependencies: 
[components/ide/jetbrains/backend-plugin:plugin-stable-rider]     intellij.rider.plugins.cwm: Plugin intellij.rider.plugins.cwm is not available in JetBrains Marketplace https://plugins.jetbrains.com/ (used for plugin dependencies)
[components/ide/jetbrains/backend-plugin:plugin-stable-rider] Compatibility problems (4): 
[components/ide/jetbrains/backend-plugin:plugin-stable-rider]     #Package 'com.jetbrains.rdserver' is not found
[components/ide/jetbrains/backend-plugin:plugin-stable-rider]         Package 'com.jetbrains.rdserver' is not found along with its 10 classes.
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-715

## How to test
<!-- Provide steps to test this PR -->

See https://github.com/gitpod-io/gitpod/actions/runs/10529262188/job/29176670136?pr=20145, which force plugin verify

(before commit https://github.com/gitpod-io/gitpod/pull/20145/commits/1caf8c007c33f5c30397f90879f1b042a8c59c24 )

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-rd-2</li>
	<li><b>🔗 URL</b> - <a href="https://hw-rd-2.preview.gitpod-dev.com/workspaces" target="_blank">hw-rd-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-rd-2-gha.28310</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-rd-2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
