### PR TITLE
Implement hashed user ID cookie for analytics on Gitpod domains

### DIFF
--- a/components/server/src/analytics-controller.ts
+++ b/components/server/src/analytics-controller.ts
@@ -18,7 +18,6 @@ import { Config } from "./config";
 import { RateLimited } from "./api/rate-limited";
 import { RateLimitter } from "./rate-limitter";
 import { RateLimiterRes } from "rate-limiter-flexible";
-import * as crypto from "crypto";
 
 @injectable()
 export class AnalyticsController {
@@ -70,7 +69,6 @@ export class AnalyticsController {
                 const clientHeaderFields = toClientHeaderFields(req);
                 const event = req.body as RemoteIdentifyMessage;
                 this.identifyUser(req.user.id, event, clientHeaderFields);
-                this.setHashedUserIdCookie(req.user.id, req, res);
                 res.sendStatus(200);
             } catch (e) {
                 console.error("failed to identify user", e);
@@ -177,36 +175,6 @@ export class AnalyticsController {
                 return true;
             }
             throw e;
-        }
-    }
-
-    private setHashedUserIdCookie(userId: string, req: express.Request, res: express.Response): void {
-        const hashedUserId = crypto.createHash("md5").update(userId).digest("hex");
-        const oneYearInSeconds = 365 * 24 * 60 * 60;
-
-        /**
-         * This implementation is inspired by isGitpodIo() from /workspace/gitpod/components/dashboard/src/utils.ts
-         * We're using a server-side equivalent here because:
-         * 1. The original function is client-side code using window.location
-         * 2. This is server-side code that needs to use the request object
-         * 3. We need to determine the appropriate domain for setting the cookie
-         */
-        const hostname = req.hostname;
-        if (
-            hostname === "gitpod.io" ||
-            hostname === "gitpod-staging.com" ||
-            hostname.endsWith("gitpod-dev.com") ||
-            hostname.endsWith("gitpod-io-dev.com")
-        ) {
-            const domain = `.${hostname}`;
-
-            res.cookie("gitpod_hashed_user_id", hashedUserId, {
-                domain: domain,
-                maxAge: oneYearInSeconds * 1000, // Convert to milliseconds
-                httpOnly: true,
-                secure: true,
-                sameSite: "lax",
-            });
         }
     }
 }

--- a/components/server/src/session-handler.spec.db.ts
+++ b/components/server/src/session-handler.spec.db.ts
@@ -53,20 +53,12 @@ describe("SessionHandler", () => {
         return await deferred.promise;
     };
 
-    class TestSessionHandler extends SessionHandler {
-        public testSetHashedUserIdCookie() {
-            // Empty implementation for testing
-            return;
-        }
-    }
-
     beforeEach(async () => {
         container = createTestContainer();
         sessionHandler = container.get(SessionHandler);
-        (sessionHandler as TestSessionHandler).testSetHashedUserIdCookie = () => {
+        (sessionHandler as any).setHashedUserIdCookie = () => {
             return;
         };
-
         jwtSessionHandler = sessionHandler.jwtSessionConvertor();
         const userService = container.get(UserService);
         // insert some users to the DB to reproduce INC-379

--- a/components/server/src/session-handler.spec.db.ts
+++ b/components/server/src/session-handler.spec.db.ts
@@ -53,9 +53,20 @@ describe("SessionHandler", () => {
         return await deferred.promise;
     };
 
+    class TestSessionHandler extends SessionHandler {
+        public testSetHashedUserIdCookie() {
+            // Empty implementation for testing
+            return;
+        }
+    }
+
     beforeEach(async () => {
         container = createTestContainer();
         sessionHandler = container.get(SessionHandler);
+        (sessionHandler as TestSessionHandler).testSetHashedUserIdCookie = () => {
+            return;
+        };
+
         jwtSessionHandler = sessionHandler.jwtSessionConvertor();
         const userService = container.get(UserService);
         // insert some users to the DB to reproduce INC-379

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -233,6 +233,12 @@ export class SessionHandler {
             sameSite,
             secure,
         });
+        res.clearCookie("gitpod_hashed_user_id", {
+            domain: `.${res.req.hostname}`,
+            httpOnly: true,
+            secure: true,
+            sameSite: "lax",
+        });
     }
 
     private setHashedUserIdCookie(req: express.Request, res: express.Response): void {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR introduces a new feature to set a hashed user ID cookie for analytics purposes on specific Gitpod domains. The cookie is set during the JWT refresh process, ensuring it's always up-to-date for authenticated users.

Changes:
- Added `setHashedUserIdCookie` method to `SessionHandler` class
- Integrated cookie setting logic into `jwtSessionConvertor` method
- Implemented domain-specific checks for cookie setting

Followup of #20226

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-801

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-e53e12238f3</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-e53e12238f3.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-e53e12238f3.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-ent-801-store-hasheduserid-in-cookie-storage-gha.28996</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-e53e12238f3%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
