### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,15 +13,15 @@ defaultArgs:
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: 8f10c5febf0162a3c2309076302f770fbad38fde
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.1.tar.gz"
-  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.2.1.1.tar.gz"
-  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.2.1.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.2.tar.gz"
+  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.2.2.tar.gz"
+  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.2.2.tar.gz"
   phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.2.1.tar.gz"
-  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.2.1.tar.gz"
-  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.2.1.tar.gz"
+  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.2.2.tar.gz"
+  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.2.2.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.4.tar.gz"
-  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.2.1.tar.gz"
-  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2024.2.tar.gz"
+  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.2.2.tar.gz"
+  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2024.2.1.tar.gz"
   jbBackendVersion: "latest"
   dockerVersion: "20.10.24"
   dockerComposeVersion: "2.27.0-gitpod.0"

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -2,7 +2,7 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=242.19533
+pluginSinceBuild=242.21829
 pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -2,7 +2,7 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=242.21829
+pluginSinceBuild=242.19533
 pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -183,6 +183,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2.1",
+            "image": "{{.Repository}}/ide/intellij:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+              "{{.Repository}}/ide/jb-launcher:commit-93f81feb1576d690040be79d1eff44d670be740d"
+            ]
+          },
+          {
             "version": "2024.2",
             "image": "{{.Repository}}/ide/intellij:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7",
             "imageLayers": [
@@ -259,6 +267,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.2.1.1",
+            "image": "{{.Repository}}/ide/goland:commit-3037306124242f17be677319a84b1203074d81e1",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+              "{{.Repository}}/ide/jb-launcher:commit-93f81feb1576d690040be79d1eff44d670be740d"
+            ]
+          },
           {
             "version": "2024.2.1",
             "image": "{{.Repository}}/ide/goland:commit-ee9bda60ffb3d400a3f6b9d812026548638b6587",
@@ -337,6 +353,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.2.1",
+            "image": "{{.Repository}}/ide/pycharm:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+              "{{.Repository}}/ide/jb-launcher:commit-93f81feb1576d690040be79d1eff44d670be740d"
+            ]
+          },
           {
             "version": "2024.1.4",
             "image": "{{.Repository}}/ide/pycharm:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7",
@@ -476,6 +500,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2.1",
+            "image": "{{.Repository}}/ide/rubymine:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+              "{{.Repository}}/ide/jb-launcher:commit-93f81feb1576d690040be79d1eff44d670be740d"
+            ]
+          },
+          {
             "version": "2024.1.4",
             "image": "{{.Repository}}/ide/rubymine:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7",
             "imageLayers": [
@@ -544,6 +576,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.2.1",
+            "image": "{{.Repository}}/ide/webstorm:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+              "{{.Repository}}/ide/jb-launcher:commit-93f81feb1576d690040be79d1eff44d670be740d"
+            ]
+          },
           {
             "version": "2024.1.5",
             "image": "{{.Repository}}/ide/webstorm:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7",
@@ -675,6 +715,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2.1",
+            "image": "{{.Repository}}/ide/clion:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+              "{{.Repository}}/ide/jb-launcher:commit-93f81feb1576d690040be79d1eff44d670be740d"
+            ]
+          },
+          {
             "version": "2024.1.4",
             "image": "{{.Repository}}/ide/clion:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7",
             "imageLayers": [
@@ -735,6 +783,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.2",
+            "image": "{{.Repository}}/ide/rustrover:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-d54058956db3274084249bdbc4f508ab111b8c51",
+              "{{.Repository}}/ide/jb-launcher:commit-93f81feb1576d690040be79d1eff44d670be740d"
+            ]
+          },
           {
             "version": "2024.1.6",
             "image": "{{.Repository}}/ide/rustrover:commit-f3193519fdae872d64a2a708f5338eeaabb3b6b7",


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR
8. Warmup is working properly using IntelliJ and spring-petclinic project sample

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_