### PR TITLE
[ws-manager-mk2] include nodeName on failure

### DIFF
--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -124,8 +124,12 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	}
 
 	if failure != "" && !workspace.IsConditionTrue(workspacev1.WorkspaceConditionFailed) {
+		var nodeName string
+		if workspace.Status.Runtime != nil {
+			nodeName = workspace.Status.Runtime.NodeName
+		}
 		// workspaces can fail only once - once there is a failed condition set, stick with it
-		log.Info("workspace failed", "workspace", workspace.Name, "reason", failure)
+		log.Info("workspace failed", "workspace", workspace.Name, "node", nodeName, "reason", failure)
 		workspace.Status.SetCondition(workspacev1.NewWorkspaceConditionFailed(failure))
 		r.Recorder.Event(workspace, corev1.EventTypeWarning, "Failed", failure)
 	}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Include the node name, if available, in workspace failed log entries. This'll help us more easily determine if a single node is poisoned, or if the problem is more wide spread.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://gitpod.slack.com/archives/C01TNS8EVQT/p1727709074376869

## How to test
<!-- Provide steps to test this PR -->

Try starting a workspace, kill registry-facade while the image is pulling:
![image](https://github.com/user-attachments/assets/82c66c3a-97e8-407a-9b81-b483bfc4da77)

Observe [the log entry](https://console.cloud.google.com/logs/query;cursorTimestamp=2024-09-30T18:20:13.798930806Z;duration=PT1H;lfeCustomFields=jsonPayload%252Fkubernetes%252Fcontainer_name;query=--%20without%20protected_secrets%20enabled%0AjsonPayload.kubernetes.host%3D%22preview-kylos101-nodename%22%0A%22workspace%20failed%22%0A--%20jsonPayload.workspaceId%3D%22gitpodio-templatepython-26ftql9iecs%22%0Atimestamp%3D%222024-09-30T18:20:13.798930806Z%22%0AinsertId%3D%221rtmfb4ed38hi%22;summaryFields=jsonPayload%252Fseverity,jsonPayload%252FserviceContext%252Fservice:false:32:beginning?project=gitpod-dev-preview) contains a node name:
![image](https://github.com/user-attachments/assets/60db4979-2689-4690-a28a-0e530a9ac7bd)


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-nodename</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-nodename.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-nodename.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-nodename-gha.29226</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-nodename%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
