### PR TITLE
Update Rider versions' backend-plugin image

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -553,7 +553,7 @@
             "version": "2024.1.3",
             "image": "{{.Repository}}/ide/rider:commit-c295f8299fd17f99913512ec5db5d8a60a1e5d98",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-c295f8299fd17f99913512ec5db5d8a60a1e5d98",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-6e78b49260501f3ccf1fb8081f4de2a9d2a54732-rider",
               "{{.Repository}}/ide/jb-launcher:commit-c295f8299fd17f99913512ec5db5d8a60a1e5d98"
             ]
           },
@@ -561,7 +561,7 @@
             "version": "2024.1.2",
             "image": "{{.Repository}}/ide/rider:commit-9823a689c6259339239381e2840e29149fc8d195",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-eaa51e9f5c19696330459f0b646c1e9c9aeabdca",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-6e78b49260501f3ccf1fb8081f4de2a9d2a54732-rider",
               "{{.Repository}}/ide/jb-launcher:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
             ]
           },
@@ -569,7 +569,7 @@
             "version": "2024.1.1",
             "image": "{{.Repository}}/ide/rider:commit-9382d33ee521e6a72d763f906b24dd53893103df",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-355c91ab71d87a57c5d9abf70e992b6a1b94461e",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-6e78b49260501f3ccf1fb8081f4de2a9d2a54732-rider",
               "{{.Repository}}/ide/jb-launcher:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
             ]
           },
@@ -577,7 +577,7 @@
             "version": "2024.1",
             "image": "{{.Repository}}/ide/rider:commit-ef400309563b040b84d9588862805ce2f26d688a",
             "imageLayers": [
-              "{{.Repository}}/ide/jb-backend-plugin:commit-ef400309563b040b84d9588862805ce2f26d688a",
+              "{{.Repository}}/ide/jb-backend-plugin:commit-6e78b49260501f3ccf1fb8081f4de2a9d2a54732-rider",
               "{{.Repository}}/ide/jb-launcher:commit-b94aec12634259de91e0e3d1b6208f348f1ffe30"
             ]
           }

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -118,7 +118,6 @@ func TestWebStorm(t *testing.T) {
 func TestRider(t *testing.T) {
 	BaseGuard(t)
 	t.Parallel()
-	t.Skip("Until ENT-56")
 	f := features.New("Start a workspace using Rider").
 		WithLabel("component", "IDE").
 		WithLabel("ide", "Rider").


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Follow up for https://github.com/gitpod-io/gitpod/pull/20141

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #20132, ENT-679

## How to test
<!-- Provide steps to test this PR -->
- Update pinable version for Rider in org settings page
- Start workspace with Rider's old versions
- Verify it's working (check `gp open README.md` or tasks terminals)

✅ 

|2024.1|2024.1.1|2024.1.2|2024.1.3|2024.1.4|
|:-:|:-:|:-:|:-:|:-:|
|<img width="958" alt="image" src="https://github.com/user-attachments/assets/a0b8aadb-1470-43be-a23b-c5e0692319dd">|<img width="976" alt="image" src="https://github.com/user-attachments/assets/2315d353-ad00-43f8-a803-b814ab6be54b">|<img width="950" alt="image" src="https://github.com/user-attachments/assets/6ab5477e-4116-46cd-b271-69a0869d58eb">|<img width="872" alt="image" src="https://github.com/user-attachments/assets/ac32a954-7833-4078-950d-d4ef6d0a53b5">|<img width="999" alt="image" src="https://github.com/user-attachments/assets/a1b72169-0689-41bb-bbbf-58ef0c392775">|



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-rd-3</li>
	<li><b>🔗 URL</b> - <a href="https://hw-rd-3.preview.gitpod-dev.com/workspaces" target="_blank">hw-rd-3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-rd-3-gha.28320</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-rd-3%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
