### PR TITLE
[.gitpod.yml] Introduce top-level `env`

### DIFF
--- a/components/gitpod-protocol/data/gitpod-schema.json
+++ b/components/gitpod-protocol/data/gitpod-schema.json
@@ -327,6 +327,13 @@
                     "description": "the hard limit acts as a ceiling for the soft limit. For more details please check https://man7.org/linux/man-pages/man2/getrlimit.2.html"
                 }
             }
+        },
+        "env": {
+            "type": "object",
+            "description": "Environment variables to set on the workspace.",
+            "additionalProperties": {
+                "type": "string"
+            }
         }
     },
     "additionalProperties": false,

--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -50,6 +50,9 @@ type GitpodConfig struct {
 	// Configure the default action of certain signals is to cause a process to terminate and produce a core dump file, a file containing an image of the process's memory at the time of termination. Disabled by default.
 	CoreDump *CoreDump `yaml:"coreDump,omitempty" json:"coreDump,omitempty"`
 
+	// Environment variables to set on the workspace.
+	Env map[string]string `yaml:"env,omitempty" json:"env,omitempty"`
+
 	// Experimental network configuration in workspaces (deprecated). Enabled by default
 	ExperimentalNetwork bool `yaml:"experimentalNetwork,omitempty" json:"experimentalNetwork,omitempty"`
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -801,6 +801,7 @@ export interface WorkspaceConfig {
     jetbrains?: JetBrainsConfig;
     coreDump?: CoreDumpConfig;
     ideCredentials?: string;
+    env?: { [env: string]: any };
 
     /** deprecated. Enabled by default **/
     experimentalNetwork?: boolean;

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -311,7 +311,7 @@ describe("EnvVarService", async () => {
         const workspaceConfig: WorkspaceConfig = {
             env: {
                 foobar: "yes please",
-                [fooAnyUserEnvVar.name]: "overridden",
+                [fooAnyUserEnvVar.name]: "overridden_by_user_var",
             },
         };
 
@@ -336,7 +336,7 @@ describe("EnvVarService", async () => {
             })),
         );
         expect(envVars.workspace).to.have.deep.members([
-            { name: fooAnyUserEnvVar.name, value: "overridden" },
+            fooAnyUserEnvVar,
             barUserCommitEnvVar,
             bazProjectEnvVar,
             { name: "foobar", value: "yes please" },

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -13,6 +13,7 @@ import {
     User,
     UserEnvVarValue,
     WithEnvvarsContext,
+    WorkspaceConfig,
 } from "@gitpod/gitpod-protocol";
 import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
 import * as chai from "chai";
@@ -43,36 +44,36 @@ const fooAnyUserEnvVar = {
     name: "foo",
     value: "any",
     repositoryPattern: "gitpod/*",
-};
+} as const;
 
 const barUserCommitEnvVar = {
     name: "bar",
     value: "commit",
     repositoryPattern: "gitpod/gitpod-io",
-};
+} as const;
 
 const barUserAnotherCommitEnvVar = {
     name: "bar",
     value: "commit",
     repositoryPattern: "gitpod/openvscode-server",
-};
+} as const;
 
 const barProjectCensoredEnvVar = {
     name: "bar",
     censored: true,
     value: "project1",
-};
+} as const;
 
 const bazProjectEnvVar = {
     name: "baz",
     censored: false,
     value: "project2",
-};
+} as const;
 
 const barContextEnvVar = {
     name: "bar",
     value: "context",
-};
+} as const;
 
 const contextEnvVars = {
     envvars: [barContextEnvVar],
@@ -299,7 +300,7 @@ describe("EnvVarService", async () => {
         });
     });
 
-    it("should resolve env variables regular projext", async () => {
+    it("should resolve env variables regular project", async () => {
         await es.addUserEnvVar(member.id, member.id, fooAnyUserEnvVar);
         await es.addUserEnvVar(member.id, member.id, barUserCommitEnvVar);
         await es.addUserEnvVar(member.id, member.id, barUserAnotherCommitEnvVar);
@@ -307,7 +308,14 @@ describe("EnvVarService", async () => {
         await es.addProjectEnvVar(owner.id, project.id, barProjectCensoredEnvVar);
         await es.addProjectEnvVar(owner.id, project.id, bazProjectEnvVar);
 
-        const envVars = await es.resolveEnvVariables(member.id, project.id, "regular", commitContext);
+        const workspaceConfig: WorkspaceConfig = {
+            env: {
+                foobar: "yes please",
+                [fooAnyUserEnvVar.name]: "overridden",
+            },
+        };
+
+        const envVars = await es.resolveEnvVariables(member.id, project.id, "regular", commitContext, workspaceConfig);
         envVars.project.forEach((e) => {
             delete (e as any).id;
             delete (e as any).projectId;
@@ -327,10 +335,15 @@ describe("EnvVarService", async () => {
                 censored: e.censored,
             })),
         );
-        expect(envVars.workspace).to.have.deep.members([fooAnyUserEnvVar, barUserCommitEnvVar, bazProjectEnvVar]);
+        expect(envVars.workspace).to.have.deep.members([
+            { name: fooAnyUserEnvVar.name, value: "overridden" },
+            barUserCommitEnvVar,
+            bazProjectEnvVar,
+            { name: "foobar", value: "yes please" },
+        ]);
     });
 
-    it("should resolve env variables prebuild with projext ", async () => {
+    it("should resolve env variables prebuild with project", async () => {
         await es.addUserEnvVar(member.id, member.id, fooAnyUserEnvVar);
         await es.addUserEnvVar(member.id, member.id, barUserCommitEnvVar);
         await es.addUserEnvVar(member.id, member.id, barUserAnotherCommitEnvVar);

--- a/components/server/src/user/env-var-service.ts
+++ b/components/server/src/user/env-var-service.ts
@@ -260,20 +260,20 @@ export class EnvVarService {
             };
         }
 
-        // 1. first merge user envs
-        if (CommitContext.is(wsContext)) {
-            // this is a commit context, thus we can filter the env vars
-            const userEnvVars = await this.userDB.getEnvVars(requestorId);
-            merge(UserEnvVar.filter(userEnvVars, wsContext.repository.owner, wsContext.repository.name));
-        }
-
-        // 2. then from the .gitpod.yml
+        // 1. first merge the `env` in the .gitpod.yml
         if (wsConfig?.env) {
             const configEnvVars = Object.entries(wsConfig.env as Record<string, string>).map(([name, value]) => ({
                 name,
                 value,
             }));
             merge(configEnvVars);
+        }
+
+        // 2. then user envs
+        if (CommitContext.is(wsContext)) {
+            // this is a commit context, thus we can filter the env vars
+            const userEnvVars = await this.userDB.getEnvVars(requestorId);
+            merge(UserEnvVar.filter(userEnvVars, wsContext.repository.owner, wsContext.repository.name));
         }
 
         // 3. then from the project

--- a/components/server/src/user/env-var-service.ts
+++ b/components/server/src/user/env-var-service.ts
@@ -13,6 +13,7 @@ import {
     UserEnvVar,
     UserEnvVarValue,
     WithEnvvarsContext,
+    WorkspaceConfig,
     WorkspaceContext,
     WorkspaceType,
 } from "@gitpod/gitpod-protocol";
@@ -231,6 +232,7 @@ export class EnvVarService {
         projectId: string | undefined,
         wsType: WorkspaceType,
         wsContext: WorkspaceContext,
+        wsConfig?: WorkspaceConfig,
     ): Promise<ResolvedEnvVars> {
         await this.auth.checkPermissionOnUser(requestorId, "read_env_var", requestorId);
         if (projectId) {
@@ -249,7 +251,7 @@ export class EnvVarService {
             : [];
 
         if (wsType === "prebuild") {
-            // prebuild does not have access to user env vars and cannot be started via prewfix URL
+            // prebuild does not have access to user env vars and cannot be started via prefix URL
             const withValues = await this.projectDB.getProjectEnvironmentVariableValues(projectEnvVars);
             merge(withValues);
             return {
@@ -265,7 +267,16 @@ export class EnvVarService {
             merge(UserEnvVar.filter(userEnvVars, wsContext.repository.owner, wsContext.repository.name));
         }
 
-        // 2. then from the project
+        // 2. then from the .gitpod.yml
+        if (wsConfig?.env) {
+            const configEnvVars = Object.entries(wsConfig.env as Record<string, string>).map(([name, value]) => ({
+                name,
+                value,
+            }));
+            merge(configEnvVars);
+        }
+
+        // 3. then from the project
         if (projectEnvVars.length) {
             // Instead of using an access guard for Project environment variables, we let Project owners decide whether
             // a variable should be:
@@ -276,7 +287,7 @@ export class EnvVarService {
             merge(withValues);
         }
 
-        // 3. then parsed from the context URL
+        // 4. then parsed from the context URL
         if (WithEnvvarsContext.is(wsContext)) {
             merge(wsContext.envvars);
         }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1226,6 +1226,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
             workspace.projectId,
             workspace.type,
             workspace.context,
+            workspace.config,
         );
 
         const result: EnvVarWithValue[] = [];

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -402,6 +402,7 @@ export class WorkspaceStarter {
                             workspace.projectId,
                             workspace.type,
                             workspace.context,
+                            workspace.config,
                         );
 
                         await this.actuallyStartWorkspace(ctx, instance, workspace, user, envVars);


### PR DESCRIPTION
## Description

The `.gitpod.yml` spec has [not changed](https://github.com/gitpod-io/gitpod/commits/main/components/gitpod-protocol/data/gitpod-schema.json) for more than 2 years! Let's break the streak.

This PR introduces the top-level `env` keyword to the `.gitpod.yml` file, defining key-value pairs of environment variables that ought to be available on workspaces created from it.

Here is an example:

```yaml
image: gitpod/workspace-full

env:
  BOND: "007"
```

Simple enough. The funny part comes when you try to plug this approach into our existing approaches for setting environment variables.

```mermaid
graph TD
    A["Environment Variable Overriding in Gitpod Workspaces"] 
    A --> |"1 (Highest Priority)"| B[".gitpod.yml[tasks][n][env]"]
    B --> |"2"| C["Environment variables passed via the context URL"]
    C --> |"3"| D["Repository-specific environment variables"]
    D --> |"4"| E["User-specific environment variables"]
    E --> |"5 (this PR's addition)"| F[".gitpod.yml[env]"]
    F --> |"6 (Lowest Priority)"| G["Image's environment variables (e.g., ENV in Dockerfile)"]
    
    style A fill:#f9f9f9,stroke:#333,stroke-width:2px;
    style B fill:#f2f2f2,stroke:#3a86ff,stroke-width:2px;
    style C fill:#f2f2f2,stroke:#8338ec,stroke-width:2px;
    style D fill:#f2f2f2,stroke:#ff006e,stroke-width:2px;
    style E fill:#f2f2f2,stroke:#fb5607,stroke-width:2px;
    style F fill:#f2f2f2,stroke:#ffbe0b,stroke-width:2px;
    style G fill:#f2f2f2,stroke:#00a676,stroke-width:2px;
```

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-874

## How to test

1. You can try starting a workspace in the [preview environment](https://ft-gitpod-197ac2670d.preview.gitpod-dev.com/workspaces) based off of https://github.com/filiptronicek/test-foofies/blob/ft/envvars/.gitpod.yml.
2. You should see `$VAR` populated with a value in the resulting workspace

This PR also updates tests

## Documentation

Yes it does. Documentation in https://github.com/gitpod-io/website/pull/4942
