### PR TITLE
[JetBrains] improve handling of client connection termination

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -313,8 +313,13 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                     clientHandle.clientClosed.advise(connectionLifetime) {
                                         // Been canceled by user
                                         if (!canceledByGitpod) {
-                                            application.invokeLater {
-                                                connectionLifetime.terminate()
+                                            connectionLifetime.launch {
+                                                // Delay for 5 seconds to see if thinClient could be terminated in time
+                                                // Then we don't see error dialog from Gateway
+                                                delay(5000)
+                                                application.invokeLater {
+                                                    connectionLifetime.terminate()
+                                                }
                                             }
                                             return@advise
                                         }

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -297,7 +297,11 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                     )
                                     clientHandle.clientClosed.advise(connectionLifetime) {
                                         application.invokeLater {
-                                            connectionLifetime.terminate()
+                                            GlobalScope.launch {
+                                                // Delay for 5 seconds to wait the thinClient actually close
+                                                delay(5000)
+                                                connectionLifetime.terminate()
+                                            }
                                         }
                                     }
                                     clientHandle.onClientPresenceChanged.advise(connectionLifetime) {

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnectionProvider.kt
@@ -41,6 +41,7 @@ import com.jetbrains.rd.util.ConcurrentHashMap
 import com.jetbrains.rd.util.URI
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.lifetime.LifetimeDefinition
+import com.jetbrains.rd.util.threading.coroutines.launch
 import io.gitpod.gitpodprotocol.api.entities.WorkspaceInstance
 import io.gitpod.jetbrains.gateway.common.GitpodConnectionHandleFactory
 import io.gitpod.jetbrains.icons.GitpodIcons
@@ -329,7 +330,7 @@ class GitpodConnectionProvider : GatewayConnectionProvider {
                                             return true
                                         }
                                         // Check if it's timed out, if so, show timed out dialog
-                                        GlobalScope.launch {
+                                        connectionLifetime.launch {
                                             val isInStoppedPhase = waitUntilStopped()
                                             val isTimedOut = isInStoppedPhase && phaseMessage.text == "Timed Out"
                                             application.invokeLater {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

- Connection provider will wait until workspace is stopped then terminate itself
  - If the stopped is due to Timed out then we will show a timed out dialog
- If user close connection himself, we wait for 5 seconds

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-804

## How to test
<!-- Provide steps to test this PR -->

**Smoke test Gitpod Gateway Plugin**
- Use Gateway 2024.2.3 beta
- Download matching version of Gitpod Plugin (contains branch name) in Dev channel https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev
- Install Plugin manually with matching Gateway version
- **Quit Gateway after Plugin is installed**
- Open a workspace in any Gitpod installation (i.e. catfood) with IntelliJ IDEA as your editor
- Click 'Open in IntelliJ IDEA' after workspace is ready
- Set workspace timeout duration to 1 minute `gp timeout set 1m`
- Wait 1 minute (more?)
- You should see a time out dialog
- You should not see `Connection Closed by Gateway: Restart the connect via JetBrains Gateway`


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
