### PR TITLE
[supervisor] Fix subscription leaks in PortsStatus

### DIFF
--- a/components/local-app/pkg/bastion/bastion.go
+++ b/components/local-app/pkg/bastion/bastion.go
@@ -760,6 +760,9 @@ func (b *Bastion) tunnelPorts(ws *Workspace) {
 }
 
 func (b *Bastion) doTunnelPorts(ctx context.Context, ws *Workspace) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
 	statusService := supervisor.NewStatusServiceClient(ws.supervisorClient)
 	status, err := statusService.PortsStatus(ctx, &supervisor.PortsStatusRequest{
 		Observe: true,

--- a/components/supervisor/pkg/ports/served-ports.go
+++ b/components/supervisor/pkg/ports/served-ports.go
@@ -40,7 +40,7 @@ type ServedPortsObserver interface {
 }
 
 const (
-	maxSubscriptions = 10
+	maxSubscriptions = 100
 
 	fnNetTCP  = "/proc/net/tcp"
 	fnNetTCP6 = "/proc/net/tcp6"


### PR DESCRIPTION
## Description

We have seen a lot of errors yesterday on catfood about our hitting our subscription limit for the PortsService of the supervisor. 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-890

## How to test

1. Try using the local companion to forward ports against the preview environment 

/hold
