### PR TITLE
[gp] Add helpful message in case "gp env --scope=user" fails because of missing create permission

### DIFF
--- a/components/gitpod-cli/cmd/env.go
+++ b/components/gitpod-cli/cmd/env.go
@@ -229,7 +229,7 @@ func setEnvs(ctx context.Context, setEnvScope envScope, args []string) error {
 			if err != nil {
 				if ferr, ok := err.(*jsonrpc2.Error); ok && ferr.Code == http.StatusForbidden && setEnvScope == envScopeUser {
 					return fmt.Errorf(""+
-						"Can't automatically create Env Var `%s` for security reasons.\n"+
+						"Can't automatically create env var `%s` for security reasons.\n"+
 						"Please create the var manually under %s/user/variables using Name=%s, Scope=*/*, Value=foobar", v.Name, result.gitpodHost, v.Name)
 				}
 				return err

--- a/components/gitpod-cli/cmd/env.go
+++ b/components/gitpod-cli/cmd/env.go
@@ -230,7 +230,7 @@ func setEnvs(ctx context.Context, setEnvScope envScope, args []string) error {
 				if ferr, ok := err.(*jsonrpc2.Error); ok && ferr.Code == http.StatusForbidden && setEnvScope == envScopeUser {
 					return fmt.Errorf(""+
 						"Can't automatically create Env Var `%s` for security reasons.\n"+
-						"Please create the var manullay under %s/user/variables using Name=%s, Scope=*/*, Value=foobar", v.Name, result.gitpodHost, v.Name)
+						"Please create the var manually under %s/user/variables using Name=%s, Scope=*/*, Value=foobar", v.Name, result.gitpodHost, v.Name)
 				}
 				return err
 			}

--- a/components/gitpod-cli/cmd/validate.go
+++ b/components/gitpod-cli/cmd/validate.go
@@ -238,7 +238,7 @@ func runRebuild(ctx context.Context, supervisorClient *supervisor.SupervisorClie
 	serverLog := logrus.NewEntry(logrus.New())
 	serverLog.Logger.SetLevel(logLevel)
 	setLoggerFormatter(serverLog.Logger)
-	workspaceEnvs, err := getWorkspaceEnvs(ctx, &connectToServerOptions{supervisorClient, wsInfo, serverLog, false})
+	workspaceEnvs, err := getWorkspaceEnvs(ctx, &connectToServerOptions{supervisorClient, wsInfo, serverLog, envScopeRepo})
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description
Introduces a helpful message incl. clickable link instead of technical error message.

## Related Issue(s)
Context: ENT-529

## How to test
 - open workspace
 - `gp env --scope=user MORE_TESTS=asd`
 - see the error message

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
