### PR TITLE
Log edge case for `updateDeletionEligibilityTime`

### DIFF
--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -538,6 +538,14 @@ export class WorkspaceService {
             const lastActive =
                 instance?.stoppingTime || instance?.startedTime || instance?.creationTime || workspace?.creationTime;
             if (!lastActive && !activeNow) {
+                log.warn(
+                    { userId, workspaceId },
+                    "[updateDeletionEligibilityTime] No last active time found, skipping update of deletion eligibility time",
+                    {
+                        workspace,
+                        instance,
+                    },
+                );
                 return;
             }
             const deletionEligibilityTime = activeNow ? new Date() : new Date(lastActive);
@@ -567,7 +575,7 @@ export class WorkspaceService {
             ) {
                 log.warn(
                     { userId, workspaceId, instanceId: instance?.id },
-                    "Prevented moving deletion eligibility time backwards",
+                    "[updateDeletionEligibilityTime] Prevented moving deletion eligibility time backwards",
                     {
                         hasGitChanges,
                         timestamps: new TrustedValue({
@@ -587,7 +595,11 @@ export class WorkspaceService {
                 deletionEligibilityTime: deletionEligibilityTime.toISOString(),
             });
         } catch (error) {
-            log.error({ userId, workspaceId }, "Failed to update deletion eligibility time", error);
+            log.error(
+                { userId, workspaceId },
+                "[updateDeletionEligibilityTime] Failed to update deletion eligibility time",
+                error,
+            );
         }
     }
 


### PR DESCRIPTION
## Description

When further investigating CLC-854, we stumbled upon a case we might not be covering with our current logs: if, for any reason, none of the properties used to assemble the `lastActive` time are present, we return early and don't update the GC eligibility time.

It also adds a common prefix for these logs to make finding them easier

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to CLC-854

/hold
