### PR TITLE
Fix docs URLs

### DIFF
--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -200,7 +200,7 @@ const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, withFeedb
             },
             {
                 title: "Docs",
-                href: "https://www.gitpod.io/docs/",
+                href: "https://www.gitpod.io/docs/introduction",
                 target: "_blank",
                 rel: "noreferrer",
             },

--- a/components/dashboard/src/workspaces/Workspaces.tsx
+++ b/components/dashboard/src/workspaces/Workspaces.tsx
@@ -188,7 +188,7 @@ const WorkspacesPage: FunctionComponent = () => {
                                         <h3 className="text-lg font-semibold text-pk-content-primary">Documentation</h3>
                                         <div className="flex flex-col gap-1 w-fit">
                                             <a
-                                                href="https://www.gitpod.io/docs"
+                                                href="https://www.gitpod.io/docs/introduction"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 className="text-sm text-pk-content-primary items-center gap-x-2 flex flex-row"

--- a/components/gitpod-cli/cmd/docs.go
+++ b/components/gitpod-cli/cmd/docs.go
@@ -9,7 +9,7 @@ import (
 )
 
 // URL of the Gitpod documentation
-const DocsUrl = "https://www.gitpod.io/docs"
+const DocsUrl = "https://www.gitpod.io/docs/introduction"
 
 var docsCmd = &cobra.Command{
 	Use:   "docs",


### PR DESCRIPTION
## Description

Because the base `/docs` path now redirects to Flex docs, this change makes all of our links to the docs end up on the Enterprise version instead, so that it doesn't get too confusing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-856
