### PR TITLE
[gha] update gateway EAP plugin to use `build` instead of `version`

### DIFF
--- a/components/ide/gha-update-image/lib/jb-helper/jb-gradle-task-config.ts
+++ b/components/ide/gha-update-image/lib/jb-helper/jb-gradle-task-config.ts
@@ -5,6 +5,9 @@ import { parseArgs } from "util";
 
 export type TaskInfo = TargetInfo & { id: number; taskName: string };
 
+// Official doc https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html#target-versions-installers:~:text=The%20listing%20of%20all%20present%20installers%20can%20be%20resolved%20with%20updates%20XML%20files%20for%20JetBrains%20IDEs%20and%20Android%20Studio%20as%20well%20as%20by%20executing%20the%20printProductsReleases%20task.
+// But use https://data.services.jetbrains.com/products/releases?code=GW&type=eap,rc,release&platform=linux seems better
+
 export const latestBackendPluginGradleTarget: TaskInfo = {
     id: 1,
     taskName: "Latest Backend Plugin",
@@ -24,7 +27,7 @@ pluginUntilBuild={{pluginUntilBuild}}
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions={{pluginVerifierIdeVersions}}
-# Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
+# Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/updates/updates.xml or exec \`./gradlew printProductsReleases\`
 platformVersion={{platformVersion}}
 `,
 };
@@ -35,7 +38,7 @@ export const latestGatewayPluginGradleTarget: TaskInfo = {
     productId: "gateway",
     productCode: "GW",
     productType: "eap,rc,release",
-    usePlatformVersionType: "version",
+    usePlatformVersionType: "build",
     gradlePropertiesPath: path.resolve(
         pathToProjectRoot,
         "components/ide/jetbrains/gateway-plugin/gradle-latest.properties",
@@ -48,7 +51,7 @@ pluginUntilBuild={{pluginUntilBuild}}
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions={{pluginVerifierIdeVersions}}
-# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
+# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/updates/updates.xml or exec \`./gradlew printProductsReleases\`
 platformVersion={{platformVersion}}
 `,
 };
@@ -72,7 +75,7 @@ pluginUntilBuild={{pluginUntilBuild}}
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions={{pluginVerifierIdeVersions}}
-# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/updates/updates.xml
+# Version from "com.jetbrains.gateway" which can be found at https://www.jetbrains.com/updates/updates.xml or exec \`./gradlew printProductsReleases\`
 platformVersion={{platformVersion}}
 `,
 };

--- a/components/ide/gha-update-image/lib/jb-helper/jb-helper.ts
+++ b/components/ide/gha-update-image/lib/jb-helper/jb-helper.ts
@@ -35,6 +35,12 @@ export interface TargetInfo {
      * @example eap,rc,release
      */
     productType: string;
+    /**
+     * Examples value for different type:
+     * - build 243.18137.22
+     * - version 2024.3
+     * - build-snapshot 243.18137-EAP-CANDIDATE-SNAPSHOT
+     */
     usePlatformVersionType: "build" | "version" | "build-snapshot";
     gradlePropertiesPath: string;
     gradlePropertiesTemplate: string;


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
There're some back and forth, I'm not quite sure how they define it but can confirm we need to use `build` for Gateway Plugin (EAP) now

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/pull/20301 that it should not use `version`

## How to test
<!-- Provide steps to test this PR -->
No need to test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
