### PR TITLE
[PAPI] Use "Timeout" for setting up a connectionTimeout

### DIFF
--- a/components/gitpod-protocol/src/util/timeout.ts
+++ b/components/gitpod-protocol/src/util/timeout.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+/**
+ * A resettable timeout, based on an AbortController + setTimeout.
+ */
+export class Timeout {
+    private _timer: NodeJS.Timeout | undefined;
+    private _abortController: AbortController | undefined;
+
+    constructor(readonly timeout: number, readonly abortCondition?: () => boolean) {}
+
+    /**
+     * Starts a new timeout (and clears the old one). Identical to `reset`.
+     */
+    public start() {
+        this.reset();
+    }
+
+    /**
+     * Starts a new timeout (and clears the old one).
+     */
+    public reset() {
+        this.clear();
+
+        const abortController = new AbortController();
+        this._abortController = abortController;
+        this._timer = setTimeout(() => {
+            if (this.abortCondition && this.abortCondition()) {
+                return;
+            }
+
+            abortController.abort();
+        }, this.timeout);
+    }
+
+    public clear() {
+        if (this._timer) {
+            clearTimeout(this._timer);
+            this._timer = undefined;
+        }
+        if (this._abortController) {
+            this._abortController = undefined;
+        }
+    }
+
+    public signal(): AbortSignal | undefined {
+        return this._abortController?.signal;
+    }
+}
+
+export class CombinedAbortSignal extends AbortSignal {}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
