### PR TITLE
Fix stable code build

### DIFF
--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -69,6 +69,7 @@ jobs:
               - [ ] test `gp open` and `gp preview`
               - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
               - [ ] telemetry data like `vscode_extension_gallery` is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)
+              - [ ] test using `ubuntu 18` is working well, [example repo](https://github.com/jeanp413/test-gp-prebuild/tree/jp/damaged-aardwolf)
 
             ### Preview status
             gitpod:summary

--- a/components/ide/code/BUILD.yaml
+++ b/components/ide/code/BUILD.yaml
@@ -25,7 +25,7 @@ packages:
       - codeQuality
       - codeVersion
     config:
-      dockerfile: leeway.Dockerfile
+      dockerfile: leeway.nightly.Dockerfile
       metadata:
         helm-component: workspace.codeImage
       buildArgs:

--- a/components/ide/code/leeway.nightly.Dockerfile
+++ b/components/ide/code/leeway.nightly.Dockerfile
@@ -125,16 +125,16 @@ RUN nameShort=$(jq --raw-output '.nameShort' product.json) && \
     mv product.json.tmp product.json && \
     jq '{quality,nameLong,nameShort}' product.json
 
-RUN npm run gulp compile-build \
-    && npm run gulp extensions-ci \
-    && npm run gulp minify-vscode-reh \
-    && npm run gulp vscode-web-min-ci \
-    && npm run gulp vscode-reh-linux-x64-min-ci
+RUN npm run gulp compile-build
+RUN npm run gulp extensions-ci
+RUN npm run gulp minify-vscode-reh
+RUN npm run gulp vscode-web-min-ci
+RUN npm run gulp vscode-reh-linux-x64-min-ci
 
 # config for first layer needed by blobserve
 # this custom urls will be then replaced by blobserve.
 # Check pkg/blobserve/blobserve.go, `inlineVars` method
-RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.esm.html /vscode-web/index.html \
+RUN cp /vscode-web/out/vs/gitpod/browser/workbench/workbench.html /vscode-web/index.html \
 && cp /vscode-web/out/vs/gitpod/browser/workbench/callback.html /vscode-web/callback.html \
 && sed -i -e "s/{{VERSION}}/$CODE_QUALITY-$CODE_COMMIT/g" /vscode-web/index.html
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Follow up for https://github.com/gitpod-io/gitpod/pull/20308#issuecomment-2425919457 and [internal chat](https://gitpod.slack.com/archives/C045J13P8A1/p1729291383860729?thread_ts=1728919134.138729&cid=C045J13P8A1)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
No need, or you could compare the changes between code > `leeway.Dockerfile` and `leeway.nightly.Dockerfile`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
