### PR TITLE
Lower fetch priority of metrics

### DIFF
--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -55,7 +55,7 @@ export function parseProps(workspaceId: string, search?: string): StartWorkspace
     const runsInIFrame = window.top !== window.self;
     return {
         workspaceId,
-        runsInIFrame: window.top !== window.self,
+        runsInIFrame,
         // Either:
         //  - not_found: we were sent back from a workspace cluster/IDE URL where we expected a workspace to be running but it wasn't because either:
         //    - this is a (very) old tab and the workspace already timed out
@@ -228,7 +228,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 return;
             }
             // TODO: Remove this once we use `useStartWorkspaceMutation`
-            // Start listening too instance updates - and explicitly query state once to guarantee we get at least one update
+            // Start listening to instance updates - and explicitly query state once to guarantee we get at least one update
             // (needed for already started workspaces, and not hanging in 'Starting ...' for too long)
             this.fetchWorkspaceInfo(result.workspace?.status?.instanceId);
         } catch (error) {

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -32,7 +32,7 @@
         "mocha": "^10.2.0",
         "rimraf": "^2.6.2",
         "ts-node": "^10.4.0",
-        "typescript": "~4.4.2",
+        "typescript": "^5.5.4",
         "typescript-parser": "^2.6.1"
     },
     "scripts": {

--- a/components/gitpod-protocol/src/metrics.ts
+++ b/components/gitpod-protocol/src/metrics.ts
@@ -477,7 +477,7 @@ export class MetricsReporter {
         }
         this.sendQueue = this.sendQueue.then(async () => {
             try {
-                const response = await fetch(request.url, request);
+                const response = await fetch(request.url, { ...request, priority: "low" });
                 if (!response.ok) {
                     this.options.log.error(
                         `metrics: endpoint responded with ${response.status} ${response.statusText}`,

--- a/components/gitpod-protocol/tsconfig.json
+++ b/components/gitpod-protocol/tsconfig.json
@@ -10,13 +10,14 @@
         "downlevelIteration": true,
         "module": "commonjs",
         "moduleResolution": "node",
-        "target": "es6",
+        "target": "ES2018",
         "jsx": "react",
         "lib": [
             "es6",
-            "es2016",
+            "es2018",
             "dom",
-            "esnext.asynciterable"
+            "ES2018.Regexp",
+            "DOM.AsyncIterable"
         ],
         "sourceMap": true,
         "declaration": true,

--- a/components/supervisor/frontend/package.json
+++ b/components/supervisor/frontend/package.json
@@ -23,7 +23,7 @@
     "css-loader": "^6.8.1",
     "source-map-loader": "^4.0.1",
     "style-loader": "^3.3.3",
-    "typescript": "~4.4.2",
+    "typescript": "^5.5.4",
     "webpack": "^5.88.2",
     "webpack-cli": "^5.1.4"
   },

--- a/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
+++ b/components/supervisor/frontend/src/ide/ide-metrics-service-client.ts
@@ -70,6 +70,7 @@ export class IDEMetricsServiceClient {
                 method: "POST",
                 body: JSON.stringify(params),
                 credentials: "omit",
+                priority: "low",
             });
             if (!response.ok) {
                 const data = await response.json(); // { code: number; message: string; }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15198,6 +15198,11 @@ typescript@^5.4.5:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.4.5.tgz#42ccef2c571fdbd0f6718b1d1f5e6e5ef006f611"
   integrity sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==
 
+typescript@^5.5.4:
+  version "5.5.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.5.4.tgz#d9852d6c82bad2d2eda4fd74a5762a8f5909e9ba"
+  integrity sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==
+
 ua-parser-js@^1.0.36:
   version "1.0.36"
   resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-1.0.36.tgz#a9ab6b9bd3a8efb90bb0816674b412717b7c428c"


### PR DESCRIPTION
## Description

Gives our metrics calls less priority in comparison to mission-critical resources like API requests. 

## How to test

1. Make sure things in the [preview environment](https://ft-metrics3af7f1b94e.preview.gitpod-dev.com/workspaces) still work

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>