### PR TITLE
[gp] Introduce "gp user-info" showing userId and email

### DIFF
--- a/components/gitpod-cli/cmd/user-info.go
+++ b/components/gitpod-cli/cmd/user-info.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
@@ -24,6 +24,9 @@ import (
 var userInfoCmdOpts struct {
 	// Json configures whether the command output is printed as JSON, to make it machine-readable.
 	Json bool
+
+	// EmailOnly returns only the email address of the user
+	EmailOnly bool
 }
 
 // infoCmd represents the info command.
@@ -53,6 +56,11 @@ var userInfoCmd = &cobra.Command{
 		data := &userInfoData{
 			UserId: user.ID,
 			Email:  email,
+		}
+
+		if userInfoCmdOpts.EmailOnly {
+			fmt.Println(data.Email)
+			return nil
 		}
 
 		if userInfoCmdOpts.Json {
@@ -117,5 +125,6 @@ func connectToAPI(ctx context.Context) (*serverapi.APIoverJSONRPC, error) {
 
 func init() {
 	userInfoCmd.Flags().BoolVarP(&userInfoCmdOpts.Json, "json", "j", false, "Output in JSON format")
+	userInfoCmd.Flags().BoolVar(&userInfoCmdOpts.EmailOnly, "email", false, "Only emit the email address of the user")
 	rootCmd.AddCommand(userInfoCmd)
 }

--- a/components/gitpod-cli/cmd/user-info.go
+++ b/components/gitpod-cli/cmd/user-info.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2022 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/olekukonko/tablewriter"
+	log "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"golang.org/x/xerrors"
+
+	"github.com/gitpod-io/gitpod/gitpod-cli/pkg/supervisor"
+	serverapi "github.com/gitpod-io/gitpod/gitpod-protocol"
+	supervisorapi "github.com/gitpod-io/gitpod/supervisor/api"
+)
+
+var userInfoCmdOpts struct {
+	// Json configures whether the command output is printed as JSON, to make it machine-readable.
+	Json bool
+}
+
+// infoCmd represents the info command.
+var userInfoCmd = &cobra.Command{
+	Use:   "user-info",
+	Short: "Display user info about the workspace owner, such as its ID, email, etc.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		defer cancel()
+
+		client, err := connectToAPI(ctx)
+		if err != nil {
+			return err
+		}
+
+		user, err := client.GetLoggedInUser(ctx)
+		if err != nil {
+			return err
+		}
+
+		// determine which email to show: prefer SSO, with random as fallback
+		email := user.GetSSOEmail()
+		if email == "" {
+			email = user.GetRandomEmail()
+		}
+
+		data := &userInfoData{
+			UserId: user.ID,
+			Email:  email,
+		}
+
+		if userInfoCmdOpts.Json {
+			content, _ := json.Marshal(data)
+			fmt.Println(string(content))
+			return nil
+		}
+		outputUserInfo(data)
+		return nil
+	},
+}
+
+type userInfoData struct {
+	UserId string `json:"user_id"`
+	Email  string `json:"email"`
+}
+
+func outputUserInfo(info *userInfoData) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetColWidth(50)
+	table.SetBorder(false)
+	table.SetColumnSeparator(":")
+	table.Append([]string{"User ID", info.UserId})
+	table.Append([]string{"Email", info.Email})
+	table.Render()
+}
+
+func connectToAPI(ctx context.Context) (*serverapi.APIoverJSONRPC, error) {
+	supervisorClient, err := supervisor.New(ctx)
+	if err != nil {
+		return nil, xerrors.Errorf("failed connecting to supervisor: %w", err)
+	}
+	defer supervisorClient.Close()
+
+	wsinfo, err := supervisorClient.Info.WorkspaceInfo(ctx, &supervisorapi.WorkspaceInfoRequest{})
+	if err != nil {
+		return nil, xerrors.Errorf("failed getting workspace info from supervisor: %w", err)
+	}
+
+	clientToken, err := supervisorClient.Token.GetToken(ctx, &supervisorapi.GetTokenRequest{
+		Host: wsinfo.GitpodApi.Host,
+		Kind: "gitpod",
+		Scope: []string{
+			"function:getLoggedInUser",
+		},
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed getting token from supervisor: %w", err)
+	}
+
+	serverLog := log.NewEntry(log.StandardLogger())
+	client, err := serverapi.ConnectToServer(wsinfo.GitpodApi.Endpoint, serverapi.ConnectToServerOpts{
+		Token:   clientToken.Token,
+		Context: ctx,
+		Log:     serverLog,
+	})
+	if err != nil {
+		return nil, xerrors.Errorf("failed connecting to server: %w", err)
+	}
+	return client, nil
+}
+
+func init() {
+	userInfoCmd.Flags().BoolVarP(&userInfoCmdOpts.Json, "json", "j", false, "Output in JSON format")
+	rootCmd.AddCommand(userInfoCmd)
+}


### PR DESCRIPTION
## Description
Does what it says on the tin.
Usage:

```
gitpod /workspace/gitpod $ ./gitpod-cli user-info --json
{"user_id":"....","email":"gero@gitpod.io"}
gitpod /workspace/gitpod $ ./gitpod-cli user-info --email
gero@gitpod.io
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-764

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
