### PR TITLE
Add flex oidc support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -341,5 +341,5 @@ ENV PRE_COMMIT_HOME=/workspace/.pre-commit
 
 # Setting the environment variable here so that it will be accessible to all tasks and
 # terminal sessions in Gitpod workspaces.
-ENV PREVIEW_ENV_DEV_SA_KEY_PATH=
+ENV PREVIEW_ENV_DEV_SA_KEY_PATH=/root/.config/gcloud/sa.json
 ENV GOOGLE_EXTERNAL_ACCOUNT_ALLOW_EXECUTABLES=1

--- a/dev/flex-oidc/oidc.js
+++ b/dev/flex-oidc/oidc.js
@@ -8,7 +8,7 @@ const getIDToken = async () => {
             const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
 
             const controlPlaneApiEndpoint = config.controlPlaneApiEndpoint;
-            const workspaceToken = config.workspaceToken;
+            const environmentToken = config.environmentToken;
 
             const url = new URL(controlPlaneApiEndpoint);
             const client = http2.connect(url.origin);
@@ -16,7 +16,7 @@ const getIDToken = async () => {
             const req = client.request({
                 ":method": "POST",
                 "content-type": "application/json",
-                authorization: `Bearer ${workspaceToken}`,
+                authorization: `Bearer ${environmentToken}`,
                 ":path": `${url.pathname}/gitpod.v1.IdentityService/GetIDToken`,
             });
 

--- a/dev/preview/workflow/preview/configure-workspace.sh
+++ b/dev/preview/workflow/preview/configure-workspace.sh
@@ -20,11 +20,11 @@ fi
 
 if [ -f "/usr/local/gitpod/config/initial-spec.json" ]; then
   gcloud iam workload-identity-pools create-cred-config \
-    projects/184212049955/locations/global/workloadIdentityPools/gitpod-next/providers/gitpod-next-provider \
+    projects/184212049955/locations/global/workloadIdentityPools/gitpod-flex/providers/gitpod-flex-provider \
     --service-account=preview-environmnet-dev@gitpod-dev-preview.iam.gserviceaccount.com \
     --service-account-token-lifetime-seconds=1h \
     --output-file="${PREVIEW_ENV_DEV_SA_KEY_PATH}" \
-    --executable-command='node /workspace/gitpod/dev/next-oidc/oidc.js' \
+    --executable-command='node /workspace/gitpod/dev/flex-oidc/oidc.js' \
     --executable-timeout-millis=5000
 elif [[ -n "${PREVIEW_ENV_DEV_CRED:-}" ]]; then
   echo "${PREVIEW_ENV_DEV_CRED}" >"${PREVIEW_ENV_DEV_SA_KEY_PATH}"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add flex oidc support

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-885
Fixes CLC-887

## How to test
<!-- Provide steps to test this PR -->
1. start an environment in flex from this branch, try `gcloud projects list`

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
