### PR TITLE
[idp] Guarantee stable email address for IDP token for organization-bound users

### DIFF
--- a/components/gitpod-protocol/go/gitpod-service.go
+++ b/components/gitpod-protocol/go/gitpod-service.go
@@ -2052,10 +2052,11 @@ type Identity struct {
 	AuthProviderID string `json:"authProviderId,omitempty"`
 
 	// This is a flag that triggers the HARD DELETION of this entity
-	Deleted      bool     `json:"deleted,omitempty"`
-	PrimaryEmail string   `json:"primaryEmail,omitempty"`
-	Readonly     bool     `json:"readonly,omitempty"`
-	Tokens       []*Token `json:"tokens,omitempty"`
+	Deleted        bool     `json:"deleted,omitempty"`
+	PrimaryEmail   string   `json:"primaryEmail,omitempty"`
+	Readonly       bool     `json:"readonly,omitempty"`
+	Tokens         []*Token `json:"tokens,omitempty"`
+	LastSigninTime string   `json:"lastSigninTime,omitempty"`
 }
 
 // User is the User message type

--- a/components/gitpod-protocol/go/user.go
+++ b/components/gitpod-protocol/go/user.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package protocol
+
+import (
+	"cmp"
+	"slices"
+)
+
+// GetSSOEmail returns the email of the user's last-used SSO identity, if any. It mirros the funcationality we have implemeted in TS here: https://github.com/gitpod-io/gitpod/blob/e4ccbf0b4d224714ffd16719a3b5c50630d6edbc/components/public-api/typescript-common/src/user-utils.ts#L24-L35
+func (u *User) GetSSOEmail() string {
+	var ssoIdentities []*Identity
+	for _, id := range u.Identities {
+		// LastSigninTime is empty for non-SSO identities, and used as a filter here.
+		if id == nil || id.Deleted || id.LastSigninTime == "" {
+			continue
+		}
+		ssoIdentities = append(ssoIdentities, id)
+	}
+	if len(ssoIdentities) == 0 {
+		return ""
+	}
+
+	// We are looking for the latest-used SSO identity.
+	slices.SortFunc(ssoIdentities, func(i, j *Identity) int {
+		return cmp.Compare(j.LastSigninTime, i.LastSigninTime)
+	})
+	return ssoIdentities[0].PrimaryEmail
+}
+
+// GetRandomEmail returns an email address of any of the user's identities.
+func (u *User) GetRandomEmail() string {
+	for _, id := range u.Identities {
+		if id == nil || id.Deleted || id.PrimaryEmail == "" {
+			continue
+		}
+		return id.PrimaryEmail
+	}
+	return ""
+}

--- a/components/gitpod-protocol/go/user_test.go
+++ b/components/gitpod-protocol/go/user_test.go
@@ -1,0 +1,75 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package protocol
+
+import "testing"
+
+func TestGetSSOEmail(t *testing.T) {
+	u := &User{
+		Identities: []*Identity{
+			{
+				PrimaryEmail:   "john@example.com",
+				LastSigninTime: "2022-01-01T00:00:00Z",
+			},
+			{
+				PrimaryEmail:   "bob@example.com",
+				LastSigninTime: "2022-03-01T00:00:00Z",
+			},
+			{
+				PrimaryEmail:   "jane@example.com",
+				LastSigninTime: "2022-02-01T00:00:00Z",
+			},
+			{
+				PrimaryEmail:   "jane22@example.com",
+				LastSigninTime: "",
+			},
+		},
+	}
+
+	expectedEmail := "bob@example.com"
+	actualEmail := u.GetSSOEmail()
+
+	if actualEmail != expectedEmail {
+		t.Errorf("Expected SSO email to be %s, but got %s", expectedEmail, actualEmail)
+	}
+}
+func TestGetRandomEmail(t *testing.T) {
+	u := &User{
+		Identities: []*Identity{
+			{
+				PrimaryEmail:   "",
+				LastSigninTime: "",
+			},
+			{
+				PrimaryEmail:   "oldjohn@example.com",
+				LastSigninTime: "",
+				Deleted:        true,
+			},
+			{
+				PrimaryEmail:   "john@example.com",
+				LastSigninTime: "",
+			},
+			{
+				PrimaryEmail:   "bob@example.com",
+				LastSigninTime: "2022-03-01T00:00:00Z",
+			},
+			{
+				PrimaryEmail:   "jane@example.com",
+				LastSigninTime: "2022-02-01T00:00:00Z",
+			},
+			{
+				PrimaryEmail:   "jane22@example.com",
+				LastSigninTime: "",
+			},
+		},
+	}
+
+	expectedEmail := "john@example.com"
+	actualEmail := u.GetRandomEmail()
+
+	if actualEmail != expectedEmail {
+		t.Errorf("Expected random email to be %s, but got %s", expectedEmail, actualEmail)
+	}
+}

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -564,7 +564,7 @@ export interface Identity {
     primaryEmail?: string;
     /** This is a flag that triggers the HARD DELETION of this entity */
     deleted?: boolean;
-    // The last time this entry was touched during a signin.
+    // The last time this entry was touched during a signin. It's only set for SSO identities.
     lastSigninTime?: string;
 
     // @deprecated as no longer in use since '19

--- a/components/public-api-server/pkg/apiv1/identityprovider_test.go
+++ b/components/public-api-server/pkg/apiv1/identityprovider_test.go
@@ -76,7 +76,7 @@ func TestGetIDToken(t *testing.T) {
 						Identities: []*protocol.Identity{
 							nil,
 							{Deleted: true, PrimaryEmail: "nonsense@gitpod.io"},
-							{Deleted: false, PrimaryEmail: "correct@gitpod.io"},
+							{Deleted: false, PrimaryEmail: "correct@gitpod.io", LastSigninTime: "2021-01-01T00:00:00Z"},
 						},
 						OrganizationId: "test",
 					},
@@ -125,7 +125,7 @@ func TestGetIDToken(t *testing.T) {
 						Identities: []*protocol.Identity{
 							nil,
 							{Deleted: true, PrimaryEmail: "nonsense@gitpod.io"},
-							{Deleted: false, PrimaryEmail: "correct@gitpod.io"},
+							{Deleted: false, PrimaryEmail: "correct@gitpod.io", LastSigninTime: "2021-01-01T00:00:00Z"},
 						},
 					},
 					nil,
@@ -243,7 +243,7 @@ func TestGetIDToken(t *testing.T) {
 						Identities: []*protocol.Identity{
 							nil,
 							{Deleted: true, PrimaryEmail: "nonsense@gitpod.io"},
-							{Deleted: false, PrimaryEmail: "correct@gitpod.io"},
+							{Deleted: false, PrimaryEmail: "correct@gitpod.io", LastSigninTime: "2021-01-01T00:00:00Z"},
 						},
 						OrganizationId: "test",
 					},


### PR DESCRIPTION
## Description
This mirrors the mechanism we use on the TS side into Go (filtering and sorting by `lastSigninTime`), and uses it in the identiyprovider.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates to: ENT-764
Fixes: EXP-202

## How to test
 - join my SSO org: https://gpl-764-sso-email.preview.gitpod-dev.com/login/supercorp
 - start a workspace, and run `eval echo $(gp idp token --audience=a --scope=s --decode | jq .Payload.email)`
 - it will always return your Google email, taken from the SSO provider :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
