### PR TITLE
Improve JetBrains integration tests to show proper failed message

### DIFF
--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -275,6 +275,7 @@ func TestIntelliJWarmup(t *testing.T) {
 							string(warmupIndexingShell),
 							"--",
 							jbCtx.SystemDir,
+							"1",
 						},
 					}, &resp)
 					if err != nil {

--- a/test/tests/ide/jetbrains/gateway_test.go
+++ b/test/tests/ide/jetbrains/gateway_test.go
@@ -281,10 +281,10 @@ func TestIntelliJWarmup(t *testing.T) {
 					if err != nil {
 						return fmt.Errorf("failed to warmup indexing: %v", err)
 					}
+					t.Logf("stdout:\n%s", string(resp.Stdout))
 					if resp.ExitCode != 0 {
 						return fmt.Errorf("failed to warmup indexing: %s, %d", resp.Stderr, resp.ExitCode)
 					}
-					t.Logf("output:\n%s", string(resp.Stdout))
 					return nil
 				}))
 			return testCtx

--- a/test/tests/ide/jetbrains/warmup-indexing.sh
+++ b/test/tests/ide/jetbrains/warmup-indexing.sh
@@ -5,12 +5,14 @@
 
 # This script is used to test JetBrains prebuild warmup indexing (search warmup-indexing.sh in codebase)
 # It will get the last indexing json file (scan type FULL_ON_PROJECT_OPEN)
-# and check if the scheduled indexing count is 0
+# and check if the scheduled indexing count is greater than a specified threshold
 #
 # `exit 0` means JetBrains IDEs no need to indexing again
+# Example: ./warmup-indexing.sh /workspace 1
 
 set -euo pipefail
 SystemDir=$1
+Threshold=$2
 
 ProjectIndexingFolder=$(find "$SystemDir"/log/indexing-diagnostic -type d -name "spring*" -print -quit)
 JsonFiles=$(find "$ProjectIndexingFolder" -type f -name "*.json")
@@ -28,4 +30,9 @@ echo "Target indexing json file: $targetFile"
 scheduledIndexing=$(jq '.projectIndexingActivityHistory.fileCount.numberOfFilesScheduledForIndexingAfterScan' "$targetFile")
 echo "Scheduled indexing count: $scheduledIndexing"
 
-[ "$scheduledIndexing" -ne 0 ] && exit 1 || exit 0
+if [ "$scheduledIndexing" -gt "$Threshold" ]; then
+    echo "Error: Scheduled indexing count $scheduledIndexing > $Threshold" >&2
+    exit 1
+else
+    exit 0
+fi

--- a/test/tests/ide/jetbrains/warmup-indexing.sh
+++ b/test/tests/ide/jetbrains/warmup-indexing.sh
@@ -28,7 +28,7 @@ mapfile -t sortedFiles < <(printf "%s\n" "${FilteredJsonFiles[@]}" | sort -r)
 targetFile=${sortedFiles[0]}
 echo "Target indexing json file: $targetFile"
 scheduledIndexing=$(jq '.projectIndexingActivityHistory.fileCount.numberOfFilesScheduledForIndexingAfterScan' "$targetFile")
-echo "Scheduled indexing count: $scheduledIndexing"
+echo "Scheduled indexing count: $scheduledIndexing, threshold: $Threshold"
 
 if [ "$scheduledIndexing" -gt "$Threshold" ]; then
     echo "Error: Scheduled indexing count $scheduledIndexing > $Threshold" >&2


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes Tests on https://github.com/gitpod-io/gitpod/pull/20160 failed without any useful info

## How to test
<!-- Provide steps to test this PR -->
Check GHA integration tests https://github.com/gitpod-io/gitpod/actions/runs/10663070116/job/29551898700?pr=20165, they should pass with proper `stdout:`
<img width="1520" alt="image" src="https://github.com/user-attachments/assets/f1cdb7d6-17db-401d-9587-44c090829a04">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-int-test-1</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-int-test-1.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-int-test-1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-int-test-1-gha.28456</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-int-test-1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
