### PR TITLE
Don't report `supervisor_check_ready` unless the FF is enabled

### DIFF
--- a/components/supervisor/frontend/src/ide/supervisor-service-client.ts
+++ b/components/supervisor/frontend/src/ide/supervisor-service-client.ts
@@ -81,6 +81,10 @@ export class SupervisorServiceClient {
 
         // track whenever a) we are done, or b) we try to connect (again)
         const trackCheckReady = (p: { aborted?: boolean }, err?: any): void => {
+            if (!this.serviceClient.isCheckReadyRetryEnabled()) {
+                return;
+            }
+
             const props: Record<string, string> = {
                 component: "supervisor-frontend",
                 instanceId: this.serviceClient.latestInfo?.instanceId ?? "",


### PR DESCRIPTION
## Description

When `supervisor_check_ready_retry` is disabled, don't report any `supervisor_check_ready` events.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C071G5TTS49/p1728468748822559

## How to test

You can try opening a workspace on https://ft-limit-sb2f59260e6.preview.gitpod-dev.com/workspaces and inspecting the network tab for outgoing `trackEvent` requests.

/hold
