### PR TITLE
[ws-proxy] introduce RED metrics, including a http_version label

### DIFF
--- a/components/ws-proxy/pkg/common/infoprovider.go
+++ b/components/ws-proxy/pkg/common/infoprovider.go
@@ -23,6 +23,8 @@ const (
 	WorkspacePathPrefixIdentifier = "workspacePathPrefix"
 
 	WorkspaceInfoIdentifier = "workspaceInfo"
+
+	ForeignContentIdentifier = "foreignContent"
 )
 
 // WorkspaceCoords represents the coordinates of a workspace (port).
@@ -33,6 +35,8 @@ type WorkspaceCoords struct {
 	Port string
 	// Debug workspace
 	Debug bool
+	// Foreign content
+	Foreign bool
 }
 
 // WorkspaceInfoProvider is an entity that is able to provide workspaces related information.

--- a/components/ws-proxy/pkg/proxy/metrics.go
+++ b/components/ws-proxy/pkg/proxy/metrics.go
@@ -16,6 +16,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
+const (
+	metricsNamespace = "gitpod"
+	metricsSubsystem = "ws_proxy"
+)
+
 type httpMetrics struct {
 	requestsTotal    *prometheus.CounterVec
 	requestsDuration *prometheus.HistogramVec
@@ -34,24 +39,32 @@ func (m *httpMetrics) Collect(ch chan<- prometheus.Metric) {
 var (
 	serverMetrics = &httpMetrics{
 		requestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "http_server_requests_total",
-			Help: "Total number of incoming HTTP requests",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "http_server_requests_total",
+			Help:      "Total number of incoming HTTP requests",
 		}, []string{"method", "resource", "code", "http_version"}),
 		requestsDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "http_server_requests_duration_seconds",
-			Help:    "Duration of incoming HTTP requests in seconds",
-			Buckets: []float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600},
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "http_server_requests_duration_seconds",
+			Help:      "Duration of incoming HTTP requests in seconds",
+			Buckets:   []float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600},
 		}, []string{"method", "resource", "code", "http_version"}),
 	}
 	clientMetrics = &httpMetrics{
 		requestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "http_client_requests_total",
-			Help: "Total number of outgoing HTTP requests",
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "http_client_requests_total",
+			Help:      "Total number of outgoing HTTP requests",
 		}, []string{"method", "resource", "code", "http_version"}),
 		requestsDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
-			Name:    "http_client_requests_duration_seconds",
-			Help:    "Duration of outgoing HTTP requests in seconds",
-			Buckets: []float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600},
+			Namespace: metricsNamespace,
+			Subsystem: metricsSubsystem,
+			Name:      "http_client_requests_duration_seconds",
+			Help:      "Duration of outgoing HTTP requests in seconds",
+			Buckets:   []float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600},
 		}, []string{"method", "resource", "code", "http_version"}),
 	}
 )

--- a/components/ws-proxy/pkg/proxy/metrics.go
+++ b/components/ws-proxy/pkg/proxy/metrics.go
@@ -1,0 +1,162 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gorilla/mux"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type httpMetrics struct {
+	requestsTotal    *prometheus.CounterVec
+	requestsDuration *prometheus.HistogramVec
+}
+
+func (m *httpMetrics) Describe(ch chan<- *prometheus.Desc) {
+	m.requestsTotal.Describe(ch)
+	m.requestsDuration.Describe(ch)
+}
+
+func (m *httpMetrics) Collect(ch chan<- prometheus.Metric) {
+	m.requestsTotal.Collect(ch)
+	m.requestsDuration.Collect(ch)
+}
+
+var (
+	serverMetrics = &httpMetrics{
+		requestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "http_server_requests_total",
+			Help: "Total number of incoming HTTP requests",
+		}, []string{"method", "resource", "code", "http_version"}),
+		requestsDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_server_requests_duration_seconds",
+			Help:    "Duration of incoming HTTP requests in seconds",
+			Buckets: []float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600},
+		}, []string{"method", "resource", "code", "http_version"}),
+	}
+	clientMetrics = &httpMetrics{
+		requestsTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Name: "http_client_requests_total",
+			Help: "Total number of outgoing HTTP requests",
+		}, []string{"method", "resource", "code", "http_version"}),
+		requestsDuration: prometheus.NewHistogramVec(prometheus.HistogramOpts{
+			Name:    "http_client_requests_duration_seconds",
+			Help:    "Duration of outgoing HTTP requests in seconds",
+			Buckets: []float64{.005, .025, .05, .1, .5, 1, 2.5, 5, 30, 60, 120, 240, 600},
+		}, []string{"method", "resource", "code", "http_version"}),
+	}
+)
+
+func init() {
+	metrics.Registry.MustRegister(serverMetrics, clientMetrics)
+}
+
+type contextKey int
+
+var (
+	resourceKey = contextKey(0)
+)
+
+func withResource(r *http.Request, resource string) *http.Request {
+	ctx := context.WithValue(r.Context(), resourceKey, []string{resource})
+	return r.WithContext(ctx)
+}
+
+func withResourceLabel() promhttp.Option {
+	return promhttp.WithLabelFromCtx("resource", func(ctx context.Context) string {
+		if v := ctx.Value(resourceKey); v != nil {
+			if resources, ok := v.([]string); ok {
+				if len(resources) > 0 {
+					return resources[0]
+				}
+			}
+		}
+		return "unknown"
+	})
+}
+
+func instrumentClientMetrics(transport http.RoundTripper) http.RoundTripper {
+	return promhttp.InstrumentRoundTripperCounter(clientMetrics.requestsTotal,
+		promhttp.InstrumentRoundTripperDuration(clientMetrics.requestsDuration,
+			transport,
+			withResourceLabel()),
+		withResourceLabel(),
+	)
+}
+
+func instrumentServerMetrics(next http.Handler) http.Handler {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		next.ServeHTTP(w, req)
+		if v := req.Context().Value(resourceKey); v != nil {
+			if resources, ok := v.([]string); ok {
+				if len(resources) > 0 {
+					resources[0] = getHandlerResource(req)
+				}
+			}
+		}
+	})
+	instrumented := promhttp.InstrumentHandlerCounter(serverMetrics.requestsTotal,
+		promhttp.InstrumentHandlerDuration(serverMetrics.requestsDuration,
+			handler,
+			withResourceLabel()),
+		withResourceLabel(),
+	)
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ctx := context.WithValue(req.Context(), resourceKey, []string{"unknown"})
+		instrumented.ServeHTTP(w, req.WithContext(ctx))
+	})
+}
+
+func getHandlerResource(req *http.Request) string {
+	hostPart := getResourceHost(req)
+	if hostPart == "" {
+		hostPart = "unknown"
+		log.WithField("URL", req.URL).Warn("client metrics: cannot determine resource host part")
+	}
+
+	routePart := ""
+	if route := mux.CurrentRoute(req); route != nil {
+		routePart = route.GetName()
+	}
+	if routePart == "" {
+		log.WithField("URL", req.URL).Warn("client metrics: cannot determine resource route part")
+		routePart = "unknown"
+	}
+	if routePart == "root" {
+		routePart = ""
+	} else {
+		routePart = "/" + routePart
+	}
+	return hostPart + routePart
+}
+
+func getResourceHost(req *http.Request) string {
+	coords := getWorkspaceCoords(req)
+
+	var parts []string
+
+	if coords.Foreign {
+		parts = append(parts, "foreign_content")
+	}
+
+	if coords.ID != "" {
+		workspacePart := "workspace"
+		if coords.Debug {
+			workspacePart = "debug_" + workspacePart
+		}
+		if coords.Port != "" {
+			workspacePart += "_port"
+		}
+		parts = append(parts, workspacePart)
+	}
+	return strings.Join(parts, "/")
+}

--- a/components/ws-proxy/pkg/proxy/metrics.go
+++ b/components/ws-proxy/pkg/proxy/metrics.go
@@ -76,7 +76,8 @@ func init() {
 type contextKey int
 
 var (
-	resourceKey = contextKey(0)
+	resourceKey    = contextKey(0)
+	httpVersionKey = contextKey(1)
 )
 
 func withResource(r *http.Request, resource string) *http.Request {
@@ -97,12 +98,17 @@ func withResourceLabel() promhttp.Option {
 	})
 }
 
+func withHttpVersion(r *http.Request) *http.Request {
+	ctx := context.WithValue(r.Context(), httpVersionKey, []string{r.Proto})
+	return r.WithContext(ctx)
+}
+
 func withHttpVersionLabel() promhttp.Option {
 	return promhttp.WithLabelFromCtx("http_version", func(ctx context.Context) string {
-		if v := ctx.Value(resourceKey); v != nil {
-			if resources, ok := v.([]string); ok {
-				if len(resources) > 0 {
-					return resources[0]
+		if v := ctx.Value(httpVersionKey); v != nil {
+			if versions, ok := v.([]string); ok {
+				if len(versions) > 0 {
+					return versions[0]
 				}
 			}
 		}

--- a/components/ws-proxy/pkg/proxy/metrics.go
+++ b/components/ws-proxy/pkg/proxy/metrics.go
@@ -80,7 +80,7 @@ var (
 	httpVersionKey = contextKey(1)
 )
 
-func withResource(r *http.Request, resource string) *http.Request {
+func withResourceMetricsLabel(r *http.Request, resource string) *http.Request {
 	ctx := context.WithValue(r.Context(), resourceKey, []string{resource})
 	return r.WithContext(ctx)
 }
@@ -98,7 +98,7 @@ func withResourceLabel() promhttp.Option {
 	})
 }
 
-func withHttpVersion(r *http.Request) *http.Request {
+func withHttpVersionMetricsLabel(r *http.Request) *http.Request {
 	ctx := context.WithValue(r.Context(), httpVersionKey, []string{r.Proto})
 	return r.WithContext(ctx)
 }

--- a/components/ws-proxy/pkg/proxy/metrics.go
+++ b/components/ws-proxy/pkg/proxy/metrics.go
@@ -138,6 +138,13 @@ func instrumentServerMetrics(next http.Handler) http.Handler {
 				}
 			}
 		}
+		if v := req.Context().Value(httpVersionKey); v != nil {
+			if versions, ok := v.([]string); ok {
+				if len(versions) > 0 {
+					versions[0] = req.Proto
+				}
+			}
+		}
 	})
 	instrumented := promhttp.InstrumentHandlerCounter(serverMetrics.requestsTotal,
 		promhttp.InstrumentHandlerDuration(serverMetrics.requestsDuration,
@@ -150,6 +157,7 @@ func instrumentServerMetrics(next http.Handler) http.Handler {
 	)
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := context.WithValue(req.Context(), resourceKey, []string{"unknown"})
+		ctx = context.WithValue(ctx, httpVersionKey, []string{"unknown"})
 		instrumented.ServeHTTP(w, req.WithContext(ctx))
 	})
 }

--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -128,8 +128,8 @@ func proxyPass(config *RouteHandlerConfig, infoProvider common.WorkspaceInfoProv
 			}
 			return
 		}
-		req = withResource(req, targetResource)
-		req = withHttpVersion(req)
+		req = withResourceMetricsLabel(req, targetResource)
+		req = withHttpVersionMetricsLabel(req)
 
 		originalURL := *req.URL
 

--- a/components/ws-proxy/pkg/proxy/pass.go
+++ b/components/ws-proxy/pkg/proxy/pass.go
@@ -129,6 +129,7 @@ func proxyPass(config *RouteHandlerConfig, infoProvider common.WorkspaceInfoProv
 			return
 		}
 		req = withResource(req, targetResource)
+		req = withHttpVersion(req)
 
 		originalURL := *req.URL
 

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -428,6 +428,7 @@ func (ir *ideRoutes) HandleRoot(route *mux.Route) {
 					return image
 				}
 				preloadSupervisorReq = withResource(preloadSupervisorReq, supervisorResource)
+				preloadSupervisorReq = withHttpVersion(preloadSupervisorReq)
 				resp, err := t.DoRoundTrip(preloadSupervisorReq)
 				if err != nil {
 					log.WithField("supervisorURL", supervisorURL).WithError(err).Error("could not preload supervisor")

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -83,6 +83,7 @@ type RouteHandler = func(r *mux.Router, config *RouteHandlerConfig)
 // installWorkspaceRoutes configures routing of workspace and IDE requests.
 func installWorkspaceRoutes(r *mux.Router, config *RouteHandlerConfig, ip common.WorkspaceInfoProvider, sshGatewayServer *sshproxy.Server) error {
 	r.Use(logHandler)
+	r.Use(instrumentServerMetrics)
 
 	// Note: the order of routes defines their priority.
 	//       Routes registered first have priority over those that come afterwards.
@@ -189,7 +190,7 @@ func (ir *ideRoutes) HandleSSHHostKeyRoute(route *mux.Route, hostKeyList []ssh.S
 	r.NewRoute().HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		rw.Header().Add("Content-Type", "application/json")
 		rw.Write(byt)
-	})
+	}).Name("ssh_host_key")
 }
 
 func (ir *ideRoutes) HandleCreateKeyRoute(route *mux.Route, hostKeyList []ssh.Signer) {
@@ -310,7 +311,7 @@ func (ir *ideRoutes) HandleDirectSupervisorRoute(route *mux.Route, authenticated
 		r.Use(ir.Config.WorkspaceAuthHandler)
 	}
 
-	r.NewRoute().HandlerFunc(proxyPass(ir.Config, ir.InfoProvider, workspacePodSupervisorResolver, proxyPassOpts...))
+	r.NewRoute().HandlerFunc(proxyPass(ir.Config, ir.InfoProvider, workspacePodSupervisorResolver, proxyPassOpts...)).Name("supervisor")
 }
 
 func (ir *ideRoutes) HandleSupervisorFrontendRoute(route *mux.Route) {
@@ -331,7 +332,7 @@ func (ir *ideRoutes) HandleSupervisorFrontendRoute(route *mux.Route) {
 		})
 	})
 	// always hit the blobserver to ensure that blob is downloaded
-	r.NewRoute().HandlerFunc(proxyPass(ir.Config, ir.InfoProvider, func(cfg *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (*url.URL, error) {
+	r.NewRoute().HandlerFunc(proxyPass(ir.Config, ir.InfoProvider, func(cfg *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (*url.URL, string, error) {
 		info := getWorkspaceInfoFromContext(req.Context())
 		return resolveSupervisorURL(cfg, info, req)
 	}, func(h *proxyPassConfig) {
@@ -359,13 +360,13 @@ func (ir *ideRoutes) HandleSupervisorFrontendRoute(route *mux.Route) {
 				return image
 			},
 		}
-	}, withUseTargetHost()))
+	}, withUseTargetHost())).Name("supervisor_frontend")
 }
 
-func resolveSupervisorURL(cfg *Config, info *common.WorkspaceInfo, req *http.Request) (*url.URL, error) {
+func resolveSupervisorURL(cfg *Config, info *common.WorkspaceInfo, req *http.Request) (*url.URL, string, error) {
 	if info == nil && len(cfg.WorkspacePodConfig.SupervisorImage) == 0 {
 		log.WithFields(log.OWI("", getWorkspaceCoords(req).ID, "")).Warn("no workspace info available - cannot resolve supervisor route")
-		return nil, xerrors.Errorf("no workspace information available - cannot resolve supervisor route")
+		return nil, "", xerrors.Errorf("no workspace information available - cannot resolve supervisor route")
 	}
 
 	// use the config value for backwards compatibility when info.SupervisorImage is not set
@@ -378,7 +379,7 @@ func resolveSupervisorURL(cfg *Config, info *common.WorkspaceInfo, req *http.Req
 	dst.Scheme = cfg.BlobServer.Scheme
 	dst.Host = cfg.BlobServer.Host
 	dst.Path = cfg.BlobServer.PathPrefix + "/" + supervisorImage
-	return &dst, nil
+	return &dst, "blobserve/supervisor", nil
 }
 
 type BlobserveInlineVars struct {
@@ -411,11 +412,11 @@ func (ir *ideRoutes) HandleRoot(route *mux.Route) {
 				if imagePath != "/index.html" && imagePath != "/" {
 					return image
 				}
-				// blobserve can inline static links in index.html for IDE and supervisor to avoid redirects for each resource
+				// blobserve can inline static links in index.html for IDE and supervisor to avoid redirects for each supervisor resource
 				// but it has to know exposed URLs in the context of current workspace cluster
 				// so first we ask blobserve to preload the supervisor image
 				// and if it is successful we pass exposed URLs to IDE and supervisor to blobserve for inlining
-				supervisorURL, err := resolveSupervisorURL(t.Config, info, req)
+				supervisorURL, supervisorResource, err := resolveSupervisorURL(t.Config, info, req)
 				if err != nil {
 					log.WithError(err).Error("could not preload supervisor")
 					return image
@@ -426,6 +427,7 @@ func (ir *ideRoutes) HandleRoot(route *mux.Route) {
 					log.WithField("supervisorURL", supervisorURL).WithError(err).Error("could not preload supervisor")
 					return image
 				}
+				preloadSupervisorReq = withResource(preloadSupervisorReq, supervisorResource)
 				resp, err := t.DoRoundTrip(preloadSupervisorReq)
 				if err != nil {
 					log.WithField("supervisorURL", supervisorURL).WithError(err).Error("could not preload supervisor")
@@ -457,10 +459,12 @@ func (ir *ideRoutes) HandleRoot(route *mux.Route) {
 				return image
 			},
 		}
-	}, withHTTPErrorHandler(directIDEPass), withUseTargetHost()))
+	}, withHTTPErrorHandler(directIDEPass), withUseTargetHost())).Name("root")
 }
 
 func installForeignRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvider common.WorkspaceInfoProvider) error {
+	r.Use(instrumentServerMetrics)
+
 	err := installWorkspacePortRoutes(r.MatcherFunc(func(r *http.Request, rm *mux.RouteMatch) bool {
 		workspacePathPrefix := rm.Vars[common.WorkspacePathPrefixIdentifier]
 		if workspacePathPrefix == "" || rm.Vars[common.WorkspacePortIdentifier] == "" {
@@ -483,24 +487,24 @@ func installForeignRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvide
 	if err != nil {
 		return err
 	}
-	installBlobserveRoutes(r.NewRoute().Subrouter(), config, infoProvider)
+	installForeignBlobserveRoutes(r.NewRoute().Subrouter(), config, infoProvider)
 	return nil
 }
 
 const imagePathSeparator = "/__files__"
 
-// installBlobserveRoutes  implements long-lived caching with versioned URLs, see https://web.dev/http-cache/#versioned-urls
-func installBlobserveRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvider common.WorkspaceInfoProvider) {
+// installForeignBlobserveRoutes  implements long-lived caching with versioned URLs, see https://web.dev/http-cache/#versioned-urls
+func installForeignBlobserveRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvider common.WorkspaceInfoProvider) {
 	r.Use(logHandler)
 	r.Use(logRouteHandlerHandler("BlobserveRootHandler"))
 
 	// filter all session cookies
 	r.Use(sensitiveCookieHandler(config.Config.GitpodInstallation.HostName))
 
-	targetResolver := func(cfg *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (tgt *url.URL, err error) {
+	targetResolver := func(cfg *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (tgt *url.URL, str string, err error) {
 		segments := strings.SplitN(req.URL.Path, imagePathSeparator, 2)
 		if len(segments) < 2 {
-			return nil, xerrors.Errorf("invalid URL")
+			return nil, "", xerrors.Errorf("invalid URL")
 		}
 		image, path := segments[0], segments[1]
 
@@ -510,9 +514,9 @@ func installBlobserveRoutes(r *mux.Router, config *RouteHandlerConfig, infoProvi
 		dst.Scheme = cfg.BlobServer.Scheme
 		dst.Host = cfg.BlobServer.Host
 		dst.Path = cfg.BlobServer.PathPrefix + "/" + strings.TrimPrefix(image, "/")
-		return &dst, nil
+		return &dst, "blobserve/foreign_content", nil
 	}
-	r.NewRoute().Handler(proxyPass(config, infoProvider, targetResolver, withLongTermCaching(), withUseTargetHost()))
+	r.NewRoute().Handler(proxyPass(config, infoProvider, targetResolver, withLongTermCaching(), withUseTargetHost())).Name("blobserve")
 }
 
 // installDebugWorkspaceRoutes configures for debug workspace.
@@ -583,27 +587,32 @@ func installWorkspacePortRoutes(r *mux.Router, config *RouteHandlerConfig, infoP
 }
 
 // workspacePodResolver resolves to the workspace pod's url from the given request.
-func workspacePodResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (url *url.URL, err error) {
+func workspacePodResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (url *url.URL, resource string, err error) {
 	coords := getWorkspaceCoords(req)
 	var port string
 	if coords.Debug {
+		resource = "debug_workspace"
 		port = fmt.Sprint(config.WorkspacePodConfig.IDEDebugPort)
 	} else {
+		resource = "workspace"
 		port = fmt.Sprint(config.WorkspacePodConfig.TheiaPort)
 	}
 	workspaceInfo := infoProvider.WorkspaceInfo(coords.ID)
-	return buildWorkspacePodURL(api.PortProtocol_PORT_PROTOCOL_HTTP, workspaceInfo.IPAddress, port)
+	url, err = buildWorkspacePodURL(api.PortProtocol_PORT_PROTOCOL_HTTP, workspaceInfo.IPAddress, port)
+	return
 }
 
 // workspacePodPortResolver resolves to the workspace pods ports.
-func workspacePodPortResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (url *url.URL, err error) {
+func workspacePodPortResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (url *url.URL, resource string, err error) {
 	coords := getWorkspaceCoords(req)
 	workspaceInfo := infoProvider.WorkspaceInfo(coords.ID)
 	var port string
 	protocol := api.PortProtocol_PORT_PROTOCOL_HTTP
 	if coords.Debug {
+		resource = "debug_workspace_port"
 		port = fmt.Sprint(config.WorkspacePodConfig.DebugWorkspaceProxyPort)
 	} else {
+		resource = "workspace_port"
 		port = coords.Port
 		prt, err := strconv.ParseUint(port, 10, 16)
 		if err != nil {
@@ -617,27 +626,31 @@ func workspacePodPortResolver(config *Config, infoProvider common.WorkspaceInfoP
 			}
 		}
 	}
-	return buildWorkspacePodURL(protocol, workspaceInfo.IPAddress, port)
+	url, err = buildWorkspacePodURL(protocol, workspaceInfo.IPAddress, port)
+	return
 }
 
 // workspacePodSupervisorResolver resolves to the workspace pods Supervisor url from the given request.
-func workspacePodSupervisorResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (url *url.URL, err error) {
+func workspacePodSupervisorResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (url *url.URL, resource string, err error) {
 	coords := getWorkspaceCoords(req)
 	var port string
 	if coords.Debug {
+		resource = "debug_workspace/supervisor"
 		port = fmt.Sprint(config.WorkspacePodConfig.SupervisorDebugPort)
 	} else {
+		resource = "workspace/supervisor"
 		port = fmt.Sprint(config.WorkspacePodConfig.SupervisorPort)
 	}
 	workspaceInfo := infoProvider.WorkspaceInfo(coords.ID)
-	return buildWorkspacePodURL(api.PortProtocol_PORT_PROTOCOL_HTTP, workspaceInfo.IPAddress, port)
+	url, err = buildWorkspacePodURL(api.PortProtocol_PORT_PROTOCOL_HTTP, workspaceInfo.IPAddress, port)
+	return
 }
 
-func dynamicIDEResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (res *url.URL, err error) {
+func dynamicIDEResolver(config *Config, infoProvider common.WorkspaceInfoProvider, req *http.Request) (res *url.URL, resource string, err error) {
 	info := getWorkspaceInfoFromContext(req.Context())
 	if info == nil {
 		log.WithFields(log.OWI("", getWorkspaceCoords(req).ID, "")).Warn("no workspace info available - cannot resolve Theia route")
-		return nil, xerrors.Errorf("no workspace information available - cannot resolve Theia route")
+		return nil, "", xerrors.Errorf("no workspace information available - cannot resolve Theia route")
 	}
 
 	var dst url.URL
@@ -645,7 +658,7 @@ func dynamicIDEResolver(config *Config, infoProvider common.WorkspaceInfoProvide
 	dst.Host = config.BlobServer.Host
 	dst.Path = config.BlobServer.PathPrefix + "/" + info.IDEImage
 
-	return &dst, nil
+	return &dst, "blobserve/ide", nil
 }
 
 func buildWorkspacePodURL(protocol api.PortProtocol, ipAddress string, port string) (*url.URL, error) {

--- a/components/ws-proxy/pkg/proxy/routes.go
+++ b/components/ws-proxy/pkg/proxy/routes.go
@@ -427,8 +427,8 @@ func (ir *ideRoutes) HandleRoot(route *mux.Route) {
 					log.WithField("supervisorURL", supervisorURL).WithError(err).Error("could not preload supervisor")
 					return image
 				}
-				preloadSupervisorReq = withResource(preloadSupervisorReq, supervisorResource)
-				preloadSupervisorReq = withHttpVersion(preloadSupervisorReq)
+				preloadSupervisorReq = withResourceMetricsLabel(preloadSupervisorReq, supervisorResource)
+				preloadSupervisorReq = withHttpVersionMetricsLabel(preloadSupervisorReq)
 				resp, err := t.DoRoundTrip(preloadSupervisorReq)
 				if err != nil {
 					log.WithField("supervisorURL", supervisorURL).WithError(err).Error("could not preload supervisor")

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -26,8 +26,6 @@ const (
 	workspacePortRegex = "(?P<" + common.WorkspacePortIdentifier + ">[0-9]+)-"
 
 	debugWorkspaceRegex = "(?P<" + common.DebugWorkspaceIdentifier + ">debug-)?"
-
-	foreignContentRegex = "(?P<" + common.ForeignContentIdentifier + ">foreign-)?"
 )
 
 // This pattern matches v4 UUIDs as well as the new generated workspace ids (e.g. pink-panda-ns35kd21).

--- a/components/ws-proxy/pkg/proxy/workspacerouter.go
+++ b/components/ws-proxy/pkg/proxy/workspacerouter.go
@@ -26,6 +26,8 @@ const (
 	workspacePortRegex = "(?P<" + common.WorkspacePortIdentifier + ">[0-9]+)-"
 
 	debugWorkspaceRegex = "(?P<" + common.DebugWorkspaceIdentifier + ">debug-)?"
+
+	foreignContentRegex = "(?P<" + common.ForeignContentIdentifier + ">foreign-)?"
 )
 
 // This pattern matches v4 UUIDs as well as the new generated workspace ids (e.g. pink-panda-ns35kd21).
@@ -172,6 +174,12 @@ func matchForeignHostHeader(wsHostSuffix string, headerProvider hostHeaderProvid
 
 		result = true
 
+		if m.Vars == nil {
+			m.Vars = make(map[string]string)
+		}
+
+		m.Vars[common.ForeignContentIdentifier] = "true"
+
 		var pathPrefix, workspaceID, workspacePort, debugWorkspace string
 		matches = pathPortRegex.FindStringSubmatch(req.URL.Path)
 		if len(matches) < 4 {
@@ -220,9 +228,10 @@ func matchForeignHostHeader(wsHostSuffix string, headerProvider hostHeaderProvid
 func getWorkspaceCoords(req *http.Request) common.WorkspaceCoords {
 	vars := mux.Vars(req)
 	return common.WorkspaceCoords{
-		ID:    vars[common.WorkspaceIDIdentifier],
-		Port:  vars[common.WorkspacePortIdentifier],
-		Debug: vars[common.DebugWorkspaceIdentifier] == "true",
+		ID:      vars[common.WorkspaceIDIdentifier],
+		Port:    vars[common.WorkspacePortIdentifier],
+		Debug:   vars[common.DebugWorkspaceIdentifier] == "true",
+		Foreign: vars[common.ForeignContentIdentifier] == "true",
 	}
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Introduce RED metrics for ws-proxy for client and server requests. This also lets us inspect http_version (as a label) on requests.

@akosyakov originally started this work in https://github.com/gitpod-io/gitpod/pull/17294 (it never landed on main). @kylos101 fixed a couple minor things (see later commits in this PR) and tested.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-673

## How to test
<!-- Provide steps to test this PR -->

### Functional test with HTTP2 ✅ 
1. Setup a port forward for grafana in the preview environment for this PR, `kubectl port-forward deployment/grafana -n  monitoring-satellite 3000` (add observability if it is missing with `leeway run dev/preview:deploy-monitoring-satellite`).
2. [Start a workspace in the preview environment from our demo-docker repo](https://kylos101-ent-673.preview.gitpod-dev.com/new#https://github.com/gitpod-demos/voting-app) (it starts a voting and runs them on ports)
3. Open the voting app), it'll manifests as HTTP/1.1 traffic (you can see this in the logs from the workspace running in preview)
4. Inspect Grafana data (queries below)

> sum by(resource, http_version) (rate(gitpod_ws_proxy_http_server_requests_total[5m]))
> sum by(resource, http_version) (rate(gitpod_ws_proxy_http_client_requests_total[5m]))

Results [here](https://github.com/gitpod-io/gitpod/pull/20196#issuecomment-2347179183).

### Functional test with HTTP2 disabled in Chrome 🚫 
1. Close all Chrome instances
2. Start Chrome using the ` --disable-http2` flag
3. Repeat the test steps (above), the client metrics should be different, but they are not ‼️ We force attempt HTTP2 [here](https://github.com/gitpod-io/gitpod/blob/1465575e6d800bbb0f72d17cd8a87c4a7894c456/components/ws-proxy/pkg/proxy/pass.go#L233). 
   * Perhaps this is different when customer networks use ZScaler, and downgrade traffic to HTTP/1.1? Either way, disabling HTTP2 in chrome doesn't change the behavior.

### Loadgen in an ephemeral cluster 🚫 
The ops repo does not allow for ephemeral clusters to be created from installer images that are not from main-gha. So, we first need to land this PR on main, and then test in an ephemeral cluster.

### dogfood this change in catfood ⌛ 
Test on Monday, Sept 16, after it lands on main.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-ent-673</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-ent-673.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-ent-673.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-ENT-673-gha.28717</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-ent-673%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
