### PR TITLE
Disable JetBrains local ports forwarding with FF

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
@@ -99,13 +99,13 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
         return completableFuture
     }
 
-    private fun isPortExposingDisabled(): Boolean {
-        return System.getenv("GITPOD_DISABLE_JETBRAINS_LOCAL_PORT_EXPOSE")?.toBoolean() ?: false
+    private fun isLocalPortForwardingDisabled(): Boolean {
+        return System.getenv("GITPOD_DISABLE_JETBRAINS_LOCAL_PORT_FORWARDING")?.toBoolean() ?: false
     }
 
     private fun syncPortsListWithClient(response: Status.PortsStatusResponse) {
-        if (isPortExposingDisabled()) {
-            thisLogger().warn("gitpod: Port exposing is disabled.")
+        if (isLocalPortForwardingDisabled()) {
+            thisLogger().warn("gitpod: Local port forwarding is disabled.")
             return
         }
         val ignoredPorts = ignoredPortsForNotificationService.getIgnoredPorts()

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
@@ -13,7 +13,6 @@ import com.intellij.util.application
 import com.jetbrains.rd.platform.codeWithMe.portForwarding.*
 import com.jetbrains.rd.util.URI
 import com.jetbrains.rd.util.lifetime.Lifetime
-import com.jetbrains.rd.util.threading.coroutines.launch
 import io.gitpod.supervisor.api.Status
 import io.gitpod.supervisor.api.Status.PortsStatus
 import io.gitpod.supervisor.api.StatusServiceGrpc
@@ -101,34 +100,34 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
     }
 
     private fun syncPortsListWithClient(response: Status.PortsStatusResponse) {
-        val ignoredPorts = ignoredPortsForNotificationService.getIgnoredPorts()
-        val portsList = response.portsList.filter { !ignoredPorts.contains(it.localPort) }
-        val portsNumbersFromPortsList = portsList.map { it.localPort }
-        val servedPorts = portsList.filter { it.served }
-        val exposedPorts = servedPorts.filter { it.exposed?.url?.isNotBlank() ?: false }
-        val portsNumbersFromNonServedPorts = portsList.filter { !it.served }.map { it.localPort }
-        val servedPortsToStartForwarding = servedPorts.filter {
-            perClientPortForwardingManager.getPorts(it.localPort).none { p -> p.labels.contains(FORWARDED_PORT_LABEL) }
-        }
-        val exposedPortsToStartExposingOnClient = exposedPorts.filter {
-            perClientPortForwardingManager.getPorts(it.localPort).none { p -> p.labels.contains(EXPOSED_PORT_LABEL) }
-        }
-        val forwardedPortsToStopForwarding = perClientPortForwardingManager.getPorts(FORWARDED_PORT_LABEL)
-                .map { it.hostPortNumber }
-                .filter { portsNumbersFromNonServedPorts.contains(it) || !portsNumbersFromPortsList.contains(it) }
-        val exposedPortsToStopExposingOnClient = perClientPortForwardingManager.getPorts(EXPOSED_PORT_LABEL)
-                .map { it.hostPortNumber }
-                .filter { portsNumbersFromNonServedPorts.contains(it) || !portsNumbersFromPortsList.contains(it) }
-
-        servedPortsToStartForwarding.forEach { startForwarding(it) }
-
-        exposedPortsToStartExposingOnClient.forEach { startExposingOnClient(it) }
-
-        forwardedPortsToStopForwarding.forEach { stopForwarding(it) }
-
-        exposedPortsToStopExposingOnClient.forEach { stopExposingOnClient(it) }
-
-        portsList.forEach { updatePortsPresentation(it) }
+//        val ignoredPorts = ignoredPortsForNotificationService.getIgnoredPorts()
+//        val portsList = response.portsList.filter { !ignoredPorts.contains(it.localPort) }
+//        val portsNumbersFromPortsList = portsList.map { it.localPort }
+//        val servedPorts = portsList.filter { it.served }
+//        val exposedPorts = servedPorts.filter { it.exposed?.url?.isNotBlank() ?: false }
+//        val portsNumbersFromNonServedPorts = portsList.filter { !it.served }.map { it.localPort }
+//        val servedPortsToStartForwarding = servedPorts.filter {
+//            perClientPortForwardingManager.getPorts(it.localPort).none { p -> p.labels.contains(FORWARDED_PORT_LABEL) }
+//        }
+//        val exposedPortsToStartExposingOnClient = exposedPorts.filter {
+//            perClientPortForwardingManager.getPorts(it.localPort).none { p -> p.labels.contains(EXPOSED_PORT_LABEL) }
+//        }
+//        val forwardedPortsToStopForwarding = perClientPortForwardingManager.getPorts(FORWARDED_PORT_LABEL)
+//                .map { it.hostPortNumber }
+//                .filter { portsNumbersFromNonServedPorts.contains(it) || !portsNumbersFromPortsList.contains(it) }
+//        val exposedPortsToStopExposingOnClient = perClientPortForwardingManager.getPorts(EXPOSED_PORT_LABEL)
+//                .map { it.hostPortNumber }
+//                .filter { portsNumbersFromNonServedPorts.contains(it) || !portsNumbersFromPortsList.contains(it) }
+//
+//        servedPortsToStartForwarding.forEach { startForwarding(it) }
+//
+//        exposedPortsToStartExposingOnClient.forEach { startExposingOnClient(it) }
+//
+//        forwardedPortsToStopForwarding.forEach { stopForwarding(it) }
+//
+//        exposedPortsToStopExposingOnClient.forEach { stopExposingOnClient(it) }
+//
+//        portsList.forEach { updatePortsPresentation(it) }
     }
 
     private fun startForwarding(portStatus: PortsStatus) {

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
@@ -40,6 +40,10 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
     private fun start() {
         if (application.isHeadlessEnvironment) return
 
+        if (isLocalPortForwardingDisabled()) {
+            thisLogger().warn("gitpod: Local port forwarding is disabled.")
+        }
+
         observePortsListWhileProjectIsOpen()
     }
 
@@ -104,10 +108,6 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
     }
 
     private fun syncPortsListWithClient(response: Status.PortsStatusResponse) {
-        if (isLocalPortForwardingDisabled()) {
-            thisLogger().warn("gitpod: Local port forwarding is disabled.")
-            return
-        }
         val ignoredPorts = ignoredPortsForNotificationService.getIgnoredPorts()
         val portsList = response.portsList.filter { !ignoredPorts.contains(it.localPort) }
         val portsNumbersFromPortsList = portsList.map { it.localPort }
@@ -139,6 +139,9 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
     }
 
     private fun startForwarding(portStatus: PortsStatus) {
+        if (isLocalPortForwardingDisabled()) {
+            return
+        }
         try {
             perClientPortForwardingManager.forwardPort(
                 portStatus.localPort,

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1559,7 +1559,7 @@ export class WorkspaceStarter {
             client
                 .getValueAsync("supervisor_set_java_processor_count", false, { user })
                 .then((v) => newEnvVar("GITPOD_IS_SET_JAVA_PROCESSOR_COUNT", String(v))),
-            client.getValueAsync("disable_jetbrains_local_port_expose", false, { user }).then((v) => newEnvVar("GITPOD_DISABLE_JETBRAINS_LOCAL_PORT_EXPOSE", String(v)))
+            client.getValueAsync("disable_jetbrains_local_port_forwarding", false, { user }).then((v) => newEnvVar("GITPOD_DISABLE_JETBRAINS_LOCAL_PORT_FORWARDING", String(v)))
         ]);
         sysEnvvars.push(isSetJavaXmx);
         sysEnvvars.push(isSetJavaProcessorCount);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1552,18 +1552,20 @@ export class WorkspaceStarter {
         sysEnvvars.push(orgIdEnv);
 
         const client = getExperimentsClientForBackend();
-        const [isSetJavaXmx, isSetJavaProcessorCount, disableJetBrainsPortExpose] = await Promise.all([
+        const [isSetJavaXmx, isSetJavaProcessorCount, disableJetBrainsLocalPortForwarding] = await Promise.all([
             client
                 .getValueAsync("supervisor_set_java_xmx", false, { user })
                 .then((v) => newEnvVar("GITPOD_IS_SET_JAVA_XMX", String(v))),
             client
                 .getValueAsync("supervisor_set_java_processor_count", false, { user })
                 .then((v) => newEnvVar("GITPOD_IS_SET_JAVA_PROCESSOR_COUNT", String(v))),
-            client.getValueAsync("disable_jetbrains_local_port_forwarding", false, { user }).then((v) => newEnvVar("GITPOD_DISABLE_JETBRAINS_LOCAL_PORT_FORWARDING", String(v)))
+            client
+                .getValueAsync("disable_jetbrains_local_port_forwarding", false, { user })
+                .then((v) => newEnvVar("GITPOD_DISABLE_JETBRAINS_LOCAL_PORT_FORWARDING", String(v))),
         ]);
         sysEnvvars.push(isSetJavaXmx);
         sysEnvvars.push(isSetJavaProcessorCount);
-        sysEnvvars.push(disableJetBrainsPortExpose);
+        sysEnvvars.push(disableJetBrainsLocalPortForwarding);
         const spec = new StartWorkspaceSpec();
         await createGitpodTokenPromise;
         spec.setEnvvarsList(envvars);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1552,16 +1552,18 @@ export class WorkspaceStarter {
         sysEnvvars.push(orgIdEnv);
 
         const client = getExperimentsClientForBackend();
-        const [isSetJavaXmx, isSetJavaProcessorCount] = await Promise.all([
+        const [isSetJavaXmx, isSetJavaProcessorCount, disableJetBrainsPortExpose] = await Promise.all([
             client
                 .getValueAsync("supervisor_set_java_xmx", false, { user })
                 .then((v) => newEnvVar("GITPOD_IS_SET_JAVA_XMX", String(v))),
             client
                 .getValueAsync("supervisor_set_java_processor_count", false, { user })
                 .then((v) => newEnvVar("GITPOD_IS_SET_JAVA_PROCESSOR_COUNT", String(v))),
+            client.getValueAsync("disable_jetbrains_local_port_expose", false, { user }).then((v) => newEnvVar("GITPOD_DISABLE_JETBRAINS_LOCAL_PORT_EXPOSE", String(v)))
         ]);
         sysEnvvars.push(isSetJavaXmx);
         sysEnvvars.push(isSetJavaProcessorCount);
+        sysEnvvars.push(disableJetBrainsPortExpose);
         const spec = new StartWorkspaceSpec();
         await createGitpodTokenPromise;
         spec.setEnvvarsList(envvars);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-826

## How to test
<!-- Provide steps to test this PR -->
- Try to enable or disable [FeatureFlag](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853?settingId=567437)
- Restart or create workspace with IntelliJ IDEA (latest or stable, but not pinned) after update FF (needs server aware FF changes, i.e. after 5 minutes)
- Check ports view, ports should not expose to local (or access `localhost:<port>`)

|Disabled Ports Exposing|Enabled|
|:-:|:-:|
|<img width="1578" alt="SCR-20241009-opju" src="https://github.com/user-attachments/assets/4f7f583b-47e8-4e00-82fb-77187d661afd">|<img width="1473" alt="SCR-20241009-oros" src="https://github.com/user-attachments/assets/7812bd58-13cc-43a2-8fd6-b3794d1d6332">|


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-pf</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-pf.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-pf.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-pf-gha.29393</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-pf%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
