### PR TITLE
Reduce required Bitbucket scopes

### DIFF
--- a/components/public-api/typescript-common/src/auth-providers.ts
+++ b/components/public-api/typescript-common/src/auth-providers.ts
@@ -37,7 +37,7 @@ export namespace GitHubScope {
 export namespace BitbucketOAuthScopes {
     // https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html
 
-    /** Read user info like name, e-mail adresses etc. */
+    /** Read user info like name, e-mail addresses etc. */
     export const ACCOUNT_READ = "account";
     /** Access repo info, clone repo over https, read and write issues */
     export const REPOSITORY_READ = "repository";
@@ -47,8 +47,6 @@ export namespace BitbucketOAuthScopes {
     export const PULL_REQUEST_READ = "pullrequest";
     /** Create, comment and merge pull requests */
     export const PULL_REQUEST_WRITE = "pullrequest:write";
-    /** Create, list web hooks */
-    export const WEBHOOK = "webhook";
 
     export const ALL = [
         ACCOUNT_READ,
@@ -56,7 +54,6 @@ export namespace BitbucketOAuthScopes {
         REPOSITORY_WRITE,
         PULL_REQUEST_READ,
         PULL_REQUEST_WRITE,
-        WEBHOOK,
     ];
 
     export const DEFAULT = ALL;

--- a/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-auth-provider.ts
@@ -63,7 +63,7 @@ export class BitbucketServerAuthProvider extends GenericAuthProvider {
         try {
             const username = await this.api.currentUsername(accessToken);
             const userProfile = await this.api.getUserProfile(accessToken, username);
-            const avatarUrl = await this.api.getAvatarUrl(username);
+            const avatarUrl = this.api.getAvatarUrl(username);
             return <AuthUserSetup>{
                 authUser: {
                     // e.g. 105
@@ -74,7 +74,7 @@ export class BitbucketServerAuthProvider extends GenericAuthProvider {
                     name: userProfile.displayName!,
                     avatarUrl,
                 },
-                currentScopes: BitbucketServerOAuthScopes.ALL,
+                currentScopes: BitbucketServerOAuthScopes.Requirements.DEFAULT,
             };
         } catch (error) {
             log.error(`(${this.strategyName}) Reading current user info failed`, error, { error });

--- a/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-oauth-scopes.ts
@@ -23,6 +23,6 @@ export namespace BitbucketServerOAuthScopes {
         /**
          * Minimal required permission.
          */
-        DEFAULT: ALL,
+        DEFAULT: [PUBLIC_REPOS, REPO_READ, REPO_WRITE],
     };
 }

--- a/components/server/src/bitbucket/bitbucket-oauth-scopes.ts
+++ b/components/server/src/bitbucket/bitbucket-oauth-scopes.ts
@@ -7,7 +7,7 @@
 // https://confluence.atlassian.com/bitbucket/oauth-on-bitbucket-cloud-238027431.html
 
 export namespace BitbucketOAuthScopes {
-    /** Read user info like name, e-mail adresses etc. */
+    /** Read user info like name, e-mail addresses etc. */
     export const ACCOUNT_READ = "account";
     /** Access repo info, clone repo over https, read and write issues */
     export const REPOSITORY_READ = "repository";
@@ -17,17 +17,8 @@ export namespace BitbucketOAuthScopes {
     export const PULL_REQUEST_READ = "pullrequest";
     /** Create, comment and merge pull requests */
     export const PULL_REQUEST_WRITE = "pullrequest:write";
-    /** Create, list web hooks */
-    export const WEBHOOK = "webhook";
 
-    export const ALL = [
-        ACCOUNT_READ,
-        REPOSITORY_READ,
-        REPOSITORY_WRITE,
-        PULL_REQUEST_READ,
-        PULL_REQUEST_WRITE,
-        WEBHOOK,
-    ];
+    export const ALL = [ACCOUNT_READ, REPOSITORY_READ, REPOSITORY_WRITE, PULL_REQUEST_READ, PULL_REQUEST_WRITE];
 
     export const Requirements = {
         /**

--- a/components/server/src/user/token-service.ts
+++ b/components/server/src/user/token-service.ts
@@ -95,7 +95,7 @@ export class TokenService implements TokenProvider {
                         const doOpportunisticRefresh =
                             !!authProvider.requiresOpportunisticRefresh && authProvider.requiresOpportunisticRefresh();
                         if (!doOpportunisticRefresh) {
-                            // No opportunistic refresh? Update reserveation and we are done.
+                            // No opportunistic refresh? Update reservation and we are done.
                             await updateReservation(tokenEntry.uid, token, requestedLifetimeDate);
                             reportScmTokenRefreshRequest(host, opportunisticRefresh, "still_valid");
                             return token;


### PR DESCRIPTION
## Description

- Gets rid of the `WEBHOOK` scope for Bitbucket
- Gets rid of the mandatory `REPO_ADMIN` and `PROJECT_ADMIN` scopes and make them optional to toggle for Bitbucket Server

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-549

## How to test

1. [Sign up](https://ft-bb-scope-changes.preview.gitpod-dev.com/orgs/join?inviteId=cad0671f-2e32-4257-83e6-f15fedb38495) to my org (it's free!)
2. Open something like https://bitbucket.gitpod-dev.com/users/filip/repos/repodepo
3. Try to push to the repo (although maybe you'll need to make your own repo to have permissions for that).

- [x] /werft with-preview
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
