### PR TITLE
Remove non-ipv4 entry from /etc/hosts

### DIFF
--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -704,15 +704,21 @@ func makeHostnameLocal(ring2root string) error {
 	newLines := []string{}
 	for _, line := range lines {
 		fields := strings.Fields(line)
-		if len(fields) != 2 {
+		if len(fields) < 1 {
 			newLines = append(newLines, line)
 			continue
 		}
-		if len(net.ParseIP(fields[0])) != net.IPv4len {
+		if strings.HasPrefix(fields[0], "#") {
+			newLines = append(newLines, line)
+		}
+		ip := net.ParseIP(fields[0]).To4()
+		if len(ip) != net.IPv4len {
 			continue
 		}
 		if fields[1] == hostname {
 			newLines = append(newLines, "127.0.0.1 "+hostname)
+		} else {
+			newLines = append(newLines, line)
 		}
 	}
 	return os.WriteFile(path, []byte(strings.Join(newLines, "\n")), stat.Mode())

--- a/components/workspacekit/cmd/rings.go
+++ b/components/workspacekit/cmd/rings.go
@@ -695,22 +695,27 @@ func makeHostnameLocal(ring2root string) error {
 	if err != nil {
 		return err
 	}
-	b, err := ioutil.ReadFile(path)
+	b, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
 	bStr := string(b)
 	lines := strings.Split(bStr, "\n")
-	for i, line := range lines {
+	newLines := []string{}
+	for _, line := range lines {
 		fields := strings.Fields(line)
 		if len(fields) != 2 {
+			newLines = append(newLines, line)
+			continue
+		}
+		if len(net.ParseIP(fields[0])) != net.IPv4len {
 			continue
 		}
 		if fields[1] == hostname {
-			lines[i] = "127.0.0.1 " + hostname
+			newLines = append(newLines, "127.0.0.1 "+hostname)
 		}
 	}
-	return ioutil.WriteFile(path, []byte(strings.Join(lines, "\n")), stat.Mode())
+	return os.WriteFile(path, []byte(strings.Join(newLines, "\n")), stat.Mode())
 }
 
 func receiveSeccmpFd(conn *net.UnixConn) (libseccomp.ScmpFd, error) {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-907

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-clc-907</li>
	<li><b>🔗 URL</b> - <a href="https://pd-clc-907.preview.gitpod-dev.com/workspaces" target="_blank">pd-clc-907.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-CLC-907-gha.29890</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-clc-907%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
