### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,15 +13,15 @@ defaultArgs:
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
   xtermCommit: d547d4ff4590b66c3ea24342fc62e3afcf6b77bc
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.3.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.4.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.2.3.tar.gz"
-  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.2.3.tar.gz"
-  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.2.3.tar.gz"
-  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.2.3.tar.gz"
-  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.2.3.tar.gz"
+  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.2.4.tar.gz"
+  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.2.4.tar.gz"
+  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.2.4.tar.gz"
+  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.2.4.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.4.tar.gz"
-  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.2.2.tar.gz"
-  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2024.2.3.tar.gz"
+  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.2.3.tar.gz"
+  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2024.2.4.tar.gz"
   jbBackendVersion: "latest"
   dockerVersion: "20.10.24"
   dockerComposeVersion: "2.27.0-gitpod.0"

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -2,10 +2,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=242.22855
+pluginSinceBuild=242.23339
 pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2024.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=242.22855-EAP-CANDIDATE-SNAPSHOT
+platformVersion=242.23339-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -2,10 +2,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=242.23339
+pluginSinceBuild=242.22855
 pluginUntilBuild=242.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2024.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=242.23339-EAP-CANDIDATE-SNAPSHOT
+platformVersion=242.22855-EAP-CANDIDATE-SNAPSHOT

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -207,6 +207,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2.3",
+            "image": "{{.Repository}}/ide/intellij:commit-c0c9b747905872fcade355a5347e4de98711a0a0",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f",
+              "{{.Repository}}/ide/jb-launcher:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f"
+            ]
+          },
+          {
             "version": "2024.2.2",
             "image": "{{.Repository}}/ide/intellij:commit-2aba460a50c43e830b015a6ff4e52e6491a3ed36",
             "imageLayers": [
@@ -394,6 +402,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2.3",
+            "image": "{{.Repository}}/ide/pycharm:commit-c0c9b747905872fcade355a5347e4de98711a0a0",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f",
+              "{{.Repository}}/ide/jb-launcher:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f"
+            ]
+          },
+          {
             "version": "2024.2.2",
             "image": "{{.Repository}}/ide/pycharm:commit-2aba460a50c43e830b015a6ff4e52e6491a3ed36",
             "imageLayers": [
@@ -479,6 +495,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2.3",
+            "image": "{{.Repository}}/ide/phpstorm:commit-c0c9b747905872fcade355a5347e4de98711a0a0",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f",
+              "{{.Repository}}/ide/jb-launcher:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f"
+            ]
+          },
+          {
             "version": "2024.2.1",
             "image": "{{.Repository}}/ide/phpstorm:commit-2aba460a50c43e830b015a6ff4e52e6491a3ed36",
             "imageLayers": [
@@ -555,6 +579,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.2.3",
+            "image": "{{.Repository}}/ide/rubymine:commit-c0c9b747905872fcade355a5347e4de98711a0a0",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f",
+              "{{.Repository}}/ide/jb-launcher:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f"
+            ]
+          },
           {
             "version": "2024.2.2",
             "image": "{{.Repository}}/ide/rubymine:commit-2aba460a50c43e830b015a6ff4e52e6491a3ed36",
@@ -640,6 +672,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.2.3",
+            "image": "{{.Repository}}/ide/webstorm:commit-c0c9b747905872fcade355a5347e4de98711a0a0",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f",
+              "{{.Repository}}/ide/jb-launcher:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f"
+            ]
+          },
           {
             "version": "2024.2.2",
             "image": "{{.Repository}}/ide/webstorm:commit-2aba460a50c43e830b015a6ff4e52e6491a3ed36",
@@ -787,6 +827,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.2.2",
+            "image": "{{.Repository}}/ide/clion:commit-c0c9b747905872fcade355a5347e4de98711a0a0",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f",
+              "{{.Repository}}/ide/jb-launcher:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f"
+            ]
+          },
+          {
             "version": "2024.2.1",
             "image": "{{.Repository}}/ide/clion:commit-d54058956db3274084249bdbc4f508ab111b8c51",
             "imageLayers": [
@@ -855,6 +903,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.2.3",
+            "image": "{{.Repository}}/ide/rustrover:commit-c0c9b747905872fcade355a5347e4de98711a0a0",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f",
+              "{{.Repository}}/ide/jb-launcher:commit-b6c243b14932a70b07d022077a41c0a1a8ab439f"
+            ]
+          },
           {
             "version": "2024.2.2",
             "image": "{{.Repository}}/ide/rustrover:commit-4498ab2cf154605be427392b8bddf25dede91f8a",


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR
8. Warmup is working properly using IntelliJ and spring-petclinic project sample

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_