### PR TITLE
[GHA] fix code nightly job

### DIFF
--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -25,7 +25,7 @@ packages:
       - codeQuality
       - codeVersion
     config:
-      dockerfile: leeway.Dockerfile
+      dockerfile: leeway.nightly.Dockerfile
       metadata:
         helm-component: workspace.codeImage
       buildArgs:

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -79,9 +79,9 @@ RUN npm run gulp compile-build \
 # config for first layer needed by blobserve
 # this custom urls will be then replaced by blobserve.
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
-RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
-    && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
-    && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /vscode-web/index.html
+RUN cp /gp-code/out/vs/gitpod/browser/workbench/workbench.html /gp-code/index.html \
+    && cp /gp-code/out/vs/gitpod/browser/workbench/callback.html /gp-code/callback.html \
+    && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /gp-code/index.html
 
 # cli config: alises to gitpod-code
 RUN cp /vscode-reh-linux-x64/bin/remote-cli/gitpod-code /vscode-reh-linux-x64/bin/remote-cli/code \
@@ -93,7 +93,7 @@ RUN chmod -R ugo+w /vscode-reh-linux-x64/extensions
 
 FROM scratch
 # copy static web resources in first layer to serve from blobserve
-COPY --from=code_builder --chown=33333:33333 /vscode-web/ /ide/
+COPY --from=code_builder --chown=33333:33333 /gp-code/ /ide/
 COPY --from=code_builder --chown=33333:33333 /vscode-reh-linux-x64/ /ide/
 
 ARG CODE_VERSION

--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -1,31 +1,14 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
-FROM gitpod/openvscode-server-linux-build-agent:centos7-devtoolset8-x64 as dependencies_builder
+FROM gitpod/openvscode-server-linux-build-agent:focal-x64 as code_builder
 
 ENV TRIGGER_REBUILD 1
-
-ARG CODE_COMMIT
-
-RUN mkdir /gp-code \
-    && cd /gp-code \
-    && git init \
-    && git remote add origin https://github.com/gitpod-io/openvscode-server \
-    && git fetch origin $CODE_COMMIT --depth=1 \
-    && git reset --hard FETCH_HEAD
-WORKDIR /gp-code
-
-# Disable v8 cache used by yarn v1.x, refs https://github.com/nodejs/node/issues/51555
-ENV DISABLE_V8_COMPILE_CACHE=1
-
-RUN yarn --cwd remote --frozen-lockfile --network-timeout 180000
-
-FROM gitpod/openvscode-server-linux-build-agent:focal-x64 as code_builder
 
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
 ENV VSCODE_ARCH=x64
-ENV NPM_REGISTRY=https://registry.yarnpkg.com
+ENV NPM_REGISTRY=https://registry.npmjs.org
 
 ARG CODE_COMMIT
 ARG CODE_QUALITY
@@ -61,15 +44,11 @@ RUN apt-get install -y pkg-config dbus xvfb libgtk-3-0 libxkbfile-dev libkrb5-de
 # Disable v8 cache used by yarn v1.x, refs https://github.com/nodejs/node/issues/51555
 ENV DISABLE_V8_COMPILE_CACHE=1
 
-ENV npm_config_arch=x64
+# ENV npm_config_arch=x64
 RUN mkdir -p .build \
-    && yarn config set registry "$NPM_REGISTRY" \
-    && yarn --cwd build --frozen-lockfile --check-files --network-timeout 180000 \
-    && yarn --frozen-lockfile --check-files --network-timeout 180000
-
-# copy remote dependencies build in dependencies_builder image
-RUN rm -rf remote/node_modules/
-COPY --from=dependencies_builder /gp-code/remote/node_modules/ /gp-code/remote/node_modules/
+    && npm config set registry "$NPM_REGISTRY" \
+    && npm ci \
+    && npm run compile
 
 # check that the provided codeVersion is the correct one for the given codeCommit
 RUN commitVersion=$(cat package.json | jq -r .version) \
@@ -91,11 +70,11 @@ RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
     mv product.json.tmp product.json && \
     jq '{quality,nameLong,nameShort}' product.json
 
-RUN yarn gulp compile-build \
-    && yarn gulp extensions-ci \
-    && yarn gulp minify-vscode-reh \
-    && yarn gulp vscode-web-min-ci \
-    && yarn gulp vscode-reh-linux-x64-min-ci
+RUN npm run gulp compile-build \
+    && npm run gulp extensions-ci \
+    && npm run gulp minify-vscode-reh \
+    && npm run gulp vscode-web-min-ci \
+    && npm run gulp vscode-reh-linux-x64-min-ci
 
 # config for first layer needed by blobserve
 # this custom urls will be then replaced by blobserve.

--- a/components/ide/code/leeway.nightly.Dockerfile
+++ b/components/ide/code/leeway.nightly.Dockerfile
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+# Copyright (c) 2024 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 FROM gitpod/openvscode-server-linux-build-agent:focal-x64 as code_builder
@@ -75,12 +75,10 @@ RUN npm run gulp compile-build \
     && npm run gulp vscode-web-min-ci \
     && npm run gulp vscode-reh-linux-x64-min-ci
 
-# RUN ls -l
-
 # config for first layer needed by blobserve
 # this custom urls will be then replaced by blobserve.
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
-RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
+RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.esm.html /vscode-web/index.html \
 && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
 && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /vscode-web/index.html
 

--- a/components/ide/code/leeway.nightly.Dockerfile
+++ b/components/ide/code/leeway.nightly.Dockerfile
@@ -79,9 +79,9 @@ RUN npm run gulp compile-build \
 # config for first layer needed by blobserve
 # this custom urls will be then replaced by blobserve.
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
-RUN cp /gp-code/out/vs/gitpod/browser/workbench/workbench.html /gp-code/index.html \
-    && cp /gp-code/out/vs/gitpod/browser/workbench/callback.html /gp-code/callback.html \
-    && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /gp-code/index.html
+RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
+    && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
+    && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /vscode-web/index.html
 
 # cli config: alises to gitpod-code
 RUN cp /vscode-reh-linux-x64/bin/remote-cli/gitpod-code /vscode-reh-linux-x64/bin/remote-cli/code \

--- a/components/ide/code/leeway.nightly.Dockerfile
+++ b/components/ide/code/leeway.nightly.Dockerfile
@@ -1,31 +1,14 @@
 # Copyright (c) 2020 Gitpod GmbH. All rights reserved.
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
-FROM gitpod/openvscode-server-linux-build-agent:centos7-devtoolset8-x64 as dependencies_builder
+FROM gitpod/openvscode-server-linux-build-agent:focal-x64 as code_builder
 
 ENV TRIGGER_REBUILD 1
-
-ARG CODE_COMMIT
-
-RUN mkdir /gp-code \
-    && cd /gp-code \
-    && git init \
-    && git remote add origin https://github.com/gitpod-io/openvscode-server \
-    && git fetch origin $CODE_COMMIT --depth=1 \
-    && git reset --hard FETCH_HEAD
-WORKDIR /gp-code
-
-# Disable v8 cache used by yarn v1.x, refs https://github.com/nodejs/node/issues/51555
-ENV DISABLE_V8_COMPILE_CACHE=1
-
-RUN yarn --cwd remote --frozen-lockfile --network-timeout 180000
-
-FROM gitpod/openvscode-server-linux-build-agent:focal-x64 as code_builder
 
 ENV PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1
 ENV ELECTRON_SKIP_BINARY_DOWNLOAD=1
 ENV VSCODE_ARCH=x64
-ENV NPM_REGISTRY=https://registry.yarnpkg.com
+ENV NPM_REGISTRY=https://registry.npmjs.org
 
 ARG CODE_COMMIT
 ARG CODE_QUALITY
@@ -61,15 +44,11 @@ RUN apt-get install -y pkg-config dbus xvfb libgtk-3-0 libxkbfile-dev libkrb5-de
 # Disable v8 cache used by yarn v1.x, refs https://github.com/nodejs/node/issues/51555
 ENV DISABLE_V8_COMPILE_CACHE=1
 
-ENV npm_config_arch=x64
+# ENV npm_config_arch=x64
 RUN mkdir -p .build \
-    && yarn config set registry "$NPM_REGISTRY" \
-    && yarn --cwd build --frozen-lockfile --check-files --network-timeout 180000 \
-    && yarn --frozen-lockfile --check-files --network-timeout 180000
-
-# copy remote dependencies build in dependencies_builder image
-RUN rm -rf remote/node_modules/
-COPY --from=dependencies_builder /gp-code/remote/node_modules/ /gp-code/remote/node_modules/
+    && npm config set registry "$NPM_REGISTRY" \
+    && npm ci \
+    && npm run compile
 
 # check that the provided codeVersion is the correct one for the given codeCommit
 RUN commitVersion=$(cat package.json | jq -r .version) \
@@ -91,18 +70,18 @@ RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
     mv product.json.tmp product.json && \
     jq '{quality,nameLong,nameShort}' product.json
 
-RUN yarn gulp compile-build \
-    && yarn gulp extensions-ci \
-    && yarn gulp minify-vscode-reh \
-    && yarn gulp vscode-web-min-ci \
-    && yarn gulp vscode-reh-linux-x64-min-ci
+RUN npm run gulp compile-build \
+    && npm run gulp extensions-ci \
+    && npm run gulp minify-vscode-reh \
+    && npm run gulp vscode-web-min-ci \
+    && npm run gulp vscode-reh-linux-x64-min-ci
 
 # config for first layer needed by blobserve
 # this custom urls will be then replaced by blobserve.
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
-RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
-    && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
-    && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /vscode-web/index.html
+RUN cp /gp-code/out/vs/gitpod/browser/workbench/workbench.html /gp-code/index.html \
+    && cp /gp-code/out/vs/gitpod/browser/workbench/callback.html /gp-code/callback.html \
+    && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /gp-code/index.html
 
 # cli config: alises to gitpod-code
 RUN cp /vscode-reh-linux-x64/bin/remote-cli/gitpod-code /vscode-reh-linux-x64/bin/remote-cli/code \
@@ -114,7 +93,7 @@ RUN chmod -R ugo+w /vscode-reh-linux-x64/extensions
 
 FROM scratch
 # copy static web resources in first layer to serve from blobserve
-COPY --from=code_builder --chown=33333:33333 /vscode-web/ /ide/
+COPY --from=code_builder --chown=33333:33333 /gp-code/ /ide/
 COPY --from=code_builder --chown=33333:33333 /vscode-reh-linux-x64/ /ide/
 
 ARG CODE_VERSION

--- a/components/ide/gha-update-image/BUILD.yaml
+++ b/components/ide/gha-update-image/BUILD.yaml
@@ -17,3 +17,21 @@ scripts:
       kubectl patch cm ide-config --type=merge -p "$cf_patch"
       kubectl rollout restart deployment ide-service
       kubectl rollout restart deployment server
+  - name: code-use-dev-latest
+    script: |
+      ide_list=("code")
+      prop_list=("latestImage")
+
+      cf_patch=$(kubectl get cm ide-config -o=json | jq '.data."config.json"' |jq -r)
+      for ide in "${ide_list[@]}"; do
+        for prop in "${prop_list[@]}"; do
+          cf_patch=$(echo "$cf_patch" | jq ".ideOptions.options.$ide.$prop = \"eu.gcr.io/gitpod-dev-artifact/build/ide/code:nightly\"")
+        done
+      done
+      cf_patch=$(echo "$cf_patch" |jq tostring)
+      cf_patch="{\"data\": {\"config.json\": $cf_patch}}"
+      # echo "$cf_patch"
+
+      kubectl patch cm ide-config --type=merge -p "$cf_patch"
+      kubectl rollout restart deployment ide-service
+      kubectl rollout restart deployment server

--- a/components/local-app-api/typescript-grpcweb/webpack.config.js
+++ b/components/local-app-api/typescript-grpcweb/webpack.config.js
@@ -30,8 +30,6 @@ module.exports = {
         libraryTarget: "umd",
         globalObject: "typeof self !== 'undefined' ? self : this",
     },
-    externals: {
-        "@improbable-eng/grpc-web": "commonjs2 @improbable-eng/grpc-web",
-    },
+    externals: {},
     mode: "production",
 };


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- https://github.com/gitpod-io/openvscode-server/pull/578

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-787

## How to test
<!-- Provide steps to test this PR -->
- Open workspace with current PR
- Exec commands (it should have cached already)
  ```
  cd /workspace/gitpod/components/ide/code
  leeway build \
    -Dversion=test \
    -DimageRepoBase=eu.gcr.io/gitpod-dev-artifact/build \
    -DcodeCommit=<latest_commit_of_openvscode_pr>\
    -DcodeVersion=1.94.0 \
    -DcodeQuality=insider \
    .:docker-nightly
  ```
- Exec commands, and wait 20 more seconds
  ```
  cd /workspace/gitpod/components/ide/gha-update-image
  leeway run .:code-use-dev-latest
  ```
- Open preview env, and use `latest` editors
- Open a workspace with latest VS Code Browser

**Test with Lates VS Code Browser**
- It can open workspace with -> you can see UI of VS Code Browser
- It shows proper commit sha in VS Code's **About** window (last commit of openvscode server PR) and version should be `1.94.0`
- Has `Gitpod:` prefixed commands (F1)
- ❌  Webview is not working (i.e. `curl lama.sh | sh` and `gp preview $(gp url 8080)` ENT-836

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-code-nightly</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-code-nightly.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-code-nightly.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-code-nightly-gha.29105</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-code-nightly%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [x] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
