### PR TITLE
Add AWS re:Invent 2024 notification

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -171,7 +171,7 @@ const AWS_REINVENT_NOTIFICATION = (updateUser: (user: Partial<UserProtocol>) => 
     return GENERAL_NOTIFICATION(
         "aws_reinvent_2024",
         <span className="text-md">
-            <b>AWS re:Invent:</b> Book a demo during re:Invent or join our exclusive dinner for Engineering Executives |{" "}
+            <b>See you at re:Invent!</b> Book a demo with us, and join our developer productivity leaders roundtable (limited tickets) |{" "}
             <a
                 className="text-kumquat-ripe font-bold"
                 href="https://www.gitpod.io/aws-reinvent-24"

--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -131,6 +131,61 @@ const INVALID_BILLING_ADDRESS = (stripePortalUrl: string | undefined) => {
     } as Notification;
 };
 
+const GENERAL_NOTIFICATION = (
+    id: string,
+    message: JSX.Element,
+    updateUser: (user: Partial<UserProtocol>) => Promise<User>,
+    eventName: string = "general_notification",
+) => {
+    return {
+        id,
+        type: "info",
+        preventDismiss: true,
+        onClose: async () => {
+            let dismissSuccess = false;
+            try {
+                const updatedUser = await updateUser({
+                    additionalData: {
+                        profile: {
+                            coachmarksDismissals: {
+                                [id]: new Date().toISOString(),
+                            },
+                        },
+                    },
+                });
+                dismissSuccess = !!updatedUser;
+            } catch (err) {
+                dismissSuccess = false;
+            } finally {
+                trackEvent("coachmark_dismissed", {
+                    name: eventName,
+                    success: dismissSuccess,
+                });
+            }
+        },
+        message,
+    } as Notification;
+};
+
+const AWS_REINVENT_NOTIFICATION = (updateUser: (user: Partial<UserProtocol>) => Promise<User>) => {
+    return GENERAL_NOTIFICATION(
+        "aws_reinvent_2024",
+        <span className="text-md">
+            <b>AWS re:Invent:</b> Book a demo during re:Invent or join our exclusive dinner for Engineering Executives |{" "}
+            <a
+                className="text-kumquat-ripe font-bold"
+                href="https://www.gitpod.io/aws-reinvent-24"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Learn more
+            </a>
+        </span>,
+        updateUser,
+        "aws_reinvent_notification",
+    );
+};
+
 export function AppNotifications() {
     const [topNotification, setTopNotification] = useState<Notification | undefined>(undefined);
     const { user, loading } = useUserLoader();
@@ -162,6 +217,10 @@ export function AppNotifications() {
 
                 if (isGitpodIo() && !user?.profile?.coachmarksDismissals[GITPOD_FLEX_INTRODUCTION_COACHMARK_KEY]) {
                     notifications.push(GITPOD_FLEX_INTRODUCTION((u: Partial<UserProtocol>) => mutateAsync(u)));
+                }
+
+                if (isGitpodIo() && !user?.profile?.coachmarksDismissals["aws_reinvent_2024"]) {
+                    notifications.push(AWS_REINVENT_NOTIFICATION((u: Partial<UserProtocol>) => mutateAsync(u)));
                 }
             }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Added a reusable notification factory to standardize creation of dismissible notifications with tracking. This reduces code duplication and makes adding new notifications simpler.

- Added `GENERAL_NOTIFICATION` factory function
- Refactored AWS re:Invent notification to use the factory
- Maintains existing functionality for dismissal, tracking and user profile updates

<img width="1124" alt="image" src="https://github.com/user-attachments/assets/60c97870-8a2c-4dd9-ab11-2ed5d87a7981">



## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - chore-aws-2d1ac28bf0</li>
	<li><b>🔗 URL</b> - <a href="https://chore-aws-2d1ac28bf0.preview.gitpod-dev.com/workspaces" target="_blank">chore-aws-2d1ac28bf0.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - chore-aws-reinvent-banner-gha.29740</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-chore-aws-2d1ac28bf0%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
