### PR TITLE
Feature flag for disabling listening for all prebuild updates

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -243,6 +243,20 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         if (!this.client) {
             return;
         }
+
+        // todo(ft) disable registering for all updates from all projects by default and only listen to updates when the client is explicity interested in them
+        const disableWebsocketPrebuildUpdates = await getExperimentsClientForBackend().getValueAsync(
+            "disableWebsocketPrebuildUpdates",
+            false,
+            {
+                gitpodHost: this.config.hostUrl.url.host,
+            },
+        );
+        if (disableWebsocketPrebuildUpdates) {
+            log.info("ws prebuild updates disabled by feature flag");
+            return;
+        }
+
         // 'registering for prebuild updates for all projects this user has access to
         const projects = await this.getAccessibleProjects();
 


### PR DESCRIPTION
## Description

Currently, we listen for all prebuild updates on all projects on all organizations the user has access to. This change optionally disables that default.

## How to test

https://ft-websock8116b02d8e.preview.gitpod-dev.com/workspaces

Make sure you can watch prebuilds (the feature flag is turned on for the preview environment)