### PR TITLE
[dashboard] do not show repo examples from incompatible providers

### DIFF
--- a/components/dashboard/src/components/RepositoryFinder.tsx
+++ b/components/dashboard/src/components/RepositoryFinder.tsx
@@ -255,10 +255,19 @@ export default function RepositoryFinder({
         }
     };
 
+    const filteredPredefinedRepos = useMemo(() => {
+        return PREDEFINED_REPOS.filter((repo) => {
+            const url = new URL(repo.url);
+            const isMatchingAuthProviderAvailable =
+                authProviders.data?.some((provider) => provider.host === url.host) ?? false;
+            return isMatchingAuthProviderAvailable;
+        });
+    }, [authProviders.data]);
+
     const getElements = useCallback(
         (searchString: string): ComboboxElement[] => {
             if (isShowingExamples && !onlyConfigurations) {
-                return PREDEFINED_REPOS.map((repo) => ({
+                return filteredPredefinedRepos.map((repo) => ({
                     id: repo.url,
                     element: <PredefinedRepositoryOption repo={repo} />,
                     isSelectable: true,
@@ -276,7 +285,7 @@ export default function RepositoryFinder({
 
             if (!onlyConfigurations) {
                 // Add predefined repos to end of the list.
-                PREDEFINED_REPOS.forEach((repo) => {
+                filteredPredefinedRepos.forEach((repo) => {
                     if (
                         repo.url.toLowerCase().includes(searchString.toLowerCase()) ||
                         repo.repoName.toLowerCase().includes(searchString.toLowerCase())
@@ -347,7 +356,7 @@ export default function RepositoryFinder({
 
             return result;
         },
-        [repos, hasMore, authProviders.data, onlyConfigurations, isShowingExamples],
+        [isShowingExamples, onlyConfigurations, repos, hasMore, authProviders.data, filteredPredefinedRepos],
     );
 
     return (


### PR DESCRIPTION
## Description

Prevents showing a given example repository when it cannot be opened given the current auth provider configuration.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-902

## How to test

You can test by opening https://ft-fix-una8406a84f5e.preview.gitpod-dev.com/workspaces and seeing that there are still only 2 suggested repositories, both from github.com. In the actual preview env, there is a third one on an arbitrary host, but it is correctly not visible because there is no auth setup with it.


/hold
