### PR TITLE
[gp] Allow update of existing user-scoped env vars

### DIFF
--- a/components/gitpod-cli/cmd/validate.go
+++ b/components/gitpod-cli/cmd/validate.go
@@ -238,7 +238,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	serverLog := logrus.NewEntry(logrus.New())
 	serverLog.Logger.SetLevel(logLevel)
 	setLoggerFormatter(serverLog.Logger)
-	workspaceEnvs, err := getWorkspaceEnvs(ctx, &connectToServerOptions{supervisorClient, wsInfo, serverLog})
+	workspaceEnvs, err := getWorkspaceEnvs(ctx, &connectToServerOptions{supervisorClient, wsInfo, serverLog, false})
 	if err != nil {
 		return err
 	}

--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -61,7 +61,6 @@ type APIInterface interface {
 	ClosePort(ctx context.Context, workspaceID string, port float32) (err error)
 	UpdateGitStatus(ctx context.Context, workspaceID string, status *WorkspaceInstanceRepoStatus) (err error)
 	GetWorkspaceEnvVars(ctx context.Context, workspaceID string) (res []*EnvVar, err error)
-	GetEnvVars(ctx context.Context) (res []*EnvVar, err error)
 	SetEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error)
 	DeleteEnvVar(ctx context.Context, variable *UserEnvVarValue) (err error)
 	HasSSHPublicKey(ctx context.Context) (res bool, err error)
@@ -179,8 +178,6 @@ const (
 	FunctionOpenPort FunctionName = "openPort"
 	// FunctionClosePort is the name of the closePort function
 	FunctionClosePort FunctionName = "closePort"
-	// FunctionGetEnvVars is the name of the getEnvVars function
-	FunctionGetEnvVars FunctionName = "getEnvVars"
 	// FunctionSetEnvVar is the name of the setEnvVar function
 	FunctionSetEnvVar FunctionName = "setEnvVar"
 	// FunctionDeleteEnvVar is the name of the deleteEnvVar function
@@ -1080,24 +1077,6 @@ func (gp *APIoverJSONRPC) GetWorkspaceEnvVars(ctx context.Context, workspaceID s
 
 	var result []*EnvVar
 	err = gp.C.Call(ctx, "getWorkspaceEnvVars", _params, &result)
-	if err != nil {
-		return
-	}
-	res = result
-
-	return
-}
-
-// GetEnvVars calls getEnvVars on the server
-func (gp *APIoverJSONRPC) GetEnvVars(ctx context.Context) (res []*EnvVar, err error) {
-	if gp == nil {
-		err = errNotConnected
-		return
-	}
-	var _params []interface{}
-
-	var result []*EnvVar
-	err = gp.C.Call(ctx, "getEnvVars", _params, &result)
 	if err != nil {
 		return
 	}

--- a/components/gitpod-protocol/go/mock.go
+++ b/components/gitpod-protocol/go/mock.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
@@ -327,19 +327,19 @@ func (mr *MockAPIInterfaceMockRecorder) GetConfiguration(ctx interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfiguration", reflect.TypeOf((*MockAPIInterface)(nil).GetConfiguration), ctx)
 }
 
-// GetEnvVars mocks base method.
-func (m *MockAPIInterface) GetEnvVars(ctx context.Context) ([]*EnvVar, error) {
+// GetDefaultWorkspaceImage mocks base method.
+func (m *MockAPIInterface) GetDefaultWorkspaceImage(ctx context.Context, params *GetDefaultWorkspaceImageParams) (*GetDefaultWorkspaceImageResult, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEnvVars", ctx)
-	ret0, _ := ret[0].([]*EnvVar)
+	ret := m.ctrl.Call(m, "GetDefaultWorkspaceImage", ctx, params)
+	ret0, _ := ret[0].(*GetDefaultWorkspaceImageResult)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetEnvVars indicates an expected call of GetEnvVars.
-func (mr *MockAPIInterfaceMockRecorder) GetEnvVars(ctx interface{}) *gomock.Call {
+// GetDefaultWorkspaceImage indicates an expected call of GetDefaultWorkspaceImage.
+func (mr *MockAPIInterfaceMockRecorder) GetDefaultWorkspaceImage(ctx, params interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEnvVars", reflect.TypeOf((*MockAPIInterface)(nil).GetEnvVars), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultWorkspaceImage", reflect.TypeOf((*MockAPIInterface)(nil).GetDefaultWorkspaceImage), ctx, params)
 }
 
 // GetGenericInvite mocks base method.
@@ -444,6 +444,21 @@ func (m *MockAPIInterface) GetOpenPorts(ctx context.Context, workspaceID string)
 func (mr *MockAPIInterfaceMockRecorder) GetOpenPorts(ctx, workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenPorts", reflect.TypeOf((*MockAPIInterface)(nil).GetOpenPorts), ctx, workspaceID)
+}
+
+// GetOrgSettings mocks base method.
+func (m *MockAPIInterface) GetOrgSettings(ctx context.Context, orgID string) (*OrganizationSettings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrgSettings", ctx, orgID)
+	ret0, _ := ret[0].(*OrganizationSettings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrgSettings indicates an expected call of GetOrgSettings.
+func (mr *MockAPIInterfaceMockRecorder) GetOrgSettings(ctx, orgID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgSettings", reflect.TypeOf((*MockAPIInterface)(nil).GetOrgSettings), ctx, orgID)
 }
 
 // GetOwnAuthProviders mocks base method.
@@ -802,36 +817,6 @@ func (m *MockAPIInterface) RemoveTeamMember(ctx context.Context, teamID, userID 
 func (mr *MockAPIInterfaceMockRecorder) RemoveTeamMember(ctx, teamID, userID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTeamMember", reflect.TypeOf((*MockAPIInterface)(nil).RemoveTeamMember), ctx, teamID, userID)
-}
-
-// GetOrgSettings mocks base method.
-func (m *MockAPIInterface) GetOrgSettings(ctx context.Context, orgID string) (*OrganizationSettings, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrgSettings", ctx, orgID)
-	ret0, _ := ret[0].(*OrganizationSettings)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetOrgSettings indicates an expected call of GetOrgSettings.
-func (mr *MockAPIInterfaceMockRecorder) GetOrgSettings(ctx, orgID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgSettings", reflect.TypeOf((*MockAPIInterface)(nil).GetOrgSettings), ctx, orgID)
-}
-
-// GetDefaultWorkspaceImage mocks base method.
-func (m *MockAPIInterface) GetDefaultWorkspaceImage(ctx context.Context, params *GetDefaultWorkspaceImageParams) (*GetDefaultWorkspaceImageResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDefaultWorkspaceImage", ctx)
-	ret0, _ := ret[0].(*GetDefaultWorkspaceImageResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetDefaultWorkspaceImage indicates an expected call of GetDefaultWorkspaceImage.
-func (mr *MockAPIInterfaceMockRecorder) GetDefaultWorkspaceImage(ctx, params *GetDefaultWorkspaceImageParams) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultWorkspaceImage", reflect.TypeOf((*MockAPIInterface)(nil).GetDefaultWorkspaceImage), ctx, params)
 }
 
 // ResetGenericInvite mocks base method.

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1616,7 +1616,6 @@ export class WorkspaceStarter {
             "function:guessGitTokenScopes",
             "function:updateGitStatus",
             "function:getWorkspaceEnvVars",
-            "function:getEnvVars", // TODO remove this after new gitpod-cli is deployed
             "function:setEnvVar",
             "function:deleteEnvVar",
             "function:getTeams",

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1665,6 +1665,8 @@ export class WorkspaceStarter {
                     operations: ["create", "get"],
                 }),
         ];
+        // By intention, we only limit the token passed down to the workspace to the env vars scoped to that workspace.
+        // This is meant to maintain the "workspace as a unit of isolation" principle on the API level.
         if (CommitContext.is(workspace.context)) {
             const subjectID = workspace.context.repository.owner + "/" + workspace.context.repository.name;
             scopes.push(
@@ -1676,6 +1678,15 @@ export class WorkspaceStarter {
                     }),
             );
         }
+        // The only exception is "updates", which we allow to be made to all env vars (that exist).
+        scopes.push(
+            "resource:" +
+                ScopedResourceGuard.marshalResourceScope({
+                    kind: "envVar",
+                    subjectID: "*/*",
+                    operations: ["update"],
+                }),
+        );
         return scopes;
     }
 


### PR DESCRIPTION
## Description
This PR does two things:
 - drops references to the long-deleted API call `getEnvVars`
 - introduces a new flag `--scope=[user|repo]` to allow `update` on already existing user-scoped environment variables

###Discussion:
Permissions on environment variables are delicated, as they touch on the "workspace as trust boundary" principle. So far we have been very careful do not allow any cross-repository/-workspace "cross-talk" on the API level.

I still feel the slight expansion to update _existing, globally-visible_ env vars make sense.
Alternatively, we could introduce a property "globally writable" on env vars, to make this even more explicit. WDYT?

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-529

## How to test
 - start a workspace here: https://gpl-529-scope-user.preview.gitpod-dev.com/workspaces
 - run these commands:
```
gitpod /workspace/bel (master) $ gp env
gitpod /workspace/bel (master) $ gp env WS_ENV=test
WS_ENV=test
gitpod /workspace/bel (master) $ gp env --scope=user USER_ENV=test
jsonrpc2: code 403 message: operation not permitted: missing create permission on envVar
```
- the the user env var in the UI with value "something"
```
gitpod /workspace/bel (master) $ gp env --scope=user USER_ENV=test
USER_ENV=test
gitpod /workspace/bel (master) $ gp env
USER_ENV=test
WS_ENV=test
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
