### PR TITLE
Repository finder & context parsing improvements

### DIFF
--- a/components/dashboard/src/components/podkit/combobox/Combobox.tsx
+++ b/components/dashboard/src/components/podkit/combobox/Combobox.tsx
@@ -84,11 +84,14 @@ export const Combobox: FunctionComponent<ComboboxProps> = ({
 
     const setActiveElement = useCallback(
         (element: string) => {
+            if (!filteredOptions.find((el) => element === el.id)?.isSelectable) {
+                return;
+            }
             setSelectedElementTemp(element);
             const el = document.getElementById(element);
             el?.scrollIntoView({ block: "nearest" });
         },
-        [setSelectedElementTemp],
+        [filteredOptions],
     );
 
     const handleOpenChange = useCallback(

--- a/components/server/src/workspace/context-parser-service.ts
+++ b/components/server/src/workspace/context-parser-service.ts
@@ -11,6 +11,7 @@ import { IPrefixContextParser, IContextParser } from "./context-parser";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { ConfigProvider } from "./config-provider";
 import { InvalidGitpodYMLError } from "@gitpod/public-api-common/lib/public-api-errors";
+import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 
 @injectable()
 export class ContextParser {
@@ -83,7 +84,10 @@ export class ContextParser {
                 }
             }
             if (!result) {
-                throw new Error(`Couldn't parse context '${nonPrefixedContextURL}'.`);
+                throw new ApplicationError(
+                    ErrorCodes.BAD_REQUEST,
+                    `Couldn't parse context '${nonPrefixedContextURL}'.`,
+                );
             }
 
             // TODO: Make the parsers return the context with normalizedContextURL set


### PR DESCRIPTION
## Description

Makes bad requests against our context parser, no longer page folks.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C01TNS8EVQT/p1728825373116179

## How to test

1. Try going to https://ft-fix-dasd89bbe5f6e.preview.gitpod-dev.com/new#bitbucket-server. `ParseContextURL` should respond with a 400 and not a 500 in the network tab of DevTools.