### PR TITLE
Build patch for VS Code Browser

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: 232bb7381c584aaa00fae1544b33b430119a857d
+  codeCommit: c0c4bad3583fb42ab400c086832538dbf89b4434
   codeVersion: 1.92.1
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: c0c4bad3583fb42ab400c086832538dbf89b4434
+  codeCommit: 2bb866718ab3d0a3a79e1e8c90457d54bd3fd05e
   codeVersion: 1.92.1
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,7 +7,7 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: f89b31db4e103a12b1f2250d16c7ae6ac6384e82
+  codeCommit: 232bb7381c584aaa00fae1544b33b430119a857d
   codeVersion: 1.92.1
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Patch https://github.com/gitpod-io/openvscode-server/commit/2bb866718ab3d0a3a79e1e8c90457d54bd3fd05e

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates ENT-742

## How to test
<!-- Provide steps to test this PR -->
- Open a workspace in preview env with **Latest VS Code Browser**
- Everything works well (light smoke test is enough)
- VS Code's commit hash in About page (Menu (click) > Help > About) should be `2bb866718ab3d0a3a79e1e8c90457d54bd3fd05e`


**Patch**
- Open workspace in preview env with **Latest VS Code Browser** + repo https://github.com/mustard-mh/test/tree/vscode/open-with-browser (main content see `extension.js`)
- Menu Bar > Run and Debug > Run Extension
- It should open a new tab, and then prompt to ask if you want to open `https://google.com`

|About|Patch|
|:-:|:-:|
|<img width="1142" alt="image" src="https://github.com/user-attachments/assets/08744ec4-c7c1-4ad9-9ac3-35eb401d491e">|<img width="1660" alt="image" src="https://github.com/user-attachments/assets/9515ebec-8634-4c0e-a942-9e5b9bf72479">|


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - mustard-mh-patch-1</li>
	<li><b>🔗 URL</b> - <a href="https://mustard-mh-patch-1.preview.gitpod-dev.com/workspaces" target="_blank">mustard-mh-patch-1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - mustard-mh-patch-1-gha.28451</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-mustard-mh-patch-1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=vscode
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
