### PR TITLE
Update Open VSX extension control manifest

### DIFF
--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -11,10 +11,10 @@ COPY components-local-app--app-with-manifest/bin/* /bin/
 
 RUN for FILE in `ls /bin/gitpod-local-companion*`;do \
   gzip -v -f -9 -k "$FILE"; \
-done
+  done
 
 RUN mkdir -p static/code
-RUN curl -o static/code/marketplace.json "https://raw.githubusercontent.com/open-vsx/publish-extensions/dfa20ca6716282d799c58d10751f94cbc3471775/extension-control/extensions.json"
+RUN curl -o static/code/marketplace.json "https://raw.githubusercontent.com/open-vsx/publish-extensions/e5c7f0ac781b430049c9f07fed10ee5c388b0097/extension-control/extensions.json"
 
 FROM caddy/caddy:2.7.6-alpine
 


### PR DESCRIPTION
## Description

A regular update of the extension control manifest, pointing to https://github.com/open-vsx/publish-extensions/commit/e5c7f0ac781b430049c9f07fed10ee5c388b0097.

No testing is required for this change.