### PR TITLE
Bump Browser Terminal

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -11,7 +11,7 @@ defaultArgs:
   codeVersion: 1.94.2
   codeQuality: stable
   codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
-  xtermCommit: 8f10c5febf0162a3c2309076302f770fbad38fde
+  xtermCommit: d547d4ff4590b66c3ea24342fc62e3afcf6b77bc
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.2.3.tar.gz"
   golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.2.3.tar.gz"


### PR DESCRIPTION
## Description

Bumps the browser terminal to https://github.com/gitpod-io/xterm-web-ide/commit/d547d4ff4590b66c3ea24342fc62e3afcf6b77bc to include changes with the introduction of the `XTERM_CONFIRM_BROWSER_EXIT` environment variable.

Fix https://github.com/gitpod-io/gitpod/issues/18416

/hold

## Preview env

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-bump-xterm</li>
	<li><b>🔗 URL</b> - <a href="https://ft-bump-xterm.preview.gitpod-dev.com/workspaces" target="_blank">ft-bump-xterm.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-bump-xterm-gha.29789</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-bump-xterm%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

- [x] /werft with-preview