### PR TITLE
Update images digests

### DIFF
--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM cgr.dev/chainguard/helm:latest@sha256:2e69b3b4a1f299620f7bb4ff54d4bc80c8b9fc9c673e70448a4624316e15e10b
+FROM cgr.dev/chainguard/helm:latest@sha256:5fe170c05c9b526707ff82eb5070dc2f4c0c42eed02394281a258cac57291381
 
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
 


### PR DESCRIPTION
Update images digests using the latest version available for image/s

## How to test
- [x] Start a workspace in the preview environment and verify that it functions properly.

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - update-digests</li>
	<li><b>🔗 URL</b> - <a href="https://update-digests.preview.gitpod-dev.com/workspaces" target="_blank">update-digests.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - update-digests-gha.28328</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-update-digests%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [x] /werft with-preview
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=ssh
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
</details>