### PR TITLE
Improve repository finder search URL validation

### DIFF
--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
@@ -5,7 +5,7 @@
  */
 
 import { SuggestedRepository } from "@gitpod/public-api/lib/gitpod/v1/scm_pb";
-import { deduplicateAndFilterRepositories } from "./unified-repositories-search-query";
+import { deduplicateAndFilterRepositories, isValidGitUrl } from "./unified-repositories-search-query";
 
 function repo(name: string, project?: string): SuggestedRepository {
     return new SuggestedRepository({
@@ -94,4 +94,27 @@ test("it should return all repositories without duplicates when excludeProjects 
     expect(deduplicated.length).toEqual(2);
     expect(deduplicated[0].repoName).toEqual("foo");
     expect(deduplicated[1].repoName).toEqual("bar");
+});
+
+test("should perform weak validation for git URLs", () => {
+    expect(isValidGitUrl("a:")).toEqual(false);
+    expect(isValidGitUrl("a:b")).toEqual(false);
+    expect(isValidGitUrl("https://b")).toEqual(false);
+    expect(isValidGitUrl("https://b/repo.git")).toEqual(false);
+    expect(isValidGitUrl("https://b.com/repo.git")).toEqual(true);
+    expect(isValidGitUrl("git@a.b:")).toEqual(false);
+    expect(isValidGitUrl("blib@a.b:")).toEqual(false);
+    expect(isValidGitUrl("blib@a.b:22:")).toEqual(false);
+
+    // some "from the wild" cases
+    expect(isValidGitUrl("https://github.com/gitpod-io/gitpod/pull/20281")).toEqual(true);
+    expect(isValidGitUrl("https://gitlab.com/filiptronicek/gitpod.git")).toEqual(true);
+    expect(isValidGitUrl("git@github.com:gitpod-io/gitpod.git")).toEqual(true);
+    expect(isValidGitUrl("git@gitlab.com:filiptronicek/gitpod.git")).toEqual(true);
+    expect(isValidGitUrl("ssh://login@server.com:12345/~/repository.git")).toBe(true);
+    expect(isValidGitUrl("https://bitbucket.gitpod-dev.com/scm/~geropl/test-user-repo.git")).toBe(true);
+    expect(isValidGitUrl("git://gitlab.com/gitpod/spring-petclinic")).toBe(true);
+    expect(isValidGitUrl("git@ssh.dev.azure.com:v3/services-azure/open-to-edit-project2/open-to-edit-project2")).toBe(
+        true,
+    );
 });

--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.test.ts
@@ -105,6 +105,7 @@ test("should perform weak validation for git URLs", () => {
     expect(isValidGitUrl("git@a.b:")).toEqual(false);
     expect(isValidGitUrl("blib@a.b:")).toEqual(false);
     expect(isValidGitUrl("blib@a.b:22:")).toEqual(false);
+    expect(isValidGitUrl("blib@a.b:g/g")).toEqual(true);
 
     // some "from the wild" cases
     expect(isValidGitUrl("https://github.com/gitpod-io/gitpod/pull/20281")).toEqual(true);

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -214,7 +214,7 @@ export class ReplayableEventEmitter<EventTypes extends EventMap> extends EventEm
     }
 }
 
-function parseUrl(url: string): URL | null {
+export function parseUrl(url: string): URL | null {
     try {
         return new URL(url);
     } catch (_) {


### PR DESCRIPTION
## Description

Adds generic validation for git URLs when inputting into the "New Workspace" repository search bar.

Supported are both full URLs (https://, http://, ssh://, git://) as well as SSH clone URLs (like `git@github.com:gitpod-io/gitpod.git`).

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-596

## How to test

1. See tests I added for this
2. Go to https://ft-better-374e81d1de.preview.gitpod-dev.com/new and play around with the input