### PR TITLE
[supervisor] revert recent changes to reduce frequency of `supervisor run error with unexpected exit code`

### DIFF
--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -22,8 +22,8 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/process"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/shared"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/supervisor"
-	reaper "github.com/gitpod-io/go-reaper"
 	"github.com/prometheus/procfs"
+	reaper "github.com/ramr/go-reaper"
 	"github.com/spf13/cobra"
 )
 
@@ -77,55 +77,25 @@ var initCmd = &cobra.Command{
 		}
 
 		supervisorDone := make(chan struct{})
-		handledByReaper := make(chan int)
-		handleSupervisorExit := func(exitCode int) {
-			if exitCode == 0 {
-				return
-			}
-			logs := extractFailureFromRun()
-			if shared.IsExpectedShutdown(exitCode) {
-				log.Fatal(logs)
-			} else {
-				log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error with unexpected exit code")
-			}
-		}
 		go func() {
 			defer close(supervisorDone)
 
 			err := runCommand.Wait()
-			if err == nil {
-				return
-			}
-			// exited by reaper
-			if strings.Contains(err.Error(), "no child processes") {
-				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
-				defer cancel()
-				select {
-				case <-ctx.Done(): // timeout
-				case exitCode := <-handledByReaper:
-					handleSupervisorExit(exitCode)
-				}
-			} else if !(strings.Contains(err.Error(), "signal: ")) {
+			if err != nil && !(strings.Contains(err.Error(), "signal: ") || strings.Contains(err.Error(), "no child processes")) {
 				if eerr, ok := err.(*exec.ExitError); ok && eerr.ExitCode() != 0 {
-					handleSupervisorExit(eerr.ExitCode())
+					logs := extractFailureFromRun()
+					if shared.IsExpectedShutdown(eerr.ExitCode()) {
+						log.Fatal(logs)
+					} else {
+						log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error with unexpected exit code")
+					}
 				}
 				log.WithError(err).Error("supervisor run error")
 				return
 			}
 		}()
 		// start the reaper to clean up zombie processes
-		reaper.Start(reaper.Config{
-			Pid:              -1,
-			Options:          0,
-			DisablePid1Check: false,
-			OnReap: func(pid int, wstatus syscall.WaitStatus) {
-				if pid != runCommand.Process.Pid {
-					return
-				}
-				exitCode := wstatus.ExitStatus()
-				handledByReaper <- exitCode
-			},
-		})
+		reaper.Reap()
 
 		select {
 		case <-supervisorDone:

--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -22,8 +22,8 @@ import (
 	"github.com/gitpod-io/gitpod/common-go/process"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/shared"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/supervisor"
+	reaper "github.com/gitpod-io/go-reaper"
 	"github.com/prometheus/procfs"
-	reaper "github.com/ramr/go-reaper"
 	"github.com/spf13/cobra"
 )
 
@@ -114,22 +114,18 @@ var initCmd = &cobra.Command{
 			}
 		}()
 		// start the reaper to clean up zombie processes
-		reaperChan := make(chan reaper.Status, 10)
 		reaper.Start(reaper.Config{
 			Pid:              -1,
 			Options:          0,
 			DisablePid1Check: false,
-			StatusChannel:    reaperChan,
-		})
-		go func() {
-			for status := range reaperChan {
-				if status.Pid != runCommand.Process.Pid {
-					continue
+			OnReap: func(pid int, wstatus syscall.WaitStatus) {
+				if pid != runCommand.Process.Pid {
+					return
 				}
-				exitCode := status.WaitStatus.ExitStatus()
+				exitCode := wstatus.ExitStatus()
 				handledByReaper <- exitCode
-			}
-		}()
+			},
+		})
 
 		select {
 		case <-supervisorDone:

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/gitpod-io/gitpod/ide-metrics-api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-daemon/api v0.0.0-00010101000000-000000000000
-	github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
@@ -30,6 +29,7 @@ require (
 	github.com/prometheus/common v0.42.0
 	github.com/prometheus/procfs v0.10.1
 	github.com/prometheus/pushgateway v1.5.1
+	github.com/ramr/go-reaper v0.2.1
 	github.com/sirupsen/logrus v1.9.3
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.4.0

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -30,7 +30,6 @@ require (
 	github.com/prometheus/common v0.42.0
 	github.com/prometheus/procfs v0.10.1
 	github.com/prometheus/pushgateway v1.5.1
-	github.com/ramr/go-reaper v0.2.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.4.0

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -119,6 +119,8 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.4 h1:QmUZXrvJ9qZ3GfWvQ+2wnW/1ePrTEJqPKMYEU3lD/DM=
 github.com/gin-gonic/gin v1.7.4/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
+github.com/gitpod-io/go-reaper v0.0.0-20241023132555-bf7fe3193e95 h1:8CExGQuXMl8ZgFzkBfU1+K8+yFLxqttXz9JGPBaoY0g=
+github.com/gitpod-io/go-reaper v0.0.0-20241023132555-bf7fe3193e95/go.mod h1:WJlnZLfag2J4+z28ZjM0CxgVqjYVYF8pnspnleDwrcA=
 github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f h1:jC8c/ONG+vsaxY6y17rM+Du7JN/faYfSBiMCFIi2NoA=
 github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f/go.mod h1:WJlnZLfag2J4+z28ZjM0CxgVqjYVYF8pnspnleDwrcA=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -321,8 +323,6 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/pushgateway v1.5.1 h1:F+meNVGklhdkJTrpt5l3pXLc86m6IG3+ZF3VfeOwubE=
 github.com/prometheus/pushgateway v1.5.1/go.mod h1:BcYcT8no4mdtnZxqpkXH3EMT0/Jf2nKgSlwu6GHirU4=
-github.com/ramr/go-reaper v0.2.2 h1:oQrw3LPL+TiEVb57+UZUHzW7k98N7Rv67TRuCRufLog=
-github.com/ramr/go-reaper v0.2.2/go.mod h1:AVypdzrcCXjSc/JYnlXl8TsB+z84WyFzxWE8Jh0MOJc=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -119,10 +119,6 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.4 h1:QmUZXrvJ9qZ3GfWvQ+2wnW/1ePrTEJqPKMYEU3lD/DM=
 github.com/gin-gonic/gin v1.7.4/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
-github.com/gitpod-io/go-reaper v0.0.0-20241023132555-bf7fe3193e95 h1:8CExGQuXMl8ZgFzkBfU1+K8+yFLxqttXz9JGPBaoY0g=
-github.com/gitpod-io/go-reaper v0.0.0-20241023132555-bf7fe3193e95/go.mod h1:WJlnZLfag2J4+z28ZjM0CxgVqjYVYF8pnspnleDwrcA=
-github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f h1:jC8c/ONG+vsaxY6y17rM+Du7JN/faYfSBiMCFIi2NoA=
-github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f/go.mod h1:WJlnZLfag2J4+z28ZjM0CxgVqjYVYF8pnspnleDwrcA=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
@@ -323,6 +319,8 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/pushgateway v1.5.1 h1:F+meNVGklhdkJTrpt5l3pXLc86m6IG3+ZF3VfeOwubE=
 github.com/prometheus/pushgateway v1.5.1/go.mod h1:BcYcT8no4mdtnZxqpkXH3EMT0/Jf2nKgSlwu6GHirU4=
+github.com/ramr/go-reaper v0.2.1 h1:zww+wlQOvTjBZuk1920R/e0GFEb6O7+B0WQLV6dM924=
+github.com/ramr/go-reaper v0.2.1/go.mod h1:AVypdzrcCXjSc/JYnlXl8TsB+z84WyFzxWE8Jh0MOJc=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to CLC-877 and https://gitpod.slack.com/archives/C071G5TTS49/p1730146705613519
Related to https://github.com/gitpod-io/gitpod/pull/20318 and https://github.com/gitpod-io/gitpod/pull/20322

## How to test
<!-- Provide steps to test this PR -->
Timeout a workspace many times in the preview environment. It's final state should be consistent.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-clc-877</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-clc-877.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-clc-877.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-clc-877-gha.29751</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-clc-877%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
