### PR TITLE
[JetBrains] Update Platform Version from JetBrains Gateway Plugin (Stable)

### DIFF
--- a/components/ide/gha-update-image/index-jb-platform-update.ts
+++ b/components/ide/gha-update-image/index-jb-platform-update.ts
@@ -43,6 +43,7 @@ platformVersion={{platformVersion}}
         xmlName: "Gateway",
         xmlChannels: ["GW-EAP-licensing-EAP", "GW-RELEASE-licensing-RELEASE", "GW-EAP-licensing-RELEASE"],
         useXml: true,
+        useHumanreadableVersion: true,
         gradlePropertiesPath: path.resolve(
             pathToProjectRoot,
             "components/ide/jetbrains/gateway-plugin/gradle-latest.properties",
@@ -68,6 +69,7 @@ platformVersion={{platformVersion}}
         xmlName: "Gateway",
         xmlChannels: ["GW-RELEASE-licensing-RELEASE"],
         useXml: true,
+        useHumanreadableVersion: true,
         gradlePropertiesPath: path.resolve(
             pathToProjectRoot,
             "components/ide/jetbrains/gateway-plugin/gradle-stable.properties",

--- a/components/ide/gha-update-image/lib/jb-update-platform-version.ts
+++ b/components/ide/gha-update-image/lib/jb-update-platform-version.ts
@@ -12,6 +12,7 @@ interface TargetInfo {
     xmlName: string;
     xmlChannels: string[];
     useXml: boolean;
+    useHumanreadableVersion: boolean;
     gradlePropertiesPath: string;
     gradlePropertiesTemplate: string;
 }
@@ -41,7 +42,8 @@ const productReleaseZod = z.record(
 );
 
 async function fetchLatestVersionFromProductReleases(info: TargetInfo) {
-    const { productCode, productType, useXml } = info;
+    const { productCode, productType, useXml, useHumanreadableVersion } = info;
+    // https://data.services.jetbrains.com/products/releases?code=GW&type=eap,rc,release&platform=linux
     const url = `https://data.services.jetbrains.com/products/releases?code=${productCode}&type=${productType}&platform=linux`;
     const response = await axios.get(url);
     const data = productReleaseZod.parse(response.data);
@@ -55,11 +57,12 @@ async function fetchLatestVersionFromProductReleases(info: TargetInfo) {
         throw new Error(`Invalid build version ${build}`);
     }
     const latestPlatformVersion = !useXml ? `${buildSem.major}.${buildSem.minor}-EAP-CANDIDATE-SNAPSHOT` : build;
+    const latestHumanreadablePlatfromVersion = latestBuild.version;
     return {
         pluginSinceBuild: `${buildSem.major}.${buildSem.minor}`,
         pluginUntilBuild: `${buildSem.major}.*`,
         pluginVerifierIdeVersions: latestBuild.majorVersion,
-        platformVersion: latestPlatformVersion,
+        platformVersion: useHumanreadableVersion ? latestHumanreadablePlatfromVersion : latestPlatformVersion,
     };
 }
 

--- a/components/ide/jetbrains/gateway-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/gateway-plugin/build.gradle.kts
@@ -16,8 +16,8 @@ plugins {
     // Kotlin support - check the latest version at https://plugins.gradle.org/plugin/org.jetbrains.kotlin.jvm
     id("org.jetbrains.kotlin.jvm") version "2.0.0"
     // gradle-intellij-plugin - read more: https://github.com/JetBrains/gradle-intellij-plugin
-    id("org.jetbrains.intellij.platform") version "2.0.0"
-//    id("org.jetbrains.intellij.platform.migration") version "2.0.0-beta8"
+    id("org.jetbrains.intellij.platform") version "2.0.1"
+//    id("org.jetbrains.intellij.platform.migration") version "2.0.1"
     // gradle-changelog-plugin - read more: https://github.com/JetBrains/gradle-changelog-plugin
     id("org.jetbrains.changelog") version "1.1.2"
     // detekt linter - read more: https://detekt.github.io/detekt/gradle.html
@@ -72,9 +72,9 @@ dependencies {
 
 dependencies {
     intellijPlatform {
+        // https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#target-platforms
         // https://www.jetbrains.com/updates/updates.xml
         create(IntelliJPlatformType.Gateway, properties("platformVersion"))
-//        create(IntelliJPlatformType.Gateway)
         bundledPlugins(properties("platformBundledPlugins").split(',').map{ it.trim() })
     }
 }
@@ -106,7 +106,7 @@ intellijPlatform {
         }
     }
 
-    verifyPlugin {
+    pluginVerification {
         ides {
             properties("pluginVerifierIdeVersions").split(',').map(String::trim).forEach { version ->
                 ide(IntelliJPlatformType.Gateway, version)

--- a/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
@@ -7,5 +7,5 @@ pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2024.2
-# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/updates/updates.xml
-platformVersion=242.21829.203
+# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/updates/updates.xml or exec `./gradlew printProductsReleases`
+platformVersion=2024.2.1

--- a/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
@@ -2,10 +2,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=242.20224
+pluginSinceBuild=242.21829
 pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2024.2
 # Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/updates/updates.xml
-platformVersion=242.20224.368
+platformVersion=242.21829.203

--- a/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/gateway-plugin/gradle-stable.properties
@@ -2,7 +2,7 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=242.21829
+pluginSinceBuild=242.20224
 pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
And fix GHA

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-773

## How to test
<!-- Provide steps to test this PR -->
Integration tests should passed 

the only failed test is JetBrains Warmup, which is a known issue ENT-778 https://github.com/gitpod-io/gitpod/actions/runs/10816967630/job/30011223924?pr=20201 

Smoke test with stable JetBrains Gateway plugin follow https://github.com/gitpod-io/gitpod/pull/20136

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-gw</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-gw.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-gw.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-gw-gha.28753</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-gw%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
