### PR TITLE
Improve CORS settings

### DIFF
--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -30,8 +30,10 @@ require (
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v4 v4.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/configcat/go-sdk/v7 v7.6.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch/v5 v5.8.0 // indirect

--- a/components/ws-proxy/go.sum
+++ b/components/ws-proxy/go.sum
@@ -6,6 +6,8 @@ github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
+github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
@@ -17,6 +19,8 @@ github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/configcat/go-sdk/v7 v7.6.0 h1:CthQJ7DMz4bvUrpc8aek6VouJjisCvZCfuTG2gyNzL4=
+github.com/configcat/go-sdk/v7 v7.6.0/go.mod h1:2245V6Igy1Xz6GXvcYuK5z996Ct0VyzyuI470XS6aTw=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -35,6 +39,8 @@ github.com/evanphx/json-patch/v5 v5.8.0/go.mod h1:VNkHZ/282BpEyt/tObQO8s5CMPmYYq
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
+github.com/frankban/quicktest v1.11.2 h1:mjwHjStlXWibxOohM7HYieIViKyh56mmt3+6viyhDDI=
+github.com/frankban/quicktest v1.11.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gitpod-io/golang-crypto v0.0.0-20231122075959-de838e9cb174 h1:OoCsCV3wxfN5FvbuhwuUgz6rZvsyfPxX3jZ2fKA+9H8=
@@ -77,6 +83,7 @@ github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6
 github.com/google/gnostic-models v0.6.8 h1:yo/ABAfM5IMRsS1VnXjTBvUb61tFIHozhlYvRgGre9I=
 github.com/google/gnostic-models v0.6.8/go.mod h1:5n7qKqH0f5wFt+aWF8CW6pZLLNOfYuF5OpfBSENuI8U=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
+github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.9/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=

--- a/components/ws-proxy/pkg/config/config.go
+++ b/components/ws-proxy/pkg/config/config.go
@@ -5,13 +5,19 @@
 package config
 
 import (
+	"context"
 	"encoding/json"
 	"os"
+	"time"
 
 	"golang.org/x/xerrors"
 
+	"github.com/gitpod-io/gitpod/common-go/experiments"
+	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/proxy"
 )
+
+const experimentsCorsEnabled = "ws_proxy_cors_enabled"
 
 // Config configures this service.
 type Config struct {
@@ -64,5 +70,30 @@ func GetConfig(fn string) (*Config, error) {
 		return nil, xerrors.Errorf("config validation error: %w", err)
 	}
 
+	timeout := time.Minute * 5
+	log.WithField("timeout", timeout).Info("nil CorsEnabled, wait for Feature Flag")
+	experimentsClient := experiments.NewClient(experiments.WithPollInterval(time.Second * 3))
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	ffValue := waitStringValue(ctx, experimentsClient, experimentsCorsEnabled, "nope", experiments.Attributes{})
+	corsEnabled := ffValue == "true"
+	log.WithField("ffValue", ffValue).WithField("corsEnabled", corsEnabled).Info("feature flag final value")
+
 	return &cfg, nil
+}
+
+func waitStringValue(ctx context.Context, client experiments.Client, experimentName, nopeValue string, attributes experiments.Attributes) string {
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return nopeValue
+		case <-ticker.C:
+			value := client.GetStringValue(ctx, experimentName, nopeValue, attributes)
+			if value != nopeValue {
+				return value
+			}
+		}
+	}
 }

--- a/components/ws-proxy/pkg/proxy/config.go
+++ b/components/ws-proxy/pkg/proxy/config.go
@@ -29,6 +29,7 @@ type Config struct {
 
 	BuiltinPages        BuiltinPagesConfig `json:"builtinPages"`
 	SSHGatewayCAKeyFile string             `json:"sshCAKeyFile"`
+	CorsEnabled         bool
 }
 
 // Validate validates the configuration to catch issues during startup and not at runtime.

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -45,7 +45,6 @@ import (
 type RouteHandlerConfig struct {
 	Config               *Config
 	DefaultTransport     http.RoundTripper
-	CorsHandler          mux.MiddlewareFunc
 	WorkspaceAuthHandler mux.MiddlewareFunc
 }
 
@@ -61,15 +60,9 @@ func WithDefaultAuth(infoprov common.WorkspaceInfoProvider) RouteHandlerConfigOp
 
 // NewRouteHandlerConfig creates a new instance.
 func NewRouteHandlerConfig(config *Config, opts ...RouteHandlerConfigOpt) (*RouteHandlerConfig, error) {
-	corsHandler, err := corsHandler(config.GitpodInstallation.Scheme, config.GitpodInstallation.HostName)
-	if err != nil {
-		return nil, err
-	}
-
 	cfg := &RouteHandlerConfig{
 		Config:               config,
 		DefaultTransport:     createDefaultTransport(config.TransportConfig),
-		CorsHandler:          corsHandler,
 		WorkspaceAuthHandler: func(h http.Handler) http.Handler { return h },
 	}
 	for _, o := range opts {
@@ -179,7 +172,6 @@ func (ir *ideRoutes) HandleSSHHostKeyRoute(route *mux.Route, hostKeyList []ssh.S
 	}
 	r := route.Subrouter()
 	r.Use(logRouteHandlerHandler("HandleSSHHostKeyRoute"))
-	r.Use(ir.Config.CorsHandler)
 	r.NewRoute().HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("Content-Type", "application/json")
 		rw.Write(byt)
@@ -189,7 +181,6 @@ func (ir *ideRoutes) HandleSSHHostKeyRoute(route *mux.Route, hostKeyList []ssh.S
 func (ir *ideRoutes) HandleCreateKeyRoute(route *mux.Route, hostKeyList []ssh.Signer) {
 	r := route.Subrouter()
 	r.Use(logRouteHandlerHandler("HandleCreateKeyRoute"))
-	r.Use(ir.Config.CorsHandler)
 	r.Use(ir.workspaceMustExistHandler)
 	r.Use(ir.Config.WorkspaceAuthHandler)
 
@@ -253,7 +244,6 @@ func extractCloseErrorCode(errStr string) string {
 func (ir *ideRoutes) HandleSSHOverWebsocketTunnel(route *mux.Route, sshGatewayServer *sshproxy.Server) {
 	r := route.Subrouter()
 	r.Use(logRouteHandlerHandler("HandleSSHOverWebsocketTunnel"))
-	r.Use(ir.Config.CorsHandler)
 	r.Use(ir.workspaceMustExistHandler)
 	r.Use(ir.Config.WorkspaceAuthHandler)
 
@@ -297,7 +287,6 @@ func (ir *ideRoutes) HandleSSHOverWebsocketTunnel(route *mux.Route, sshGatewaySe
 func (ir *ideRoutes) HandleDirectSupervisorRoute(route *mux.Route, authenticated bool) {
 	r := route.Subrouter()
 	r.Use(logRouteHandlerHandler(fmt.Sprintf("HandleDirectSupervisorRoute (authenticated: %v)", authenticated)))
-	r.Use(ir.Config.CorsHandler)
 	r.Use(ir.workspaceMustExistHandler)
 	if authenticated {
 		r.Use(ir.Config.WorkspaceAuthHandler)
@@ -382,7 +371,6 @@ type BlobserveInlineVars struct {
 func (ir *ideRoutes) HandleRoot(route *mux.Route) {
 	r := route.Subrouter()
 	r.Use(logRouteHandlerHandler("handleRoot"))
-	r.Use(ir.Config.CorsHandler)
 	r.Use(ir.workspaceMustExistHandler)
 
 	proxyPassWoSensitiveCookies := sensitiveCookieHandler(ir.Config.Config.GitpodInstallation.HostName)(proxyPass(ir.Config, ir.InfoProvider, workspacePodResolver))
@@ -516,7 +504,6 @@ func installDebugWorkspaceRoutes(r *mux.Router, config *RouteHandlerConfig, info
 	}
 
 	r.Use(logHandler)
-	r.Use(config.CorsHandler)
 	r.Use(config.WorkspaceAuthHandler)
 	// filter all session cookies
 	r.Use(sensitiveCookieHandler(config.Config.GitpodInstallation.HostName))
@@ -652,48 +639,6 @@ func buildWorkspacePodURL(protocol api.PortProtocol, ipAddress string, port stri
 		return nil, xerrors.Errorf("protocol not supported")
 	}
 	return url.Parse(fmt.Sprintf("%v://%v:%v", portProtocol, ipAddress, port))
-}
-
-// corsHandler produces the CORS handler for workspaces.
-func corsHandler(scheme, hostname string) (mux.MiddlewareFunc, error) {
-	origin := fmt.Sprintf("%s://%s", scheme, hostname)
-
-	domainRegex := strings.ReplaceAll(hostname, ".", "\\.")
-	originRegex, err := regexp.Compile(".*" + domainRegex)
-	if err != nil {
-		return nil, err
-	}
-
-	return handlers.CORS(
-		handlers.AllowedOriginValidator(func(origin string) bool {
-			// Is the origin a subdomain of the installations hostname?
-			matches := originRegex.Match([]byte(origin))
-			return matches
-		}),
-		// TODO(gpl) For domain-based workspace access with authentication (for accessing the IDE) we need to respond with the precise Origin header that was sent
-		handlers.AllowedOrigins([]string{origin}),
-		handlers.AllowedMethods([]string{
-			"GET",
-			"POST",
-			"OPTIONS",
-		}),
-		handlers.AllowedHeaders([]string{
-			// "Accept", "Accept-Language", "Content-Language" are allowed per default
-			"Cache-Control",
-			"Content-Type",
-			"DNT",
-			"If-Modified-Since",
-			"Keep-Alive",
-			"Origin",
-			"User-Agent",
-			"X-Requested-With",
-		}),
-		handlers.AllowCredentials(),
-		// required to be able to read Authorization header in frontend
-		handlers.ExposedHeaders([]string{"Authorization"}),
-		handlers.MaxAge(60),
-		handlers.OptionStatusCode(200),
-	), nil
 }
 
 type wsproxyContextKey struct{}

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -450,7 +450,7 @@ func TestRoutes(t *testing.T) {
 			},
 		},
 		{
-			Desc:   "CORS preflight",
+			Desc:   "no CORS allow in workspace urls",
 			Config: &config,
 			Request: modifyRequest(httptest.NewRequest("GET", workspaces[0].URL+"somewhere/in/the/ide", nil),
 				addHostHeader,
@@ -462,12 +462,9 @@ func TestRoutes(t *testing.T) {
 			Expectation: Expectation{
 				Status: http.StatusOK,
 				Header: http.Header{
-					"Access-Control-Allow-Credentials": {"true"},
-					"Access-Control-Allow-Origin":      {"test-domain.com"},
-					"Access-Control-Expose-Headers":    {"Authorization"},
-					"Content-Length":                   {"37"},
-					"Content-Type":                     {"text/plain; charset=utf-8"},
-					"Vary":                             {"Accept-Encoding"},
+					"Content-Length": {"37"},
+					"Content-Type":   {"text/plain; charset=utf-8"},
+					"Vary":           {"Accept-Encoding"},
 				},
 				Body: "workspace hit: /somewhere/in/the/ide\n",
 			},

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -95,6 +95,7 @@ var (
 		BuiltinPages: BuiltinPagesConfig{
 			Location: "../../public",
 		},
+		CorsEnabled: false,
 	}
 )
 

--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -409,6 +409,31 @@ func ConfigcatEnv(ctx *RenderContext) []corev1.EnvVar {
 	}
 }
 
+func ConfigcatEnvOutOfCluster(ctx *RenderContext) []corev1.EnvVar {
+	var sdkKey string
+	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {
+		if cfg.WebApp != nil && cfg.WebApp.ConfigcatKey != "" {
+			sdkKey = cfg.WebApp.ConfigcatKey
+		}
+		return nil
+	})
+
+	if sdkKey == "" {
+		return nil
+	}
+
+	return []corev1.EnvVar{
+		{
+			Name:  "CONFIGCAT_SDK_KEY",
+			Value: "gitpod",
+		},
+		{
+			Name:  "CONFIGCAT_BASE_URL",
+			Value: fmt.Sprintf("https://%s/configcat", ctx.Config.Domain),
+		},
+	}
+}
+
 func ConfigcatProxyEnv(ctx *RenderContext) []corev1.EnvVar {
 	var (
 		sdkKey        string

--- a/install/installer/pkg/common/common_test.go
+++ b/install/installer/pkg/common/common_test.go
@@ -11,9 +11,11 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/baseserver"
 	"github.com/gitpod-io/gitpod/installer/pkg/common"
 	config "github.com/gitpod-io/gitpod/installer/pkg/config/v1"
+	"github.com/gitpod-io/gitpod/installer/pkg/config/v1/experimental"
 	"github.com/gitpod-io/gitpod/installer/pkg/config/versions"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 func TestKubeRBACProxyContainer_DefaultPorts(t *testing.T) {
@@ -72,4 +74,20 @@ func TestServerComponentWaiterContainer(t *testing.T) {
 	labels := common.DefaultLabelSelector(common.ServerComponent)
 	require.Equal(t, labels, "app=gitpod,component=server")
 	require.Equal(t, []string{"-v", "component", "--namespace", "test_namespace", "--component", common.ServerComponent, "--labels", labels, "--image", ctx.Config.Repository + "/server:" + "happy_path_server_image"}, container.Args)
+}
+
+func TestConfigcatEnvOutOfCluster(t *testing.T) {
+	ctx, err := common.NewRenderContext(config.Config{
+		Domain: "gitpod.io",
+		Experimental: &experimental.Config{
+			WebApp: &experimental.WebAppConfig{
+				ConfigcatKey: "foo",
+			},
+		},
+	}, versions.Manifest{}, "test_namespace")
+	require.NoError(t, err)
+
+	envVars := common.ConfigcatEnvOutOfCluster(ctx)
+	require.Equal(t, len(envVars), 2)
+	require.Equal(t, envVars, []v1.EnvVar([]v1.EnvVar{{Name: "CONFIGCAT_SDK_KEY", Value: "gitpod"}, {Name: "CONFIGCAT_BASE_URL", Value: "https://gitpod.io/configcat"}}))
 }

--- a/install/installer/pkg/components/proxy/networkpolicy.go
+++ b/install/installer/pkg/components/proxy/networkpolicy.go
@@ -104,10 +104,6 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": common.DashboardComponent,
 					}},
-				}, {
-					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-						"component": common.WSProxyComponent,
-					}},
 				}},
 			}},
 		},

--- a/install/installer/pkg/components/proxy/networkpolicy.go
+++ b/install/installer/pkg/components/proxy/networkpolicy.go
@@ -104,6 +104,10 @@ func networkpolicy(ctx *common.RenderContext) ([]runtime.Object, error) {
 					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"component": common.DashboardComponent,
 					}},
+				}, {
+					PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"component": common.WSProxyComponent,
+					}},
 				}},
 			}},
 		},

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -142,6 +142,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				common.DefaultEnv(&ctx.Config),
 				common.WorkspaceTracingEnv(ctx, Component),
 				common.AnalyticsEnv(&ctx.Config),
+				common.ConfigcatEnv(ctx),
 			)),
 			ReadinessProbe: &corev1.Probe{
 				InitialDelaySeconds: int32(2),

--- a/install/installer/pkg/components/ws-proxy/deployment.go
+++ b/install/installer/pkg/components/ws-proxy/deployment.go
@@ -142,7 +142,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				common.DefaultEnv(&ctx.Config),
 				common.WorkspaceTracingEnv(ctx, Component),
 				common.AnalyticsEnv(&ctx.Config),
-				common.ConfigcatEnv(ctx),
+				// ws-proxy and proxy may not in the same cluster
+				common.ConfigcatEnvOutOfCluster(ctx),
 			)),
 			ReadinessProbe: &corev1.Probe{
 				InitialDelaySeconds: int32(2),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-538

## How to test
<!-- Provide steps to test this PR -->
See [internal chat](https://gitpod.slack.com/archives/C071G5TTS49/p1724754595201039)

Preview env should work well
- Workspace can start
- Open with VS Code Browser, Gitpod CLI , JetBrains Gateway, VS Code Browser
- Can access private port

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-ent-538</li>
	<li><b>🔗 URL</b> - <a href="https://hw-ent-538.preview.gitpod-dev.com/workspaces" target="_blank">hw-ent-538.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-ENT-538-gha.28366</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-ent-538%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=vscode
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
