### PR TITLE
Fix constant Gitpod Plugin exception on Gateway startup

### DIFF
--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/auth/GitpodAuthCallbackHandler.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/auth/GitpodAuthCallbackHandler.kt
@@ -16,7 +16,7 @@ import org.jetbrains.io.response
 import java.nio.charset.StandardCharsets
 
 internal class GitpodAuthCallbackHandler : RestService() {
-    private val service = GitpodAuthService.instance
+    private val service = GitpodAuthService.instance.get()
 
     override fun getServiceName(): String = service.name
 

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/auth/GitpodAuthService.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/auth/GitpodAuthService.kt
@@ -17,8 +17,10 @@ import com.intellij.credentialStore.CredentialAttributes
 import com.intellij.credentialStore.generateServiceName
 import com.intellij.ide.passwordSafe.PasswordSafe
 import com.intellij.openapi.Disposable
+import com.intellij.openapi.application.CachedSingletonsRegistry
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.util.EventDispatcher
 import com.intellij.util.Url
 import com.intellij.util.Urls.encodeParameters
@@ -35,6 +37,7 @@ import java.net.http.HttpResponse
 import java.security.SecureRandom
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.function.Supplier
 import kotlin.math.absoluteValue
 
 @Service
@@ -148,7 +151,8 @@ internal class GitpodAuthService : OAuthServiceBase<Credentials>() {
     }
 
     companion object {
-        val instance: GitpodAuthService = service()
+        @Suppress("UnstableApiUsage")
+        val instance: Supplier<GitpodAuthService> = CachedSingletonsRegistry.lazy { service() }
 
         private const val SERVICE_NAME = "gitpod/oauth"
         private const val CLIENT_ID = "jetbrains-gateway-gitpod-plugin"
@@ -176,7 +180,7 @@ internal class GitpodAuthService : OAuthServiceBase<Credentials>() {
         }
 
         suspend fun authorize(gitpodHost: String): String {
-            val accessToken = instance.authorize(gitpodHost).await().accessToken
+            val accessToken = instance.get().authorize(gitpodHost).await().accessToken
             setAccessToken(gitpodHost, accessToken)
             return accessToken
         }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes ENT-865

## How to test
<!-- Provide steps to test this PR -->

**Smoke test Gitpod Gateway Plugin**
- Use EAP Gateway
- Download matching version of Gitpod Plugin (contains branch name) in Dev channel https://plugins.jetbrains.com/plugin/18438-gitpod-gateway/versions/dev
- Install Plugin manually with matching Gateway version
- There should show no error red dot on right bottom of Gateway UI
- Auth flow should work well


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [x] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
