### PR TITLE
[ops] Introduce GitpodWsManagerMk2BackupFailureError and GitpodWsManagerMk2BackupFailureCritical

### DIFF
--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -49,7 +49,6 @@ spec:
       labels:
         severity: error
         team: engine
-      for: 1h
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WorkspaceBackupFailures.md
         summary: Workspace backups failed recently in cluster {{ $labels.cluster }}
@@ -60,7 +59,6 @@ spec:
       labels:
         severity: critical
         team: engine
-      for: 1h
       annotations:
         runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WorkspaceBackupFailures.md
         summary: Workspace backups failed recently in cluster {{ $labels.cluster }}

--- a/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
+++ b/operations/observability/mixins/workspace/rules/satellite/workspaces.yaml
@@ -45,3 +45,25 @@ spec:
         sum by(cluster) (avg_over_time(gitpod_workspace_regular_not_active_percentage_mk2[1m]) > 0)
         AND
         sum by(cluster) (rate(gitpod_ws_manager_mk2_workspace_startup_seconds_sum{type="Regular"}[1m])) == 0
+    - alert: GitpodWsManagerMk2BackupFailureError
+      labels:
+        severity: error
+        team: engine
+      for: 1h
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WorkspaceBackupFailures.md
+        summary: Workspace backups failed recently in cluster {{ $labels.cluster }}
+        description: This can happen when a single node has failed in the cloud provider
+      expr: |
+        sum by (cluster) (increase(gitpod_ws_manager_mk2_workspace_backups_failure_total{cluster!~"ephemeral.*"}[1h])) <= 16
+    - alert: GitpodWsManagerMk2BackupFailureCritical
+      labels:
+        severity: critical
+        team: engine
+      for: 1h
+      annotations:
+        runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/WorkspaceBackupFailures.md
+        summary: Workspace backups failed recently in cluster {{ $labels.cluster }}
+        description: This can be an indicator of two or more nodes failing in a cloud provider
+      expr: |
+        sum by (cluster) (increase(gitpod_ws_manager_mk2_workspace_backups_failure_total{cluster!~"ephemeral.*"}[1h])) > 16


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Notify in Slack and PagerDuty when backup failures occur. I'll create a separate PR for Enterprise.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to ENT-839
Relates to https://github.com/gitpod-io/runbooks/pull/433

## How to test
<!-- Provide steps to test this PR -->
Slack notifications will trigger in the future:
![image](https://github.com/user-attachments/assets/8754b30e-6118-4cb0-890d-91fa6680e4d5)

If it gets "bad", so will PagerDuty.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
Slack notifications will trigger in the future:

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
