### PR TITLE
[tests] fix JetBrains warmup integration test

### DIFF
--- a/test/tests/ide/jetbrains/warmup-indexing.sh
+++ b/test/tests/ide/jetbrains/warmup-indexing.sh
@@ -4,7 +4,7 @@
 # See License.AGPL.txt in the project root for license information.
 
 # This script is used to test JetBrains prebuild warmup indexing (search warmup-indexing.sh in codebase)
-# It will get the last indexing json file (scan type FULL_ON_PROJECT_OPEN)
+# It will get the last indexing json file (scan reason `On project open`)
 # and check if the scheduled indexing count is greater than a specified threshold
 #
 # `exit 0` means JetBrains IDEs no need to indexing again
@@ -19,7 +19,7 @@ JsonFiles=$(find "$ProjectIndexingFolder" -type f -name "*.json")
 
 FilteredJsonFiles=()
 for jsonFile in $JsonFiles; do
-    if jq -e '.projectIndexingActivityHistory.times.scanningType == "FULL_ON_PROJECT_OPEN"' "$jsonFile" > /dev/null; then
+    if jq -e '.projectIndexingActivityHistory.times.scanningReason == "On project open"' "$jsonFile" > /dev/null; then
         FilteredJsonFiles+=("$jsonFile")
     fi
 done


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-778

## How to test
<!-- Provide steps to test this PR -->
No need. See screenshot below, scan type is not `full on project open` anymore. But I found their reason is the same (screenshot 2)

(Maybe the better idea is to plus 1 and 2 as total scheduled indexings on screenshot 1)

<img width="1912" alt="image" src="https://github.com/user-attachments/assets/44496170-1969-401c-82e8-006ee94df450">
<img width="2328" alt="image" src="https://github.com/user-attachments/assets/9be507a7-df0e-44d0-b5ce-d55c5591ac90">



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
