### PR TITLE
[server] Add more tests around "prebuild selection"

### DIFF
--- a/components/server/src/prebuilds/incremental-workspace-service.ts
+++ b/components/server/src/prebuilds/incremental-workspace-service.ts
@@ -66,7 +66,7 @@ export class IncrementalWorkspaceService {
         return history;
     }
 
-    public async findGoodBaseForIncrementalBuild(
+    public async findBaseForIncrementalWorkspace(
         context: CommitContext,
         config: WorkspaceConfig,
         history: WithCommitHistory,

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -381,7 +381,11 @@ export class PrebuildManager {
                         JSON.stringify(filterPrebuildTasks(config?.tasks));
                     // If there is an existing prebuild that isn't failed and it's based on the current config, we return it here instead of triggering a new prebuild.
                     if (isSameConfig) {
-                        return { prebuildId: existingPB.id, wsid: existingPB.buildWorkspaceId, done: true };
+                        return {
+                            prebuildId: existingPB.id,
+                            wsid: existingPB.buildWorkspaceId,
+                            done: existingPB.state === "available",
+                        };
                     }
                 }
             }
@@ -416,8 +420,11 @@ export class PrebuildManager {
                     true,
                 );
                 if (prebuild) {
-                    // TODO(gpl): Why not "done: prebuild.state === "available""?
-                    return { prebuildId: prebuild.id, wsid: prebuild.buildWorkspaceId, done: true };
+                    return {
+                        prebuildId: prebuild.id,
+                        wsid: prebuild.buildWorkspaceId,
+                        done: prebuild.state === "available",
+                    };
                 }
             }
 

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -407,7 +407,7 @@ export class PrebuildManager {
                         commitHistory: repoHist.commitHistory.slice(0, prebuildInterval),
                     })),
                 };
-                const prebuild = await this.incrementalPrebuildsService.findGoodBaseForIncrementalBuild(
+                const prebuild = await this.incrementalPrebuildsService.findBaseForIncrementalWorkspace(
                     context,
                     config,
                     history,
@@ -416,6 +416,7 @@ export class PrebuildManager {
                     true,
                 );
                 if (prebuild) {
+                    // TODO(gpl): Why not "done: prebuild.state === "available""?
                     return { prebuildId: prebuild.id, wsid: prebuild.buildWorkspaceId, done: true };
                 }
             }

--- a/components/server/src/workspace/context-service.spec.db.ts
+++ b/components/server/src/workspace/context-service.spec.db.ts
@@ -92,7 +92,7 @@ class MockRepositoryProvider implements RepositoryProvider {
         if (!b) {
             throw new Error("branch not found");
         }
-        b.commits.push(commit);
+        b.commits.unshift(commit);
     }
 
     async hasReadAccess(user: any, owner: string, repo: string): Promise<boolean> {
@@ -123,8 +123,8 @@ class MockRepositoryProvider implements RepositoryProvider {
         for (const b of this.branches.values()) {
             for (const [i, c] of b.commits.entries()) {
                 if (c.sha === ref) {
-                    // this commit, and everything before it
-                    return b.commits.slice(0, i).map((c) => c.sha);
+                    // everything before `ref`
+                    return b.commits.slice(i + 1).map((c) => c.sha);
                 }
             }
         }
@@ -150,14 +150,14 @@ function headu<T>(arr: T[] | undefined): T | undefined {
     if (!arr || arr.length === 0) {
         return undefined;
     }
-    return arr[arr.length - 1];
+    return arr[0];
 }
 
 function head<T>(arr: T[]): T {
     if (arr.length === 0) {
         throw new Error("empty array");
     }
-    return arr[arr.length - 1];
+    return arr[0];
 }
 
 const SNAPSHOT_BUCKET = "https://gitpod.io/none-bucket";

--- a/components/server/src/workspace/context-service.ts
+++ b/components/server/src/workspace/context-service.ts
@@ -29,7 +29,7 @@ export class ContextService {
     constructor(
         @inject(TracedWorkspaceDB) private readonly workspaceDb: DBWithTracing<WorkspaceDB>,
         @inject(ContextParser) private contextParser: ContextParser,
-        @inject(IncrementalWorkspaceService) private readonly incrementalPrebuildsService: IncrementalWorkspaceService,
+        @inject(IncrementalWorkspaceService) private readonly incrementalWorkspaceService: IncrementalWorkspaceService,
         @inject(ConfigProvider) private readonly configProvider: ConfigProvider,
 
         @inject(ProjectsService) private readonly projectsService: ProjectsService,
@@ -57,14 +57,15 @@ export class ContextService {
             }
         } else {
             const configPromise = this.configProvider.fetchConfig({}, user, context, organizationId);
-            const history = await this.incrementalPrebuildsService.getCommitHistoryForContext(context, user);
+            const history = await this.incrementalWorkspaceService.getCommitHistoryForContext(context, user);
             const { config } = await configPromise;
-            prebuiltWorkspace = await this.incrementalPrebuildsService.findGoodBaseForIncrementalBuild(
+            prebuiltWorkspace = await this.incrementalWorkspaceService.findBaseForIncrementalWorkspace(
                 context,
                 config,
                 history,
                 user,
                 projectId,
+                false,
             );
         }
         if (!prebuiltWorkspace?.projectId) {


### PR DESCRIPTION
## Description
More unit tests for prebuild selection which happens during context parsing.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related: CLC-913

## How to test
 - see that unit tests are green

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
