### PR TITLE
Fix public API test on `main`

### DIFF
--- a/components/public-api/typescript-common/fixtures/toWorkspace2_1.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspace2_1.golden
@@ -8,7 +8,8 @@
             "annotations": {},
             "name": "gitpod-io/workspace-images - main",
             "pinned": false,
-            "originalContextUrl": "https://github.com/gitpod-io/workspace-images"
+            "originalContextUrl": "https://github.com/gitpod-io/workspace-images",
+            "warnings": []
         },
         "spec": {
             "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspace2_2.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspace2_2.golden
@@ -8,7 +8,8 @@
             "annotations": {},
             "name": "gitpod-io/gitpod - main",
             "pinned": true,
-            "originalContextUrl": "https://github.com/gitpod-io/gitpod"
+            "originalContextUrl": "https://github.com/gitpod-io/gitpod",
+            "warnings": []
         },
         "spec": {
             "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspace2_3.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspace2_3.golden
@@ -8,7 +8,8 @@
             "annotations": {},
             "name": "gitpod-io/empty ",
             "pinned": false,
-            "originalContextUrl": "https://github.com/gitpod-io/empty"
+            "originalContextUrl": "https://github.com/gitpod-io/empty",
+            "warnings": []
         },
         "spec": {
             "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_1.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_1.golden
@@ -8,7 +8,8 @@
             "annotations": {},
             "name": "description",
             "pinned": true,
-            "originalContextUrl": "https://github.com/gitpod-io/contextURL"
+            "originalContextUrl": "https://github.com/gitpod-io/contextURL",
+            "warnings": []
         },
         "spec": {
             "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_2.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspace3_adminPage_2.golden
@@ -8,7 +8,8 @@
             "annotations": {},
             "name": "empty",
             "pinned": true,
-            "originalContextUrl": "https://github.com/gitpod-io/empty"
+            "originalContextUrl": "https://github.com/gitpod-io/empty",
+            "warnings": []
         },
         "spec": {
             "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSession_1.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSession_1.golden
@@ -10,7 +10,8 @@
                 "annotations": {},
                 "name": "akosyakov/parcel-demo - master",
                 "pinned": false,
-                "originalContextUrl": "https://github.com/akosyakov/parcel-demo"
+                "originalContextUrl": "https://github.com/akosyakov/parcel-demo",
+                "warnings": []
             },
             "spec": {
                 "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSession_2.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSession_2.golden
@@ -10,7 +10,8 @@
                 "annotations": {},
                 "name": "svenefftinge/2048-in-terminal - master",
                 "pinned": false,
-                "originalContextUrl": "https://github.com/svenefftinge/2048-in-terminal"
+                "originalContextUrl": "https://github.com/svenefftinge/2048-in-terminal",
+                "warnings": []
             },
             "spec": {
                 "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSession_3.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSession_3.golden
@@ -10,7 +10,8 @@
                 "annotations": {},
                 "name": "svenefftinge/2048-in-terminal - master",
                 "pinned": false,
-                "originalContextUrl": "https://github.com/svenefftinge/2048-in-terminal"
+                "originalContextUrl": "https://github.com/svenefftinge/2048-in-terminal",
+                "warnings": []
             },
             "spec": {
                 "initializer": {

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSession_4.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSession_4.golden
@@ -10,7 +10,8 @@
                 "annotations": {},
                 "name": "svenefftinge/2048-in-terminal - master",
                 "pinned": false,
-                "originalContextUrl": "https://github.com/svenefftinge/2048-in-terminal"
+                "originalContextUrl": "https://github.com/svenefftinge/2048-in-terminal",
+                "warnings": []
             },
             "spec": {
                 "initializer": {


### PR DESCRIPTION
## Description

For some reason, https://github.com/gitpod-io/gitpod/pull/20345 got merged without reporting any failed tests when I changed the converter in there (maybe because I only changed the inputs from `server` and not the actual public API code).
