### PR TITLE
[code] update code image layers

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,7 +8,7 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-80f3b3e47fc065d521be745b5795841d5e883667",
+        "image": "{{.Repository}}/ide/code:commit-cee438b2e2c0990279824c4dde6f053ad2154715",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-1bc46bd2a58dbc9033313519453939d895f16fce",


### PR DESCRIPTION
## Description
This PR updates the VS Code Browser image layers to the most recent installer version.

## How to test

Test if changes are working.

i.e.
- `code-helper` it can start browser code with extensions installed
- `gitpod-web-extension` extension functionalities are working well
- `code` is not expected it to be changed

### Preview status
gitpod:summary

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment