### PR TITLE
Fix spicedb throwing on invalid arguments

### DIFF
--- a/components/gitpod-protocol/src/util/gitpod-host-url.ts
+++ b/components/gitpod-protocol/src/util/gitpod-host-url.ts
@@ -16,7 +16,7 @@ const baseWorkspaceIDRegex =
     "(([a-f][0-9a-f]{7}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})|([0-9a-z]{2,16}-[0-9a-z]{2,16}-[0-9a-z]{8,11}))";
 
 // this pattern matches v4 UUIDs as well as the new generated workspace ids (e.g. pink-panda-ns35kd21)
-const workspaceIDRegex = RegExp(`^(?:debug-)?${baseWorkspaceIDRegex}$`);
+export const workspaceIDRegex = RegExp(`^(?:debug-)?${baseWorkspaceIDRegex}$`);
 
 // this pattern matches URL prefixes of workspaces
 const workspaceUrlPrefixRegex = RegExp(`^(([0-9]{4,6}|debug)-)?${baseWorkspaceIDRegex}\\.`);

--- a/components/server/src/api/workspace-service-api.ts
+++ b/components/server/src/api/workspace-service-api.ts
@@ -58,6 +58,15 @@ import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messag
 import { ContextService } from "../workspace/context-service";
 import { UserService } from "../user/user-service";
 import { ContextParser } from "../workspace/context-parser-service";
+import { workspaceIDRegex } from "@gitpod/gitpod-protocol/lib/util/gitpod-host-url";
+
+const isWorkspaceId = (workspaceId?: string) => {
+    if (!workspaceId) {
+        return false;
+    }
+
+    return workspaceIDRegex.test(workspaceId);
+};
 
 @injectable()
 export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceInterface> {
@@ -68,8 +77,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
     @inject(ContextParser) private contextParser: ContextParser;
 
     async getWorkspace(req: GetWorkspaceRequest, _: HandlerContext): Promise<GetWorkspaceResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         const info = await this.workspaceService.getWorkspace(ctxUserId(), req.workspaceId);
         const response = new GetWorkspaceResponse();
@@ -198,8 +207,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
 
     async startWorkspace(req: StartWorkspaceRequest): Promise<StartWorkspaceResponse> {
         // We rely on FGA to do the permission checking
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         const user = await this.userService.findUserById(ctxUserId(), ctxUserId());
         const { workspace, latestInstance: instance } = await this.workspaceService.getWorkspace(
@@ -227,8 +236,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
         req: GetWorkspaceDefaultImageRequest,
         _: HandlerContext,
     ): Promise<GetWorkspaceDefaultImageResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         const result = await this.workspaceService.getWorkspaceDefaultImage(ctxUserId(), req.workspaceId);
         const response = new GetWorkspaceDefaultImageResponse({
@@ -246,8 +255,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
     }
 
     async sendHeartBeat(req: SendHeartBeatRequest, _: HandlerContext): Promise<SendHeartBeatResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         const info = await this.workspaceService.getWorkspace(ctxUserId(), req.workspaceId);
         if (!info.latestInstance?.id || info.latestInstance.status.phase !== "running") {
@@ -265,8 +274,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
         req: GetWorkspaceOwnerTokenRequest,
         _: HandlerContext,
     ): Promise<GetWorkspaceOwnerTokenResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         const ownerToken = await this.workspaceService.getOwnerToken(ctxUserId(), req.workspaceId);
         const response = new GetWorkspaceOwnerTokenResponse();
@@ -278,8 +287,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
         req: GetWorkspaceEditorCredentialsRequest,
         _: HandlerContext,
     ): Promise<GetWorkspaceEditorCredentialsResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         const credentials = await this.workspaceService.getIDECredentials(ctxUserId(), req.workspaceId);
         const response = new GetWorkspaceEditorCredentialsResponse();
@@ -288,8 +297,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
     }
 
     async updateWorkspace(req: UpdateWorkspaceRequest): Promise<UpdateWorkspaceResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         if (req.spec?.timeout?.inactivity?.seconds || (req.spec?.sshPublicKeys && req.spec?.sshPublicKeys.length > 0)) {
             throw new ApplicationError(ErrorCodes.UNIMPLEMENTED, "not implemented");
@@ -363,8 +372,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
     }
 
     async stopWorkspace(req: StopWorkspaceRequest): Promise<StopWorkspaceResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         await this.workspaceService.stopWorkspace(ctxUserId(), req.workspaceId, "stopped via API");
         const response = new StopWorkspaceResponse();
@@ -372,8 +381,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
     }
 
     async deleteWorkspace(req: DeleteWorkspaceRequest): Promise<DeleteWorkspaceResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         await this.workspaceService.deleteWorkspace(ctxUserId(), req.workspaceId, "user");
         const response = new DeleteWorkspaceResponse();
@@ -389,8 +398,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
     }
 
     async createWorkspaceSnapshot(req: CreateWorkspaceSnapshotRequest): Promise<CreateWorkspaceSnapshotResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         const snapshot = await this.workspaceService.takeSnapshot(ctxUserId(), {
             workspaceId: req.workspaceId,
@@ -410,8 +419,8 @@ export class WorkspaceServiceAPI implements ServiceImpl<typeof WorkspaceServiceI
     }
 
     async updateWorkspacePort(req: UpdateWorkspacePortRequest): Promise<UpdateWorkspacePortResponse> {
-        if (!req.workspaceId) {
-            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "workspaceId is required");
+        if (!isWorkspaceId(req.workspaceId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "a valid workspaceId is required");
         }
         if (!req.port) {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "port is required");

--- a/components/server/src/authorization/spicedb-authorizer.ts
+++ b/components/server/src/authorization/spicedb-authorizer.ts
@@ -15,6 +15,7 @@ import { base64decode } from "@jmondi/oauth2-server";
 import { DecodedZedToken } from "@gitpod/spicedb-impl/lib/impl/v1/impl.pb";
 import { ctxTryGetCache, ctxTrySetCache } from "../util/request-context";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
+import { isGrpcError } from "@gitpod/gitpod-protocol/lib/util/grpc";
 
 async function tryThree<T>(errMessage: string, code: (attempt: number) => Promise<T>): Promise<T> {
     let attempt = 0;
@@ -104,6 +105,9 @@ export class SpiceDBAuthorizer {
                 const permitted = response.permissionship === v1.CheckPermissionResponse_Permissionship.HAS_PERMISSION;
                 return { permitted, checkedAt: response.checkedAt?.token };
             } catch (err) {
+                if (isGrpcError(err) && err.code === grpc.status.INVALID_ARGUMENT) {
+                    throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Invalid request for permission check: ${err}`);
+                }
                 error = err;
                 log.error("[spicedb] Failed to perform authorization check.", err, {
                     request: new TrustedValue(req),

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -248,7 +248,7 @@ export class WorkspaceService {
         const res = await this.db.find({
             limit: 20,
             ...options,
-            userId, // gpl: We probably want to removed this limitation in the future, butkeeping the old behavior for now due to focus on FGA
+            userId, // gpl: We probably want to removed this limitation in the future, but keeping the old behavior for now due to focus on FGA
             includeHeadless: false,
         });
 


### PR DESCRIPTION
## Description

If you called `WorkspaceService.GetWorkspace` with `workspaceId: valid-workspace-id?hello`, we would let SpiceDB throw an exception, because `checkPermission` would fail. This PR fixes that from 2 fronts:
1. We no longer consider SpiceDB returning `INVALID_ARGUMENT` a system exception and instead throw a `ErrorCodes.BAD_REQUEST`.
2. We now validate workspace IDs on every `WorkspaceService` method that needs it using a Regex that seems to have worked for us for ~ 2 years. 
 
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-842

## How to test

Make a request to some API under `WorkspaceServer` with an invalid workspace ID, you should get back "a valid workspaceId is required" 

```
curl 'https://ft-fix-spi5a78964ae9.preview.gitpod-dev.com/public-api/gitpod.v1.WorkspaceService/GetWorkspace' --compressed -X POST -H 'content-type: application/json' -H 'Origin: https://ft-fix-spi5a78964ae9.preview.gitpod-dev.com' -H 'Cookie: __Host-_ft_fix_spi5a78964ae9_preview_gitpod_dev_com_jwt2_=ey[...]' --data-raw '{"pagination":{"pageSize":50},"organizationId":"3e213667-9617-4020-99bd-e3b5ceba3999", "workspaceId": "gitpoddemos-springpetcl-pi2uhnyqm20?aaa"}'
```

For requests to other resources or things that this validity check just doesn't catch, the error message will be similar to the following:
```json
{"code":"invalid_argument","message":"Invalid request for permission check: Error: 3 INVALID_ARGUMENT: invalid CheckPermissionRequest.Resource: embedded message failed validation | caused by: invalid ObjectReference.ObjectId: value does not match regex pattern \"^(([a-zA-Z0-9/_|\\\\-=+]{1,})|\\\\*)$\""}                                                             
```