### PR TITLE
[supervisor] Frontend: re-try + track "checkReady"

### DIFF
--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -184,6 +184,7 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
         private clientWindow: Window,
     ) {
         this.processServerInfo();
+        this.sendFeatureFlagsUpdate();
         window.addEventListener("message", (event: MessageEvent) => {
             if (IDEFrontendDashboardService.isTrackEventData(event.data)) {
                 this.trackEvent(event.data.msg);
@@ -199,6 +200,9 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
             }
             if (IDEFrontendDashboardService.isOpenDesktopIDE(event.data)) {
                 this.openDesktopIDE(event.data.url);
+            }
+            if (IDEFrontendDashboardService.isFeatureFlagsRequestEventData(event.data)) {
+                this.sendFeatureFlagsUpdate();
             }
         });
         window.addEventListener("unload", () => {
@@ -372,6 +376,23 @@ export class IDEFrontendService implements IDEFrontendDashboardService.IServer {
                 type: "ide-info-update",
                 info,
             } as IDEFrontendDashboardService.InfoUpdateEventData,
+            "*",
+        );
+    }
+
+    private async sendFeatureFlagsUpdate() {
+        const supervisor_check_ready_retry = await getExperimentsClient().getValueAsync(
+            "supervisor_check_ready_retry",
+            false,
+            {
+                gitpodHost: gitpodHostUrl.toString(),
+            },
+        );
+        this.clientWindow.postMessage(
+            {
+                type: "ide-feature-flag-update",
+                flags: { supervisor_check_ready_retry },
+            } as IDEFrontendDashboardService.FeatureFlagsUpdateEventData,
             "*",
         );
     }

--- a/components/gitpod-protocol/src/frontend-dashboard-service.ts
+++ b/components/gitpod-protocol/src/frontend-dashboard-service.ts
@@ -69,6 +69,15 @@ export namespace IDEFrontendDashboardService {
         info: Info;
     }
 
+    export interface FeatureFlagsUpdateEventData {
+        type: "ide-feature-flag-update";
+        flags: { supervisor_check_ready_retry: boolean };
+    }
+
+    export interface FeatureFlagsRequestEventData {
+        type: "ide-feature-flag-request";
+    }
+
     export interface HeartbeatEventData {
         type: "ide-heartbeat";
     }
@@ -99,6 +108,14 @@ export namespace IDEFrontendDashboardService {
 
     export function isInfoUpdateEventData(obj: any): obj is InfoUpdateEventData {
         return obj != null && typeof obj === "object" && obj.type === "ide-info-update";
+    }
+
+    export function isFeatureFlagsUpdateEventData(obj: any): obj is FeatureFlagsUpdateEventData {
+        return obj != null && typeof obj === "object" && obj.type === "ide-feature-flag-update";
+    }
+
+    export function isFeatureFlagsRequestEventData(obj: any): obj is FeatureFlagsRequestEventData {
+        return obj != null && typeof obj === "object" && obj.type === "ide-feature-flag-request";
     }
 
     export function isHeartbeatEventData(obj: any): obj is HeartbeatEventData {

--- a/components/gitpod-protocol/src/util/timeout.spec.ts
+++ b/components/gitpod-protocol/src/util/timeout.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import * as chai from "chai";
+const expect = chai.expect;
+import { suite, test } from "@testdeck/mocha";
+import { Timeout } from "./timeout";
+
+@suite()
+export class TimeoutSpec {
+    @test
+    async testSimpleRun() {
+        const timeout = new Timeout(1);
+        timeout.start();
+        await timeout.await();
+        expect(timeout.signal()?.aborted).to.be.true;
+    }
+
+    @test
+    async testSimpleRunNotStarted() {
+        const timeout = new Timeout(1);
+        await timeout.await();
+        expect(timeout.signal()).to.be.undefined;
+    }
+
+    @test
+    async testRestart() {
+        const timeout = new Timeout(20);
+        timeout.start();
+        await timeout.await();
+        expect(timeout.signal()?.aborted).to.be.true;
+
+        timeout.restart();
+        expect(timeout.signal()).to.not.be.undefined;
+        expect(timeout.signal()?.aborted).to.be.false;
+        await timeout.await();
+        expect(timeout.signal()?.aborted).to.be.true;
+    }
+
+    @test
+    async testClear() {
+        const timeout = new Timeout(1000);
+        timeout.restart();
+        timeout.clear();
+        expect(timeout.signal()).to.be.undefined;
+    }
+
+    @test
+    async testAbortCondition() {
+        const timeout = new Timeout(1, () => false); // will never trigger abort
+        timeout.start();
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(timeout.signal()).to.not.be.undefined;
+        expect(timeout.signal()?.aborted).to.be.false;
+    }
+}

--- a/components/gitpod-protocol/src/util/timeout.ts
+++ b/components/gitpod-protocol/src/util/timeout.ts
@@ -1,0 +1,80 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+/**
+ * A restartable timeout, based on an AbortController + setTimeout.
+ *
+ * Note: When cleared/reset, the AbortController is _NOT_ aborted.
+ */
+export class Timeout {
+    private _timer: NodeJS.Timeout | undefined;
+    private _abortController: AbortController | undefined;
+
+    /**
+     * @param timeout The timeout in milliseconds.
+     * @param abortCondition An optional condition evaluated on timeout: If set, the abort is only emitted if it evaluates to true.
+     */
+    constructor(readonly timeout: number, readonly abortCondition?: () => boolean) {}
+
+    /**
+     * Starts a new timeout (and clears the old one). Identical to `reset`.
+     */
+    public start() {
+        this.restart();
+    }
+
+    /**
+     * Starts a new timeout (and clears the old one).
+     */
+    public restart() {
+        this.clear();
+
+        const abortController = new AbortController();
+        this._abortController = abortController;
+        this._timer = setTimeout(() => {
+            if (this.abortCondition && !this.abortCondition()) {
+                return;
+            }
+
+            abortController.abort();
+        }, this.timeout);
+    }
+
+    /**
+     * Clears the current timeout.
+     */
+    public clear() {
+        if (this._timer) {
+            clearTimeout(this._timer);
+            this._timer = undefined;
+        }
+        if (this._abortController) {
+            this._abortController = undefined;
+        }
+    }
+
+    /**
+     * Convenience method to await the timeout.
+     * @returns
+     */
+    public async await(): Promise<boolean> {
+        const abortController = this._abortController;
+        if (!abortController) {
+            return false;
+        }
+
+        return new Promise((resolve) => {
+            abortController.signal.addEventListener("abort", () => resolve(true));
+        });
+    }
+
+    /**
+     * @returns The AbortSignal of the current timeout, if one is active.
+     */
+    public signal(): AbortSignal | undefined {
+        return this._abortController?.signal;
+    }
+}

--- a/components/gitpod-protocol/tsconfig.json
+++ b/components/gitpod-protocol/tsconfig.json
@@ -16,8 +16,7 @@
             "es6",
             "es2018",
             "dom",
-            "ES2018.Regexp",
-            "DOM.AsyncIterable"
+            "ES2018.Regexp"
         ],
         "sourceMap": true,
         "declaration": true,

--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -103,7 +103,7 @@ export class SupervisorServiceClient {
 
         // setup a timeout, which is meant to re-establish the connection every 5 seconds
         let isError = false;
-        const timeout = new Timeout(5000);
+        const timeout = new Timeout(5000, () => this.serviceClient.isCheckReadyRetryEnabled());
         try {
             timeout.restart();
 

--- a/components/supervisor/frontend/src/index.ts
+++ b/components/supervisor/frontend/src/index.ts
@@ -85,9 +85,9 @@ LoadingFrame.load().then(async (loading) => {
     window.gitpod.encrypt = frontendDashboardServiceClient.encrypt.bind(frontendDashboardServiceClient);
     window.gitpod.isEncryptedData = frontendDashboardServiceClient.isEncryptedData.bind(frontendDashboardServiceClient);
 
-    (async () => {
-        const supervisorServiceClient = SupervisorServiceClient.get();
+    const supervisorServiceClient = new SupervisorServiceClient(frontendDashboardServiceClient);
 
+    (async () => {
         let hideDesktopIde = false;
         const hideDesktopIdeEventListener = frontendDashboardServiceClient.onOpenBrowserIDE(() => {
             hideDesktopIdeEventListener.dispose();
@@ -271,7 +271,6 @@ LoadingFrame.load().then(async (loading) => {
                 });
             });
         }
-        const supervisorServiceClient = SupervisorServiceClient.get();
         if (debugWorkspace) {
             supervisorServiceClient.supervisorWillShutdown.then(() => {
                 window.open("", "_self")?.close();

--- a/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
+++ b/components/supervisor/frontend/src/shared/frontend-dashboard-service.ts
@@ -26,6 +26,7 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
 
     private resolveInit!: () => void;
     private initPromise = new Promise<void>((resolve) => (this.resolveInit = resolve));
+    private featureFlags: Partial<IDEFrontendDashboardService.FeatureFlagsUpdateEventData["flags"]> = {};
 
     private version?: number;
 
@@ -59,7 +60,11 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
             if (IDEFrontendDashboardService.isOpenBrowserIDE(event.data)) {
                 this.onOpenBrowserIDEEmitter.fire(undefined);
             }
+            if (IDEFrontendDashboardService.isFeatureFlagsUpdateEventData(event.data)) {
+                this.featureFlags = event.data.flags;
+            }
         });
+        this.requestFreshFeatureFlags();
     }
     initialize(): Promise<void> {
         return this.initPromise;
@@ -139,6 +144,17 @@ export class FrontendDashboardServiceClient implements IDEFrontendDashboardServi
             { type: "ide-open-desktop", url } as IDEFrontendDashboardService.OpenDesktopIDE,
             serverUrl.url.origin,
         );
+    }
+
+    requestFreshFeatureFlags(): void {
+        window.postMessage(
+            { type: "ide-feature-flag-request" } as IDEFrontendDashboardService.FeatureFlagsRequestEventData,
+            serverUrl.url.origin,
+        );
+    }
+
+    isCheckReadyRetryEnabled(): boolean {
+        return !!this.featureFlags.supervisor_check_ready_retry;
     }
 }
 

--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -210,6 +210,12 @@ func withHTTPErrorHandler(h http.Handler) proxyPassOpt {
 	}
 }
 
+func withErrorHandler(h errorHandler) proxyPassOpt {
+	return func(cfg *proxyPassConfig) {
+		cfg.ErrorHandler = h
+	}
+}
+
 func createDefaultTransport(config *TransportConfig) *http.Transport {
 	// TODO equivalent of client_max_body_size 2048m; necessary ???
 	// this is based on http.DefaultTransport, with some values exposed to config


### PR DESCRIPTION
## Description
This PR:
 - ws-proxy: enables INFO logging for /supervisor/v1/status/(ide|content|supervisor) endpoints
 - add tracking for connection attempts towards supervisor `status` endpoints
   - requires a small follow-up PR to actually export the event `supervisor_check_ready` data from Dedicated installations
 - introduces a re-try logic (every 5s) on the supervisor `status` endpoints, to avoid being stuck on stale requests
   - this is just a theory so far, and needs to be validated with he tracking above :point_up: 
   - the re-try is guarded by the `supervisor_check_ready_retry` feature flag (default: false)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-672

## How to test
 - https://gpl-672-sup-front.preview.gitpod-dev.com/workspaces

### Happy path - re-try disabled
 - confirm configcat featureFlag `supervisor_check_ready_retry` = false
 - start workspace (workspaceId must not contain "-bel-"!)
 - see that track event is emitted: :heavy_check_mark: 
![image](https://github.com/user-attachments/assets/9277523e-51b5-463e-a30c-687646c1227f)
 - workspace opens :heavy_check_mark: 

### Broken - re-try disabled
 - confirm configcat featureFlag `supervisor_check_ready_retry` = false
 - start workspace (workspaceId must "-bel-", which leads to no response on the `/status` requests)
 - see `/status` request stuck in pending :red_circle: 
 - workspace still won't open :red_circle: 

### Broken - re-try enabled
 - confirm configcat featureFlag `supervisor_check_ready_retry` = false
 - start workspace (workspaceId must "-bel-", which leads to no response on the `/status` requests)
 - see that tracking events with `aborted: true` are emitted :heavy_check_mark: 
 
![image](https://github.com/user-attachments/assets/50d8826a-bca2-4c0e-a91a-89b59f367104)

 - workspace still won't open because of the simple test code
 
### Happy path - re-try enabled
 - confirm configcat featureFlag `supervisor_check_ready_retry` = true
 - start workspace (workspaceId must not contain "-bel-"!)
 - see that track event is emitted :heavy_check_mark: 
 - workspace opens :heavy_check_mark: 




## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
