### PR TITLE
Enable collaborators

### DIFF
--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -142,7 +142,7 @@ export function deduplicateAndFilterRepositories(
 
 const ALLOWED_GIT_PROTOCOLS = ["ssh:", "git:", "http:", "https:"];
 /**
- * An opionated git URL validator
+ * An opinionated git URL validator
  *
  * Assumptions:
  * - Git hosts are not themselves TLDs (like .com) or reserved names like `localhost`

--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -128,15 +128,12 @@ export function deduplicateAndFilterRepositories(
     if (results.length === 0) {
         // If the searchString is a URL, and it's not present in the proposed results, "artificially" add it here.
         if (isValidGitUrl(searchString)) {
-            console.log("It's valid man");
             results.push(
                 new SuggestedRepository({
                     url: searchString,
                 }),
             );
         }
-
-        console.log("Valid after man");
     }
 
     // Limit what we show to 200 results

--- a/components/server/src/workspace/context-service.ts
+++ b/components/server/src/workspace/context-service.ts
@@ -158,7 +158,9 @@ export class ContextService {
                 user.id,
                 context.repository.cloneUrl,
                 options?.organizationId,
+                true,
             );
+            // todo(ft): solve for this case with collaborators who can't select projects directly
             if (projects.length > 1) {
                 throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Multiple projects found for clone URL.");
             }

--- a/components/server/src/workspace/suggested-repos-sorter.ts
+++ b/components/server/src/workspace/suggested-repos-sorter.ts
@@ -20,7 +20,7 @@ export const sortSuggestedRepositories = (repos: SuggestedRepositoryWithSorting[
     // This allows us to consider the lastUse of a recently used project when sorting
     // as it will may have an entry for the project (no lastUse), and another for recent workspaces (w/ lastUse)
 
-    const projectURLs: string[] = [];
+    let projectURLs: string[] = [];
     let uniqueRepositories: SuggestedRepositoryWithSorting[] = [];
 
     for (const repo of repos) {
@@ -88,7 +88,7 @@ export const sortSuggestedRepositories = (repos: SuggestedRepositoryWithSorting[
     uniqueRepositories = uniqueRepositories.map((repo) => {
         if (repo.projectId && !repo.projectName) {
             delete repo.projectId;
-            delete projectURLs[projectURLs.indexOf(repo.url)];
+            projectURLs = projectURLs.filter((url) => url !== repo.url);
         }
 
         return repo;

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -819,7 +819,7 @@ export class WorkspaceService {
         }
 
         const projectPromise = workspace.projectId
-            ? ApplicationError.notFoundToUndefined(this.projectsService.getProject(user.id, workspace.projectId))
+            ? ApplicationError.notFoundToUndefined(this.projectsService.getProject(user.id, workspace.projectId, true))
             : Promise.resolve(undefined);
 
         await mayStartPromise;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -566,8 +566,8 @@ export class WorkspaceStarter {
             return;
         }
 
-        // implicit project (existing on the same clone URL)
-        const projects = await this.projectService.findProjectsByCloneUrl(user.id, contextURL, organizationId);
+        // implicit project (existing on the same clone URL). We skip the permission check so that collaborators are not stuck
+        const projects = await this.projectService.findProjectsByCloneUrl(user.id, contextURL, organizationId, true);
         if (projects.length === 0) {
             throw new ApplicationError(
                 ErrorCodes.PRECONDITION_FAILED,
@@ -1951,10 +1951,12 @@ export class WorkspaceStarter {
                 {},
             );
             if (isEnabledPrebuildFullClone) {
-                const project = await this.projectService.getProject(user.id, workspace.projectId).catch((err) => {
-                    log.error("failed to get project", err);
-                    return undefined;
-                });
+                const project = await this.projectService
+                    .getProject(user.id, workspace.projectId, true)
+                    .catch((err) => {
+                        log.error("failed to get project", err);
+                        return undefined;
+                    });
                 if (project && project.settings?.prebuilds?.cloneSettings?.fullClone) {
                     result.setFullClone(true);
                 }

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -92,7 +92,7 @@ schema: |-
       permission read_billing = member + owner + installation->admin
       permission write_billing = owner + installation->admin
 
-      permission read_prebuild = member + owner + installation->admin
+      permission read_prebuild = collaborator + member + owner + installation->admin
 
       permission create_workspace = member + collaborator
 
@@ -118,7 +118,7 @@ schema: |-
       permission write_info = editor + org->owner + org->installation_admin
       permission delete = editor + org->owner + org->installation_admin
 
-      permission read_env_var = viewer + editor + org->owner + org->installation_admin
+      permission read_env_var = viewer + editor + org->collaborator + org->owner + org->installation_admin
       permission write_env_var = editor + org->owner + org->installation_admin
 
       permission read_prebuild = viewer + editor + org->owner + org->installation_admin


### PR DESCRIPTION
## Description

Makes the following changes to the Collaborator role:
1. Allows Collaborators to read environment variables of a project
2. Allows Collaborators to read prebuilds of a project
3. Allows Collaborators to start a project (this is necessary for the two new capabilities above), but just by starting a workspace on the same repo that an existing project exists on. Any details, including project name, will not be shown.

To be merged sometime around November 25th to give users a heads-up.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-815

## How to test

1. [Join my org](https://ft-collabo839341ea94.preview.gitpod-dev.com/orgs/join?inviteId=2a32fe57-fe71-4999-ade4-4122a34efa7d), you'll become a collaborator to it
2. Try starting any repo, it should not let you.
3. Try starting https://github.com/gitpod-samples/spring-petclinic, it should have environment variables (check for `HELLO_VARIABLES`) and it should be prebuilt.

## Documentation

This does require documentation changes. I will work on those as we get closer to the merge date

/hold
