### PR TITLE
Add Flex webinar notification banner

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -167,11 +167,12 @@ const GENERAL_NOTIFICATION = (
     } as Notification;
 };
 
-const AWS_REINVENT_NOTIFICATION = (updateUser: (user: Partial<UserProtocol>) => Promise<User>) => {
+/* const AWS_REINVENT_NOTIFICATION = (updateUser: (user: Partial<UserProtocol>) => Promise<User>) => {
     return GENERAL_NOTIFICATION(
         "aws_reinvent_2024",
         <span className="text-md">
-            <b>See you at re:Invent!</b> Book a demo with us, and join our developer productivity leaders roundtable (limited tickets) |{" "}
+            <b>See you at re:Invent!</b> Book a demo with us, and join our developer productivity leaders roundtable
+            (limited tickets) |{" "}
             <a
                 className="text-kumquat-ripe font-bold"
                 href="https://www.gitpod.io/aws-reinvent-24"
@@ -183,6 +184,25 @@ const AWS_REINVENT_NOTIFICATION = (updateUser: (user: Partial<UserProtocol>) => 
         </span>,
         updateUser,
         "aws_reinvent_notification",
+    );
+}; */
+
+const FLEX_WEBINAR_NOTIFICATION = (updateUser: (user: Partial<UserProtocol>) => Promise<User>) => {
+    return GENERAL_NOTIFICATION(
+        "flex_webinar_2024",
+        <span className="text-md">
+            <b>Upcoming webinar:</b> Gitpod Flex - Deploy your self-hosted CDE in 3 minutes |{" "}
+            <a
+                className="text-kumquat-ripe font-bold"
+                href="https://www.gitpod.io/webinars/gitpod-flex-demo"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Register now
+            </a>
+        </span>,
+        updateUser,
+        "flex_webinar_notification",
     );
 };
 
@@ -219,8 +239,12 @@ export function AppNotifications() {
                     notifications.push(GITPOD_FLEX_INTRODUCTION((u: Partial<UserProtocol>) => mutateAsync(u)));
                 }
 
-                if (isGitpodIo() && !user?.profile?.coachmarksDismissals["aws_reinvent_2024"]) {
-                    notifications.push(AWS_REINVENT_NOTIFICATION((u: Partial<UserProtocol>) => mutateAsync(u)));
+                // if (isGitpodIo() && !user?.profile?.coachmarksDismissals["aws_reinvent_2024"]) {
+                //     notifications.push(AWS_REINVENT_NOTIFICATION((u: Partial<UserProtocol>) => mutateAsync(u)));
+                // }
+
+                if (isGitpodIo() && !user?.profile?.coachmarksDismissals["flex_webinar_2024"]) {
+                    notifications.push(FLEX_WEBINAR_NOTIFICATION((u: Partial<UserProtocol>) => mutateAsync(u)));
                 }
             }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This change replaces the AWS re:Invent banner with a notification for the upcoming Gitpod Flex webinar. The notification invites users to register for a demonstration of deploying self-hosted CDE in 3 minutes.

Changes:
- Added FLEX_WEBINAR_NOTIFICATION component
- Updated notification logic to show Flex webinar instead of re:Invent
- Uses existing notification system and tracking

The re:Invent banner can be restored after the Flex webinar by reverting these changes.

<img width="1109" alt="image" src="https://github.com/user-attachments/assets/ccfe56c5-5442-432e-bfff-1f60219d82a8">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes [internal conv.](https://gitpod.slack.com/archives/C046Z4BBP2N/p1730281811700259)

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
