### PR TITLE
Fix login URL host parsing regression

### DIFF
--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -37,6 +37,26 @@ export function hasLoggedInBefore() {
     return GitpodCookie.isPresent(document.cookie);
 }
 
+const SEGMENT_SEPARATOR = "/";
+const getContextUrlFromHash = (input: string): URL | undefined => {
+    if (typeof URL.canParse !== "function") {
+        return undefined;
+    }
+    if (URL.canParse(input)) {
+        return new URL(input);
+    }
+
+    const chunks = input.split(SEGMENT_SEPARATOR);
+    for (const chunk of chunks) {
+        input = input.replace(`${chunk}${SEGMENT_SEPARATOR}`, "");
+        if (URL.canParse(input)) {
+            return new URL(input);
+        }
+    }
+
+    return undefined;
+};
+
 type LoginProps = {
     onLoggedIn?: () => void;
 };
@@ -56,7 +76,12 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
                 setRepoPathname(url.pathname);
             }
         } catch (error) {
-            // hash is not a valid URL
+            // hash is not a valid URL, try to extract the context URL when there are parts like env vars or other prefixes
+            const contextUrl = getContextUrlFromHash(urlHash);
+            if (contextUrl) {
+                setHostFromContext(contextUrl.host);
+                setRepoPathname(contextUrl.pathname);
+            }
         }
     }, [urlHash]);
 

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -49,10 +49,14 @@ export const Login: FC<LoginProps> = ({ onLoggedIn }) => {
     const enterprise = !!authProviders.data && authProviders.data.length === 0;
 
     useEffect(() => {
-        if (urlHash.length > 0) {
-            const url = new URL(urlHash);
-            setHostFromContext(url.host);
-            setRepoPathname(url.pathname);
+        try {
+            if (urlHash.length > 0) {
+                const url = new URL(urlHash);
+                setHostFromContext(url.host);
+                setRepoPathname(url.pathname);
+            }
+        } catch (error) {
+            // hash is not a valid URL
         }
     }, [urlHash]);
 


### PR DESCRIPTION
## Description

I introduced a regression in #20255 which couldn't handle URL hashes on the login page which weren't URLs. This also meant we couldn't handle logging in with URLs starting with prefixes like `imagebuild/` or `VARIABLE=value`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #20263

## How to test
<!-- Provide steps to test this PR -->

https://ft-fix-log430fae49f1.preview.gitpod-dev.com



/hold
