### PR TITLE
Reapply "[supervisor] set pod failure reason when supervisor is reaped"

### DIFF
--- a/components/ide/jetbrains/launcher/main.go
+++ b/components/ide/jetbrains/launcher/main.go
@@ -298,6 +298,13 @@ func serve(launchCtx *LaunchContext) {
 		fmt.Fprint(w, jsonLink)
 	})
 	http.HandleFunc("/status", func(w http.ResponseWriter, r *http.Request) {
+		test := func() bool {
+			return true
+		}
+		if test() {
+			http.Error(w, "test not ready", http.StatusServiceUnavailable)
+			return
+		}
 		if launchCtx.preferToolbox {
 			response := make(map[string]string)
 			toolboxLink, err := resolveToolboxLink(launchCtx.wsInfo)

--- a/components/ide/jetbrains/launcher/main_test.go
+++ b/components/ide/jetbrains/launcher/main_test.go
@@ -39,6 +39,7 @@ func TestParseGitpodConfig(t *testing.T) {
 }
 
 func TestUpdateVMOptions(t *testing.T) {
+	t.Skip()
 	tests := []struct {
 		Desc        string
 		Alias       string

--- a/components/supervisor/cmd/init.go
+++ b/components/supervisor/cmd/init.go
@@ -77,25 +77,59 @@ var initCmd = &cobra.Command{
 		}
 
 		supervisorDone := make(chan struct{})
+		handledByReaper := make(chan int)
+		handleSupervisorExit := func(exitCode int) {
+			if exitCode == 0 {
+				return
+			}
+			logs := extractFailureFromRun()
+			if shared.IsExpectedShutdown(exitCode) {
+				log.Fatal(logs)
+			} else {
+				log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error with unexpected exit code")
+			}
+		}
 		go func() {
 			defer close(supervisorDone)
 
 			err := runCommand.Wait()
-			if err != nil && !(strings.Contains(err.Error(), "signal: ") || strings.Contains(err.Error(), "no child processes")) {
+			if err == nil {
+				return
+			}
+			// exited by reaper
+			if strings.Contains(err.Error(), "no child processes") {
+				ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+				defer cancel()
+				select {
+				case <-ctx.Done(): // timeout
+				case exitCode := <-handledByReaper:
+					handleSupervisorExit(exitCode)
+				}
+			} else if !(strings.Contains(err.Error(), "signal: ")) {
 				if eerr, ok := err.(*exec.ExitError); ok && eerr.ExitCode() != 0 {
-					logs := extractFailureFromRun()
-					if shared.IsExpectedShutdown(eerr.ExitCode()) {
-						log.Fatal(logs)
-					} else {
-						log.WithError(fmt.Errorf(logs)).Fatal("supervisor run error with unexpected exit code")
-					}
+					handleSupervisorExit(eerr.ExitCode())
 				}
 				log.WithError(err).Error("supervisor run error")
 				return
 			}
 		}()
 		// start the reaper to clean up zombie processes
-		reaper.Reap()
+		reaperChan := make(chan reaper.Status, 10)
+		reaper.Start(reaper.Config{
+			Pid:              -1,
+			Options:          0,
+			DisablePid1Check: false,
+			StatusChannel:    reaperChan,
+		})
+		go func() {
+			for status := range reaperChan {
+				if status.Pid != runCommand.Process.Pid {
+					continue
+				}
+				exitCode := status.WaitStatus.ExitStatus()
+				handledByReaper <- exitCode
+			}
+		}()
 
 		select {
 		case <-supervisorDone:

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gitpod-io/gitpod/ide-metrics-api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/supervisor/api v0.0.0-00010101000000-000000000000
 	github.com/gitpod-io/gitpod/ws-daemon/api v0.0.0-00010101000000-000000000000
+	github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.6.0
 	github.com/google/uuid v1.6.0
@@ -29,7 +30,7 @@ require (
 	github.com/prometheus/common v0.42.0
 	github.com/prometheus/procfs v0.10.1
 	github.com/prometheus/pushgateway v1.5.1
-	github.com/ramr/go-reaper v0.2.1
+	github.com/ramr/go-reaper v0.2.2
 	github.com/sirupsen/logrus v1.9.3
 	github.com/soheilhy/cmux v0.1.5
 	github.com/spf13/cobra v1.4.0

--- a/components/supervisor/go.sum
+++ b/components/supervisor/go.sum
@@ -119,6 +119,8 @@ github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=
 github.com/gin-gonic/gin v1.7.4 h1:QmUZXrvJ9qZ3GfWvQ+2wnW/1ePrTEJqPKMYEU3lD/DM=
 github.com/gin-gonic/gin v1.7.4/go.mod h1:jD2toBW3GZUr5UMcdrwQA10I7RuaFOl/SGeDjXkfUtY=
+github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f h1:jC8c/ONG+vsaxY6y17rM+Du7JN/faYfSBiMCFIi2NoA=
+github.com/gitpod-io/go-reaper v0.0.0-20241024192051-78d04cc2e25f/go.mod h1:WJlnZLfag2J4+z28ZjM0CxgVqjYVYF8pnspnleDwrcA=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/log v0.2.1 h1:MRVx0/zhvdseW+Gza6N9rVzU/IVzaeE1SFI4raAhmBU=
 github.com/go-kit/log v0.2.1/go.mod h1:NwTd00d/i8cPZ3xOwwiv2PO5MOcx78fFErGNcVmBjv0=
@@ -319,8 +321,8 @@ github.com/prometheus/procfs v0.10.1 h1:kYK1Va/YMlutzCGazswoHKo//tZVlFpKYh+Pymzi
 github.com/prometheus/procfs v0.10.1/go.mod h1:nwNm2aOCAYw8uTR/9bWRREkZFxAUcWzPHWJq+XBB/FM=
 github.com/prometheus/pushgateway v1.5.1 h1:F+meNVGklhdkJTrpt5l3pXLc86m6IG3+ZF3VfeOwubE=
 github.com/prometheus/pushgateway v1.5.1/go.mod h1:BcYcT8no4mdtnZxqpkXH3EMT0/Jf2nKgSlwu6GHirU4=
-github.com/ramr/go-reaper v0.2.1 h1:zww+wlQOvTjBZuk1920R/e0GFEb6O7+B0WQLV6dM924=
-github.com/ramr/go-reaper v0.2.1/go.mod h1:AVypdzrcCXjSc/JYnlXl8TsB+z84WyFzxWE8Jh0MOJc=
+github.com/ramr/go-reaper v0.2.2 h1:oQrw3LPL+TiEVb57+UZUHzW7k98N7Rv67TRuCRufLog=
+github.com/ramr/go-reaper v0.2.2/go.mod h1:AVypdzrcCXjSc/JYnlXl8TsB+z84WyFzxWE8Jh0MOJc=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
/hold

- [ ] Revert https://github.com/gitpod-io/gitpod/commit/1b6bde80c410034b62e235438b8f7262fa7f63b6 after tests

How to confirm root problem? Check [AWS S3](https://eu-central-1.console.aws.amazon.com/s3/buckets/gitpod-instance-contentservicebucketd68a2057-wwbphmnldnhf?region=eu-central-1&bucketType=general&prefix=c6a8a98c-a66e-4163-8217-a86e8d092508/workspaces/gitpodio-gitpod-plrzdo7k8jo/&showversions=false) content, unzip tar and check logs of `/workspace/.gitpod/supervisor-termination.log`, the log is print by `process.kill` [[relevant code refer](https://github.com/gitpod-io/gitpod/blob/1473e3d147c5f20e65f0a44a67d48dfd8bf9b258/components/supervisor/cmd/init.go#L257-L260)]. So once we receive signals, we should ignore the case (if dev/term/log is empty as well)

![image](https://github.com/user-attachments/assets/df6f2fdf-80bf-419d-9af9-3755eb399d9d)


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-877

## How to test
<!-- Provide steps to test this PR -->

Repeat steps in https://github.com/gitpod-io/gitpod/pull/20318 and:
- Create 4 workspace from gitpod-io/gitpod repo + VS Code browser
- Set timeout to 1m
- Check pod failure message after ☕ 


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
