### PR TITLE
[gp validate] using `gitpod/workspace-full:latest` as default image

### DIFF
--- a/components/gitpod-cli/cmd/validate.go
+++ b/components/gitpod-cli/cmd/validate.go
@@ -92,6 +92,9 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 		if err != nil {
 			return err
 		}
+		if image == "" {
+			image = "gitpod/workspace-full:latest"
+		}
 		fmt.Println("Using default workspace image:", image)
 	case string:
 		image = img


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[gp validate] using `gitpod/workspace-full:latest` as default image

The reason for not using installationDefaultImage is that in dedicated instances, the default image points to a private ECR, which can be successfully pulled on the node, but not in the workspace due to the lack of credentials.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-374
Fixes ENT-649

## How to test
<!-- Provide steps to test this PR -->
1. start a non gitpodify workspace in this preview env
2. try `gp validate`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
