### PR TITLE
refactor: Update setHashedUserIdCookie method in analytics controller

### DIFF
--- a/components/server/src/analytics-controller.ts
+++ b/components/server/src/analytics-controller.ts
@@ -198,14 +198,7 @@ export class AnalyticsController {
             hostname.endsWith("gitpod-dev.com") ||
             hostname.endsWith("gitpod-io-dev.com")
         ) {
-            const domain =
-                hostname === "gitpod.io"
-                    ? ".gitpod.io"
-                    : hostname === "gitpod-staging.com"
-                    ? ".gitpod-staging.com"
-                    : hostname.endsWith("gitpod-dev.com")
-                    ? ".gitpod-dev.com"
-                    : ".gitpod-io-dev.com";
+            const domain = `.${hostname}`;
 
             res.cookie("gitpod_hashed_user_id", hashedUserId, {
                 domain: domain,


### PR DESCRIPTION


## Description
<!-- Describe your changes in detail -->

This PR updates the `setHashedUserIdCookie` method in the analytics controller. The changes include:
- Adding a server-side implementation to determine the appropriate domain for setting the cookie based on the request hostname

Followup of #20226

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/20226/files#r1763283486

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
