### PR TITLE
Disable ipv6 inside workspace

### DIFF
--- a/components/ws-daemon/nsinsider/main.go
+++ b/components/ws-daemon/nsinsider/main.go
@@ -403,6 +403,13 @@ func main() {
 				},
 			},
 			{
+				Name:  "disable-ipv6",
+				Usage: "disable IPv6",
+				Action: func(c *cli.Context) error {
+					return os.WriteFile("/proc/sys/net/ipv6/conf/all/disable_ipv6", []byte("1"), 0644)
+				},
+			},
+			{
 				Name:  "dump-network-info",
 				Usage: "dump network info",
 				Flags: []cli.Flag{

--- a/components/ws-daemon/pkg/iws/iws.go
+++ b/components/ws-daemon/pkg/iws/iws.go
@@ -489,6 +489,13 @@ func (wbs *InWorkspaceServiceServer) MountProc(ctx context.Context, req *api.Mou
 	masks = append(masks, procDefaultReadonlyPaths...)
 	cleanupMaskedMount(wbs.Session.OWI(), nodeStaging, masks)
 
+	err = nsi.Nsinsider(wbs.Session.InstanceID, int(procPID), func(c *exec.Cmd) {
+		c.Args = append(c.Args, "disable-ipv6")
+	}, nsi.EnterNetNS(true), nsi.EnterMountNSPid(1))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "cannot disable IPv6")
+	}
+
 	return &api.MountProcResponse{}, nil
 }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR disable workspace ipv6, we don't really support it, and it also blocked the latest version of Docker.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-817

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace form this preview env
2. run `ip a` make sure all interface don't have ipv6 address
3. run `sudo install-packages docker-ce docker-ce-cli containerd.io docker-buildx-plugin` to install latest docker 
4. run `docker version` for validate docker is in latest version 27.x
5. run `docker run --rm -it alpine` for validate docker can start container
6. inside container run `ip a` make sure all interface don't have ipv6 address

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-clc-817</li>
	<li><b>🔗 URL</b> - <a href="https://pd-clc-817.preview.gitpod-dev.com/workspaces" target="_blank">pd-clc-817.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-CLC-817-gha.29765</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-clc-817%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
