### PR TITLE
[GP-CLI] fix `gp preview` not outputting stderr and stdout properly

### DIFF
--- a/components/gitpod-cli/cmd/preview.go
+++ b/components/gitpod-cli/cmd/preview.go
@@ -84,7 +84,6 @@ func openPreview(gpBrowserEnvVar string, url string) error {
 	args = append(args, url)
 
 	previewCmd := exec.Command(pcmd, args...)
-	previewCmd.Stdout = os.Stdout
 	previewCmd.Stderr = os.Stderr
 	err = previewCmd.Run()
 	if err != nil {

--- a/components/gitpod-cli/cmd/preview.go
+++ b/components/gitpod-cli/cmd/preview.go
@@ -84,6 +84,8 @@ func openPreview(gpBrowserEnvVar string, url string) error {
 	args = append(args, url)
 
 	previewCmd := exec.Command(pcmd, args...)
+	previewCmd.Stdout = os.Stdout
+	previewCmd.Stderr = os.Stderr
 	err = previewCmd.Run()
 	if err != nil {
 		return err


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-743

## How to test
<!-- Provide steps to test this PR -->
https://hw-preview-err.preview.gitpod-dev.com/workspaces

- Open a workspace in preview env
- Exec command below, there should have no error and prompt to open `google.com`
```
gp preview --external https://google.com
```
- Exec command below, it should show error messages
```
ELECTRON_RUN_AS_NODE=1 gp preview --external https://google.com
```

<img width="1201" alt="image" src="https://github.com/user-attachments/assets/d5a0e6ca-b0fd-41f6-9f84-974f405fc4be">


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
