### PR TITLE
[dashboard] Add a notice of Prebuild GC to the prebuilds list

### DIFF
--- a/components/dashboard/src/prebuilds/list/PrebuildList.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildList.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { useHistory } from "react-router-dom";
+import { Link, useHistory } from "react-router-dom";
 import { useQueryParams } from "../../hooks/use-query-params";
 import { PrebuildListEmptyState } from "./PrebuildListEmptyState";
 import { PrebuildListErrorState } from "./PrebuildListErrorState";
@@ -175,21 +175,33 @@ export const PrebuildsList = ({ initialFilter, organizationId, hideOrgSpecificCo
             {isLoading && <LoadingState />}
 
             {showTable && (
-                <PrebuildsTable
-                    prebuilds={prebuilds}
-                    // we check isPreviousData too so we don't show spinner if it's a background refresh
-                    isSearching={isFetching && isPreviousData}
-                    isFetchingNextPage={isFetchingNextPage}
-                    hasNextPage={!!hasNextPage}
-                    filter={filter}
-                    sort={sort}
-                    hasMoreThanOnePage={hasMoreThanOnePage}
-                    hideOrgSpecificControls={!!hideOrgSpecificControls}
-                    onLoadNextPage={() => fetchNextPage()}
-                    onFilterChange={handleFilterChange}
-                    onSort={handleSort}
-                    onTriggerPrebuild={() => setShowRunPrebuildModal(true)}
-                />
+                <>
+                    <PrebuildsTable
+                        prebuilds={prebuilds}
+                        // we check isPreviousData too so we don't show spinner if it's a background refresh
+                        isSearching={isFetching && isPreviousData}
+                        isFetchingNextPage={isFetchingNextPage}
+                        hasNextPage={!!hasNextPage}
+                        filter={filter}
+                        sort={sort}
+                        hasMoreThanOnePage={hasMoreThanOnePage}
+                        hideOrgSpecificControls={!!hideOrgSpecificControls}
+                        onLoadNextPage={() => fetchNextPage()}
+                        onFilterChange={handleFilterChange}
+                        onSort={handleSort}
+                        onTriggerPrebuild={() => setShowRunPrebuildModal(true)}
+                    />
+                    <div className="flex justify-center mt-4">
+                        <span className="text-pk-content-secondary text-xs max-w-md text-center">
+                            Looking for older prebuilds? Prebuilds are garbage-collected if no workspace is started from
+                            them within seven days. To view records of older prebuilds, please refer to the{" "}
+                            <Link to={"/usage"} className="gp-link">
+                                usage report
+                            </Link>
+                            .
+                        </span>
+                    </div>
+                </>
             )}
 
             {showRunPrebuildModal && (

--- a/components/dashboard/src/prebuilds/list/PrebuildTable.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildTable.tsx
@@ -132,16 +132,17 @@ export const PrebuildsTable: FC<Props> = ({
                         <Subheading className="max-w-md">No results found. Try adjusting your search terms.</Subheading>
                     </div>
                 )}
-
-                <div className="mt-4 mb-8 flex flex-row justify-center">
-                    {hasNextPage ? (
-                        <LoadingButton variant="secondary" onClick={onLoadNextPage} loading={isFetchingNextPage}>
-                            Load more
-                        </LoadingButton>
-                    ) : (
-                        hasMoreThanOnePage && <TextMuted>All prebuilds are loaded</TextMuted>
-                    )}
-                </div>
+                {prebuilds.length > 1 && (
+                    <div className="mt-4 mb-8 flex flex-row justify-center">
+                        {hasNextPage ? (
+                            <LoadingButton variant="secondary" onClick={onLoadNextPage} loading={isFetchingNextPage}>
+                                Load more
+                            </LoadingButton>
+                        ) : (
+                            hasMoreThanOnePage && <TextMuted>All prebuilds are loaded</TextMuted>
+                        )}
+                    </div>
+                )}
             </div>
         </>
     );


### PR DESCRIPTION
## Description

Adds our garbage collection policy for prebuilds as a notice in the organization prebuilds list
<img width="778" alt="image" src="https://github.com/user-attachments/assets/541d3324-c562-4f6e-8d73-430e11f305f8">

This is displayed at all times if the number of displayed prebuilds is > 1. This was done to reduce confusion when onboarding.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-838

## How to test

1. [Join my org](https://ft-prebuila8b3a76da0.preview.gitpod-dev.com/orgs/join?inviteId=1f13050c-d2eb-4d99-835b-d8926dcbafd3)
2. Take a gander at `/prebuilds`