### PR TITLE
[ws-proxy] close connection if workspace or port stopped share

### DIFF
--- a/components/ws-proxy/cmd/run.go
+++ b/components/ws-proxy/cmd/run.go
@@ -78,15 +78,13 @@ var runCmd = &cobra.Command{
 			log.WithError(err).Fatal(err, "unable to start manager")
 		}
 
-		var infoprov proxy.CompositeInfoProvider
-		crdInfoProv, err := proxy.NewCRDWorkspaceInfoProvider(mgr.GetClient(), mgr.GetScheme())
+		infoprov, err := proxy.NewCRDWorkspaceInfoProvider(mgr.GetClient(), mgr.GetScheme())
 		if err != nil {
 			log.WithError(err).Fatal("cannot create CRD-based info provider")
 		}
-		if err = crdInfoProv.SetupWithManager(mgr); err != nil {
+		if err = infoprov.SetupWithManager(mgr); err != nil {
 			log.WithError(err).Fatal(err, "unable to create CRD-based info provider", "controller", "Workspace")
 		}
-		infoprov = append(infoprov, crdInfoProv)
 
 		if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 			log.WithError(err).Fatal("unable to set up health check")

--- a/components/ws-proxy/pkg/common/infoprovider.go
+++ b/components/ws-proxy/pkg/common/infoprovider.go
@@ -5,6 +5,7 @@
 package common
 
 import (
+	"context"
 	"time"
 
 	"github.com/gitpod-io/gitpod/ws-manager/api"
@@ -43,6 +44,9 @@ type WorkspaceCoords struct {
 type WorkspaceInfoProvider interface {
 	// WorkspaceInfo returns the workspace information of a workspace using it's workspace ID
 	WorkspaceInfo(workspaceID string) *WorkspaceInfo
+
+	AcquireContext(ctx context.Context, workspaceID, port string) (context.Context, string, error)
+	ReleaseContext(id string)
 }
 
 // WorkspaceInfo is all the infos ws-proxy needs to know about a workspace.

--- a/components/ws-proxy/pkg/proxy/auth.go
+++ b/components/ws-proxy/pkg/proxy/auth.go
@@ -19,9 +19,9 @@ import (
 )
 
 var (
-	ErrTokenNotFound  = fmt.Errorf("no owner cookie present")
-	ErrTokenMissmatch = fmt.Errorf("owner token mismatch")
-	ErrTokenDecode    = fmt.Errorf("cannot decode owner token")
+	ErrTokenNotFound = fmt.Errorf("no owner cookie present")
+	ErrTokenMismatch = fmt.Errorf("owner token mismatch")
+	ErrTokenDecode   = fmt.Errorf("cannot decode owner token")
 )
 
 // WorkspaceAuthHandler rejects requests which are not authenticated or authorized to access a workspace.
@@ -87,7 +87,7 @@ func WorkspaceAuthHandler(domain string, info common.WorkspaceInfoProvider) mux.
 				}
 
 				if tkn != ws.Auth.OwnerToken {
-					return false, ErrTokenMissmatch
+					return false, ErrTokenMismatch
 				}
 				return true, nil
 			}
@@ -99,7 +99,7 @@ func WorkspaceAuthHandler(domain string, info common.WorkspaceInfoProvider) mux.
 						resp.WriteHeader(http.StatusUnauthorized)
 						return
 					}
-					if errors.Is(err, ErrTokenMissmatch) {
+					if errors.Is(err, ErrTokenMismatch) {
 						log.Warn("owner token mismatch")
 						resp.WriteHeader(http.StatusForbidden)
 						return

--- a/components/ws-proxy/pkg/proxy/auth.go
+++ b/components/ws-proxy/pkg/proxy/auth.go
@@ -5,6 +5,7 @@
 package proxy
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -15,6 +16,12 @@ import (
 
 	"github.com/gitpod-io/gitpod/ws-manager/api"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/common"
+)
+
+var (
+	ErrTokenNotFound  = fmt.Errorf("no owner cookie present")
+	ErrTokenMissmatch = fmt.Errorf("owner token mismatch")
+	ErrTokenDecode    = fmt.Errorf("cannot decode owner token")
 )
 
 // WorkspaceAuthHandler rejects requests which are not authenticated or authorized to access a workspace.
@@ -47,19 +54,10 @@ func WorkspaceAuthHandler(domain string, info common.WorkspaceInfoProvider) mux.
 				return
 			}
 
+			isPublic := false
 			if ws.Auth != nil && ws.Auth.Admission == api.AdmissionLevel_ADMIT_EVERYONE {
-				// workspace is free for all - no tokens or cookies matter
-				h.ServeHTTP(resp, req)
-
-				return
-			}
-
-			if port != "" {
-				// this is a workspace port request and ports can be public or private.
-				// For public ports no tokens or cookies matter, private ports are subject
-				// to the same access policies as the workspace itself is.
-				var isPublic bool
-
+				isPublic = true
+			} else if port != "" {
 				prt, err := strconv.ParseUint(port, 10, 16)
 				if err != nil {
 					log.WithField("port", port).WithError(err).Error("cannot convert port to int")
@@ -67,48 +65,65 @@ func WorkspaceAuthHandler(domain string, info common.WorkspaceInfoProvider) mux.
 					for _, p := range ws.Ports {
 						if p.Port == uint32(prt) {
 							isPublic = p.Visibility == api.PortVisibility_PORT_VISIBILITY_PUBLIC
-
 							break
 						}
 					}
 				}
-
-				if isPublic {
-					// workspace port is free for all - no tokens or cookies matter
-					h.ServeHTTP(resp, req)
-
-					return
-				}
-
-				// port seems to be private - subject it to the same access policy as the workspace itself
 			}
 
-			tkn := req.Header.Get("x-gitpod-owner-token")
-			if tkn == "" {
-				cn := fmt.Sprintf("%s%s_owner_", cookiePrefix, ws.InstanceID)
-				c, err := req.Cookie(cn)
+			authenticate := func() (bool, error) {
+				tkn := req.Header.Get("x-gitpod-owner-token")
+				if tkn == "" {
+					cn := fmt.Sprintf("%s%s_owner_", cookiePrefix, ws.InstanceID)
+					c, err := req.Cookie(cn)
+					if err != nil {
+						return false, ErrTokenNotFound
+					}
+					tkn = c.Value
+				}
+				tkn, err := url.QueryUnescape(tkn)
 				if err != nil {
-					log.WithField("cookieName", cn).Debug("no owner cookie present")
-					resp.WriteHeader(http.StatusUnauthorized)
-
-					return
+					return false, ErrTokenDecode
 				}
 
-				tkn = c.Value
+				if tkn != ws.Auth.OwnerToken {
+					return false, ErrTokenMissmatch
+				}
+				return true, nil
 			}
-			tkn, err := url.QueryUnescape(tkn)
-			if err != nil {
-				log.WithError(err).Warn("cannot decode owner token")
-				resp.WriteHeader(http.StatusBadRequest)
 
+			authenticated, err := authenticate()
+			if !authenticated && !isPublic {
+				if err != nil {
+					if errors.Is(err, ErrTokenNotFound) {
+						resp.WriteHeader(http.StatusUnauthorized)
+						return
+					}
+					if errors.Is(err, ErrTokenMissmatch) {
+						log.Warn("owner token mismatch")
+						resp.WriteHeader(http.StatusForbidden)
+						return
+					}
+					if errors.Is(err, ErrTokenDecode) {
+						log.Warn("cannot decode owner token")
+						resp.WriteHeader(http.StatusBadRequest)
+						return
+					}
+				}
+				log.WithError(err).Error("cannot authenticate")
+				resp.WriteHeader(http.StatusInternalServerError)
 				return
 			}
 
-			if tkn != ws.Auth.OwnerToken {
-				log.Warn("owner token mismatch")
-				resp.WriteHeader(http.StatusForbidden)
-
-				return
+			if !authenticated && isPublic {
+				ctx, id, err := info.AcquireContext(req.Context(), wsID, port)
+				if err != nil {
+					log.WithError(err).Error("cannot acquire context")
+					resp.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				defer info.ReleaseContext(id)
+				req = req.WithContext(ctx)
 			}
 
 			h.ServeHTTP(resp, req)

--- a/components/ws-proxy/pkg/proxy/auth_test.go
+++ b/components/ws-proxy/pkg/proxy/auth_test.go
@@ -36,8 +36,8 @@ func TestWorkspaceAuthHandler(t *testing.T) {
 		testPort    = 8080
 	)
 	var (
-		ownerOnlyInfos = map[string]*common.WorkspaceInfo{
-			workspaceID: {
+		ownerOnlyInfos = []common.WorkspaceInfo{
+			{
 				WorkspaceID: workspaceID,
 				InstanceID:  instanceID,
 				Auth: &api.WorkspaceAuthentication{
@@ -47,8 +47,8 @@ func TestWorkspaceAuthHandler(t *testing.T) {
 				Ports: []*api.PortSpec{{Port: testPort, Visibility: api.PortVisibility_PORT_VISIBILITY_PRIVATE}},
 			},
 		}
-		publicPortInfos = map[string]*common.WorkspaceInfo{
-			workspaceID: {
+		publicPortInfos = []common.WorkspaceInfo{
+			{
 				WorkspaceID: workspaceID,
 				InstanceID:  instanceID,
 				Auth: &api.WorkspaceAuthentication{
@@ -58,8 +58,8 @@ func TestWorkspaceAuthHandler(t *testing.T) {
 				Ports: []*api.PortSpec{{Port: testPort, Visibility: api.PortVisibility_PORT_VISIBILITY_PUBLIC}},
 			},
 		}
-		admitEveryoneInfos = map[string]*common.WorkspaceInfo{
-			workspaceID: {
+		admitEveryoneInfos = []common.WorkspaceInfo{
+			{
 				WorkspaceID: workspaceID,
 				InstanceID:  instanceID,
 				Auth:        &api.WorkspaceAuthentication{Admission: api.AdmissionLevel_ADMIT_EVERYONE},
@@ -68,7 +68,7 @@ func TestWorkspaceAuthHandler(t *testing.T) {
 	)
 	tests := []struct {
 		Name        string
-		Infos       map[string]*common.WorkspaceInfo
+		Infos       []common.WorkspaceInfo
 		OwnerCookie string
 		WorkspaceID string
 		Port        string
@@ -225,7 +225,7 @@ func TestWorkspaceAuthHandler(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
 			var res testResult
-			handler := WorkspaceAuthHandler(domain, &fixedInfoProvider{Infos: test.Infos})(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
+			handler := WorkspaceAuthHandler(domain, &fakeWsInfoProvider{infos: test.Infos})(http.HandlerFunc(func(resp http.ResponseWriter, req *http.Request) {
 				res.HandlerCalled = true
 				resp.WriteHeader(http.StatusOK)
 			}))

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -177,28 +177,3 @@ func (r *CRDWorkspaceInfoProvider) SetupWithManager(mgr ctrl.Manager) error {
 		).
 		Complete(r)
 }
-
-// CompositeInfoProvider checks each of its info providers and returns the first info found.
-type CompositeInfoProvider []common.WorkspaceInfoProvider
-
-func (c CompositeInfoProvider) WorkspaceInfo(workspaceID string) *common.WorkspaceInfo {
-	for _, ip := range c {
-		res := ip.WorkspaceInfo(workspaceID)
-		if res != nil {
-			return res
-		}
-	}
-	return nil
-}
-
-type fixedInfoProvider struct {
-	Infos map[string]*common.WorkspaceInfo
-}
-
-// WorkspaceInfo returns the workspace information of a workspace using it's workspace ID.
-func (fp *fixedInfoProvider) WorkspaceInfo(workspaceID string) *common.WorkspaceInfo {
-	if fp.Infos == nil {
-		return nil
-	}
-	return fp.Infos[workspaceID]
-}

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -8,10 +8,12 @@ import (
 	"context"
 	"net/url"
 	"sort"
+	"strconv"
 
 	"golang.org/x/xerrors"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/tools/cache"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,6 +22,7 @@ import (
 
 	wsk8s "github.com/gitpod-io/gitpod/common-go/kubernetes"
 	"github.com/gitpod-io/gitpod/common-go/log"
+	"github.com/gitpod-io/gitpod/ws-manager/api"
 	wsapi "github.com/gitpod-io/gitpod/ws-manager/api"
 	workspacev1 "github.com/gitpod-io/gitpod/ws-manager/api/crd/v1"
 	"github.com/gitpod-io/gitpod/ws-proxy/pkg/common"
@@ -48,11 +51,19 @@ func getPortStr(urlStr string) string {
 	return portURL.Port()
 }
 
+type ConnectionContext struct {
+	WorkspaceID string
+	Port        string
+	UUID        string
+	CancelFunc  context.CancelCauseFunc
+}
+
 type CRDWorkspaceInfoProvider struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	store cache.ThreadSafeStore
+	store        cache.ThreadSafeStore
+	contextStore cache.ThreadSafeStore
 }
 
 // NewCRDWorkspaceInfoProvider creates a fresh WorkspaceInfoProvider.
@@ -67,12 +78,21 @@ func NewCRDWorkspaceInfoProvider(client client.Client, scheme *runtime.Scheme) (
 			return nil, xerrors.Errorf("object is not a WorkspaceInfo")
 		},
 	}
+	contextIndexers := cache.Indexers{
+		workspaceIndex: func(obj interface{}) ([]string, error) {
+			if connCtx, ok := obj.(*ConnectionContext); ok {
+				return []string{connCtx.WorkspaceID}, nil
+			}
+			return nil, xerrors.Errorf("object is not a ConnectionContext")
+		},
+	}
 
 	return &CRDWorkspaceInfoProvider{
 		Client: client,
 		Scheme: scheme,
 
-		store: cache.NewThreadSafeStore(indexers, cache.Indices{}),
+		store:        cache.NewThreadSafeStore(indexers, cache.Indices{}),
+		contextStore: cache.NewThreadSafeStore(contextIndexers, cache.Indices{}),
 	}, nil
 }
 
@@ -99,6 +119,28 @@ func (r *CRDWorkspaceInfoProvider) WorkspaceInfo(workspaceID string) *common.Wor
 	}
 
 	return nil
+}
+
+func (r *CRDWorkspaceInfoProvider) AcquireContext(ctx context.Context, workspaceID string, port string) (context.Context, string, error) {
+	ws := r.WorkspaceInfo(workspaceID)
+	if ws == nil {
+		return ctx, "", xerrors.Errorf("workspace %s not found", workspaceID)
+	}
+	id := string(uuid.NewUUID())
+	ctx, cancel := context.WithCancelCause(ctx)
+	connCtx := &ConnectionContext{
+		WorkspaceID: workspaceID,
+		Port:        port,
+		CancelFunc:  cancel,
+		UUID:        id,
+	}
+
+	r.contextStore.Add(id, connCtx)
+	return ctx, id, nil
+}
+
+func (r *CRDWorkspaceInfoProvider) ReleaseContext(id string) {
+	r.contextStore.Delete(id)
 }
 
 func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -162,9 +204,42 @@ func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	r.store.Update(req.Name, wsinfo)
+	r.invalidConnectionContext(wsinfo)
 	log.WithField("workspace", req.Name).WithField("details", wsinfo).Debug("adding/updating workspace details")
 
 	return ctrl.Result{}, nil
+}
+
+func (r *CRDWorkspaceInfoProvider) invalidConnectionContext(ws *common.WorkspaceInfo) {
+	connCtxs, err := r.contextStore.ByIndex(workspaceIndex, ws.WorkspaceID)
+	if err != nil {
+		return
+	}
+	if len(connCtxs) == 0 {
+		return
+	}
+
+	if ws.Auth != nil && ws.Auth.Admission == wsapi.AdmissionLevel_ADMIT_EVERYONE {
+		return
+	}
+	publicPorts := make(map[string]struct{})
+	for _, p := range ws.Ports {
+		if p.Visibility == api.PortVisibility_PORT_VISIBILITY_PUBLIC {
+			publicPorts[strconv.FormatUint(uint64(p.Port), 10)] = struct{}{}
+		}
+	}
+
+	for _, _connCtx := range connCtxs {
+		connCtx, ok := _connCtx.(*ConnectionContext)
+		if !ok {
+			continue
+		}
+		if _, ok := publicPorts[connCtx.Port]; ok {
+			continue
+		}
+		connCtx.CancelFunc(xerrors.Errorf("workspace %s is no longer public", ws.WorkspaceID))
+		r.contextStore.Delete(connCtx.UUID)
+	}
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/components/ws-proxy/pkg/proxy/infoprovider.go
+++ b/components/ws-proxy/pkg/proxy/infoprovider.go
@@ -204,13 +204,13 @@ func (r *CRDWorkspaceInfoProvider) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	r.store.Update(req.Name, wsinfo)
-	r.invalidConnectionContext(wsinfo)
+	r.invalidateConnectionContext(wsinfo)
 	log.WithField("workspace", req.Name).WithField("details", wsinfo).Debug("adding/updating workspace details")
 
 	return ctrl.Result{}, nil
 }
 
-func (r *CRDWorkspaceInfoProvider) invalidConnectionContext(ws *common.WorkspaceInfo) {
+func (r *CRDWorkspaceInfoProvider) invalidateConnectionContext(ws *common.WorkspaceInfo) {
 	connCtxs, err := r.contextStore.ByIndex(workspaceIndex, ws.WorkspaceID)
 	if err != nil {
 		return

--- a/components/ws-proxy/pkg/proxy/routes_test.go
+++ b/components/ws-proxy/pkg/proxy/routes_test.go
@@ -861,6 +861,12 @@ func (p *fakeWsInfoProvider) WorkspaceInfo(workspaceID string) *common.Workspace
 	return nil
 }
 
+func (p *fakeWsInfoProvider) AcquireContext(ctx context.Context, workspaceID string, port string) (context.Context, string, error) {
+	return ctx, "", nil
+}
+func (p *fakeWsInfoProvider) ReleaseContext(id string) {
+}
+
 // WorkspaceCoords returns the workspace coords for a public port.
 func (p *fakeWsInfoProvider) WorkspaceCoords(wsProxyPort string) *common.WorkspaceCoords {
 	for _, info := range p.infos {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR adds a mechanism to disconnect previously unauthenticated connections if the visibility of the workspace or port changes.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-755

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace
2. execute example stream server
3. make port public
4. try using curl `https://workspace-port-url/hello` and open this URL in browser (with login)
5. try to make port private
6. you will observe the curl command will disconnection immediately and browser one is still work.


```js
const express = require('express');
const app = express();

const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

app.get('/hello', async (req, res) => {
    res.write('hello');
    while (true) {
        await sleep(1000);
        res.write('\nhello' + new Date());
    }
})

app.listen(3000, () => {})
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-ent-755</li>
	<li><b>🔗 URL</b> - <a href="https://pd-ent-755.preview.gitpod-dev.com/workspaces" target="_blank">pd-ent-755.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-ent-755-gha.29190</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-ent-755%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
