### PR TITLE
Hashed user ID cookie improvements

### DIFF
--- a/components/dashboard/src/user-context.tsx
+++ b/components/dashboard/src/user-context.tsx
@@ -18,6 +18,17 @@ const UserContext = createContext<{
     setUser: () => null,
 });
 
+const refetchCookie = async () => {
+    await fetch("/api/auth/jwt-cookie", {
+        credentials: "include",
+    })
+        .then((resp) => resp.text())
+        .then((text) => console.log(`Completed JWT Cookie refresh: ${text}`))
+        .catch((err) => {
+            console.log("Failed to update jwt-cookie", err);
+        });
+};
+
 const UserContextProvider: React.FC = ({ children }) => {
     const [user, setUser] = useState<User>();
 
@@ -46,16 +57,9 @@ const UserContextProvider: React.FC = ({ children }) => {
             const frequencyMs = 1000 * 60 * 5; // 5 mins
             if (!_gp.jwttimer) {
                 // Store the timer on the window, to avoid queuing up multiple
-                _gp.jwtTimer = setInterval(() => {
-                    fetch("/api/auth/jwt-cookie", {
-                        credentials: "include",
-                    })
-                        .then((resp) => resp.text())
-                        .then((text) => console.log(`Completed JWT Cookie refresh: ${text}`))
-                        .catch((err) => {
-                            console.log("Failed to update jwt-cookie", err);
-                        });
-                }, frequencyMs);
+                _gp.jwtTimer = setInterval(refetchCookie, frequencyMs);
+
+                setTimeout(refetchCookie, 20_000);
             }
         },
         [user, client],

--- a/components/server/src/auth/login-completion-handler.ts
+++ b/components/server/src/auth/login-completion-handler.ts
@@ -103,6 +103,7 @@ export class LoginCompletionHandler {
         // (default case) If we got redirected here onto the base domain of the Gitpod installation, we can just issue the cookie right away.
         const cookie = await this.session.createJWTSessionCookie(user.id);
         response.cookie(cookie.name, cookie.value, cookie.opts);
+        this.session.setHashedUserIdCookie(request, response);
         reportJWTCookieIssued();
 
         log.info(logContext, `User is logged in successfully. Redirect to: ${returnTo}`);

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -51,7 +51,6 @@ export class SessionHandler {
             if (!decoded) {
                 const cookie = await this.createJWTSessionCookie(user.id);
                 res.cookie(cookie.name, cookie.value, cookie.opts);
-                this.setHashedUserIdCookie(req, res);
 
                 reportJWTCookieIssued();
                 res.status(200);
@@ -242,7 +241,7 @@ export class SessionHandler {
         });
     }
 
-    private setHashedUserIdCookie(req: express.Request, res: express.Response): void {
+    public setHashedUserIdCookie(req: express.Request, res: express.Response): void {
         const user = req.user as User;
         if (!user) return;
 

--- a/components/server/src/session-handler.ts
+++ b/components/server/src/session-handler.ts
@@ -51,6 +51,7 @@ export class SessionHandler {
             if (!decoded) {
                 const cookie = await this.createJWTSessionCookie(user.id);
                 res.cookie(cookie.name, cookie.value, cookie.opts);
+                this.setHashedUserIdCookie(req, res);
 
                 reportJWTCookieIssued();
                 res.status(200);


### PR DESCRIPTION
## Description

This PR introduces two changes:
- Forces JWT cookie verification after a set time after page load (20 seconds)
- Issues the hashed user ID cookie after login, so that we make its use consistent with our regular auth cookie lifecycle

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C071G5TTS49/p1726677726256909?thread_ts=1726648214.862269&cid=C071G5TTS49

Test today at https://ft-initial835bbe244e.preview.gitpod-dev.com/workspaces


- [x] /werft with-preview
- [x] /werft with-gce-vm

### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-initial835bbe244e</li>
	<li><b>🔗 URL</b> - <a href="https://ft-initial835bbe244e.preview.gitpod-dev.com/workspaces" target="_blank">ft-initial835bbe244e.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-initial-jwt-cookie-refresh-gha.29009</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-initial835bbe244e%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>