### PR TITLE
Introduce builtin Gradle Sync pausing in JetBrains IDEs with GP CLI

### DIFF
--- a/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
+++ b/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// Note: This location is used on GradleSyncListener.kt
+// https://github.com/gitpod-io/gitpod/blob/5317b915e409968af72bd857aa69b3ebf10b6698/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt#L24
 const gradleSyncLockFile = "/tmp/gitpod-gradle.lock"
 
 var jetbrainsGradlePauseCmd = &cobra.Command{

--- a/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
+++ b/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
@@ -19,16 +19,16 @@ var jetbrainsGradlePauseCmd = &cobra.Command{
 
 This command is typically used to prevent concurrent Gradle syncs between:
 - Manual gradle initialization in Gitpod init tasks
-- JetBrains Gateway/IDEA's automatic Gradle sync on project open
+- JetBrains IDEs' (IDEA) automatic Gradle sync on project open
 
 Typical usage in your .gitpod.yml:
 
 tasks:
   - init: |
-      ide jetbrains gradle pause          # Prevent IDEA's gradle sync
+      gp jetbrains gradle pause          # Prevent JetBrains' gradle sync
 	  ...
       ./gradlew <init_service>            # Run your initialization tasks
-      ide jetbrains gradle resume         # Enable
+      gp jetbrains gradle resume         # Enable
     command: ./gradlew <dev_service>
 
 If you have two init tasks want to pause Gradle Sync:
@@ -36,10 +36,10 @@ If you have two init tasks want to pause Gradle Sync:
 tasks:
   - name: Task 1
     init: |
-      ide jetbrains gradle pause          # Prevent IDEA's gradle sync
+      gp jetbrains gradle pause          # Prevent JetBrains' gradle sync
       ./gradlew <init_service>
       gp sync-await gradle-init-1
-      ide jetbrains gradle resume         # Enable
+      gp jetbrains gradle resume         # Enable
   - name: Task 2
     init: |
       ./gradlew <init_service>

--- a/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
+++ b/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+const gradleSyncLockFile = "/tmp/gitpod-gradle.lock"
+
+var jetbrainsGradlePauseCmd = &cobra.Command{
+	Use:   "pause",
+	Short: "Pause Gradle Sync in JetBrains IDEs",
+	Long: `Pause JetBrains IDE gradle sync to prevent performance issues on Gitpod workspace startup when there's no Prebuilds ready.
+
+This command is typically used to prevent concurrent Gradle syncs between:
+- Manual gradle initialization in Gitpod init tasks
+- JetBrains Gateway/IDEA's automatic Gradle sync on project open
+
+Typical usage in your .gitpod.yml:
+
+tasks:
+  - init: |
+      ide jetbrains gradle pause          # Prevent IDEA's gradle sync
+	  ...
+      ./gradlew <init_service>            # Run your initialization tasks
+      ide jetbrains gradle resume         # Enable
+    command: ./gradlew <dev_service>
+
+If you have two init tasks want to pause Gradle Sync:
+
+tasks:
+  - name: Task 1
+    init: |
+      ide jetbrains gradle pause          # Prevent IDEA's gradle sync
+      ./gradlew <init_service>
+      gp sync-await gradle-init-1
+      ide jetbrains gradle resume         # Enable
+  - name: Task 2
+    init: |
+      ./gradlew <init_service>
+      gp sync-done gradle-init-1
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := os.WriteFile(gradleSyncLockFile, []byte{}, 0644)
+		if err != nil && os.IsExist(err) {
+			return nil
+		}
+		return err
+	},
+}
+
+func init() {
+	jetbrainsGradleCmd.AddCommand(jetbrainsGradlePauseCmd)
+}

--- a/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
+++ b/components/gitpod-cli/cmd/jetbrains-gradle-pause.go
@@ -14,8 +14,8 @@ const gradleSyncLockFile = "/tmp/gitpod-gradle.lock"
 
 var jetbrainsGradlePauseCmd = &cobra.Command{
 	Use:   "pause",
-	Short: "Pause Gradle Sync in JetBrains IDEs",
-	Long: `Pause JetBrains IDE gradle sync to prevent performance issues on Gitpod workspace startup when there's no Prebuilds ready.
+	Short: "Pause JetBrains' builtin automatic Gradle Sync",
+	Long: `Pause JetBrains' builtin automatic Gradle Sync to prevent performance issues on Gitpod workspace startup when there's no Prebuilds ready.
 
 This command is typically used to prevent concurrent Gradle syncs between:
 - Manual gradle initialization in Gitpod init tasks
@@ -25,10 +25,10 @@ Typical usage in your .gitpod.yml:
 
 tasks:
   - init: |
-      gp jetbrains gradle pause          # Prevent JetBrains' gradle sync
-	  ...
+      gp jetbrains gradle pause           # Prevent JetBrains' auto gradle sync at beginning
+	    ...
       ./gradlew <init_service>            # Run your initialization tasks
-      gp jetbrains gradle resume         # Enable
+      gp jetbrains gradle resume          # Enable
     command: ./gradlew <dev_service>
 
 If you have two init tasks want to pause Gradle Sync:
@@ -36,7 +36,7 @@ If you have two init tasks want to pause Gradle Sync:
 tasks:
   - name: Task 1
     init: |
-      gp jetbrains gradle pause          # Prevent JetBrains' gradle sync
+      gp jetbrains gradle pause          # Prevent JetBrains' auto gradle sync
       ./gradlew <init_service>
       gp sync-await gradle-init-1
       gp jetbrains gradle resume         # Enable
@@ -44,6 +44,8 @@ tasks:
     init: |
       ./gradlew <init_service>
       gp sync-done gradle-init-1
+  - name: Task 3
+    command: echo hi there
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := os.WriteFile(gradleSyncLockFile, []byte{}, 0644)

--- a/components/gitpod-cli/cmd/jetbrains-gradle-resume.go
+++ b/components/gitpod-cli/cmd/jetbrains-gradle-resume.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var jetbrainsGradleResumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume paused Gradle Sync in JetBrains IDEs",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		err := os.Remove(gradleSyncLockFile)
+		if err != nil && os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	},
+}
+
+func init() {
+	jetbrainsGradleCmd.AddCommand(jetbrainsGradleResumeCmd)
+}

--- a/components/gitpod-cli/cmd/jetbrains-gradle-resume.go
+++ b/components/gitpod-cli/cmd/jetbrains-gradle-resume.go
@@ -12,7 +12,7 @@ import (
 
 var jetbrainsGradleResumeCmd = &cobra.Command{
 	Use:   "resume",
-	Short: "Resume paused Gradle Sync in JetBrains IDEs",
+	Short: "Resume paused Gradle Sync",
 	RunE: func(cmd *cobra.Command, args []string) error {
 		err := os.Remove(gradleSyncLockFile)
 		if err != nil && os.IsNotExist(err) {

--- a/components/gitpod-cli/cmd/jetbrains-gradle.go
+++ b/components/gitpod-cli/cmd/jetbrains-gradle.go
@@ -1,0 +1,18 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var jetbrainsGradleCmd = &cobra.Command{
+	Use:   "gradle",
+	Short: "Interact with JetBrains Gradle services.",
+}
+
+func init() {
+	jetbrainsCmd.AddCommand(jetbrainsGradleCmd)
+}

--- a/components/gitpod-cli/cmd/jetbrains.go
+++ b/components/gitpod-cli/cmd/jetbrains.go
@@ -1,0 +1,19 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var jetbrainsCmd = &cobra.Command{
+	Use:     "jetbrains",
+	Aliases: []string{"jb"},
+	Short:   "Interact with JetBrains editor.",
+}
+
+func init() {
+	rootCmd.AddCommand(jetbrainsCmd)
+}

--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -151,6 +151,7 @@ packages:
       - NO_VERIFY_JB_PLUGIN=true
     config:
       commands:
+        - ["rm", "-rf", "src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt"]
         - ["mv", "build.gradle-stable.kts", "build.gradle.kts"]
         - ["./build.sh", "${__git_commit}"]
   - name: plugin-latest-rider
@@ -182,6 +183,7 @@ packages:
       - SDKMAN_DIR=/home/gitpod/.sdkman
     config:
       commands:
+        - ["rm", "-rf", "src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt"]
         # TODO(hw): remove after 2024.2.* is stable
         - ["mv", "build.gradle-latest.kts", "build.gradle.kts"]
         - - "bash"

--- a/components/ide/jetbrains/backend-plugin/build.gradle.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle.kts
@@ -40,6 +40,7 @@ project(":") {
         if (properties("platformType") == "RD") {
             print("Rider: exclude unnecessary files")
             sourceSets["main"].kotlin.exclude("**/GitpodForceUpdateMavenProjectsActivity.kt")
+            sourceSets["main"].kotlin.exclude("**/GradleSyncListener.kt")
             sourceSets["main"].kotlin.exclude("**/maven.xml")
         }
     }

--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -1,7 +1,7 @@
 pluginVersion=0.0.1
 gitpodVersion=dev
 # Supported environments: stable, latest (via https://github.com/stevesaliman/gradle-properties-plugin)
-environmentName=stable
+environmentName=latest
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=io.gitpod.jetbrains

--- a/components/ide/jetbrains/backend-plugin/gradle.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle.properties
@@ -1,7 +1,7 @@
 pluginVersion=0.0.1
 gitpodVersion=dev
 # Supported environments: stable, latest (via https://github.com/stevesaliman/gradle-properties-plugin)
-environmentName=latest
+environmentName=stable
 # IntelliJ Platform Artifacts Repositories
 # -> https://plugins.jetbrains.com/docs/intellij/intellij-artifacts.html
 pluginGroup=io.gitpod.jetbrains

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt
@@ -1,0 +1,56 @@
+// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.listeners
+
+import com.intellij.notification.Notification
+import com.intellij.notification.NotificationAction
+import com.intellij.notification.NotificationType
+import com.intellij.notification.Notifications
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskId
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskNotificationListener
+import com.intellij.openapi.externalSystem.model.task.ExternalSystemTaskType
+import java.io.File
+
+class GradleSyncListener : ExternalSystemTaskNotificationListener {
+    override fun onStart(id: ExternalSystemTaskId, workingDir: String?) {
+        if (id.projectSystemId.toString() != "GRADLE" || id.type != ExternalSystemTaskType.RESOLVE_PROJECT) {
+            return
+        }
+        val lockFile = File("/tmp/gitpod-gradle.lock")
+        if (!lockFile.exists()) {
+            return
+        }
+
+        val notification = Notification(
+            "gitpod",
+            "Gitpod: Pause gradle sync",
+            "Pausing Gradle Sync, execute <code style='color: orange;'>gp jetbrains gradle resume</code> to unblock all builtin Gradle Sync <br><br>Current Task ID: ${id.id}",
+            NotificationType.INFORMATION
+        )
+        var isCancelled = false
+        notification.addAction(object : NotificationAction("Cancel") {
+            override fun actionPerformed(e: AnActionEvent, notification: Notification) {
+                isCancelled = true
+                notification.expire()
+            }
+        })
+        Notifications.Bus.notify(notification)
+
+        while (lockFile.exists()) {
+            if (isCancelled) {
+                thisLogger().warn("gitpod: gradle sync pausing is cancelled")
+                break
+            }
+            Thread.sleep(1000)
+        }
+        thisLogger().warn("gitpod: gradle sync pausing finished")
+        ApplicationManager.getApplication().invokeLater {
+            notification.expire()
+        }
+    }
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt
@@ -29,7 +29,7 @@ class GradleSyncListener : ExternalSystemTaskNotificationListener {
         val notification = Notification(
             "gitpod",
             "Gitpod: Pause gradle sync",
-            "Pausing Gradle Sync, execute <code style='color: orange;'>gp jetbrains gradle resume</code> to unblock all builtin Gradle Sync <br><br>Current Task ID: ${id.id}",
+            "Pausing Gradle Sync, execute <code style='color: orange;'>gp jetbrains gradle resume</code> to unblock all builtin Gradle Sync",
             NotificationType.INFORMATION
         )
         var isCancelled = false

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/listeners/GradleSyncListener.kt
@@ -21,6 +21,8 @@ class GradleSyncListener : ExternalSystemTaskNotificationListener {
         if (id.projectSystemId.toString() != "GRADLE" || id.type != ExternalSystemTaskType.RESOLVE_PROJECT) {
             return
         }
+        // Note: This file is written by the GP CLI
+        // https://github.com/gitpod-io/gitpod/blob/5317b915e409968af72bd857aa69b3ebf10b6698/components/gitpod-cli/cmd/jetbrains-gradle-pause.go#L1
         val lockFile = File("/tmp/gitpod-gradle.lock")
         if (!lockFile.exists()) {
             return

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -54,6 +54,9 @@
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService"
                             serviceImplementation="io.gitpod.jetbrains.remote.internal.GitpodIgnoredPortsForNotificationServiceImpl"
                             preload="true"/>
+
+        <externalSystemTaskNotificationListener
+                implementation="io.gitpod.jetbrains.remote.listeners.GradleSyncListener"/>
     </extensions>
 
     <actions>


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
**Updates**: We're not sure if we want to ship this change or not yet.

Make it able to block the builtin Gradle Sync in JetBrains IDEs via GP CLI, to improve workspace performance on workspace start without Prebuilds ready when there's two gradle processing running. Show notification in JetBrains IDE to make user aware of this pausing (cancellable)

<img width="392" alt="image" src="https://github.com/user-attachments/assets/b01e0ec7-f57a-4a57-a5ca-69e0805450d8">


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-525

## How to test
<!-- Provide steps to test this PR -->

> [!NOTE]
> Don't forget to delete files before exit (elasticsearch repo is too big) to save space in preview env `rm -rf /workspace ; gp stop`

- Create workspaces with context below in preview env with stable or latest IntelliJ IDEA
- Exec `./gradlew --status` to see gradle state
- Case 1: With repo `1`, you should be able to see there's two gradle busy running when workspace started (you should be faster than they finish)
- Case 2: With repo `2`, there should only have one gradle running, and after it's stopped, another one should show (the second one is from IntelliJ IDEA itself)
   - elasticsearch repo is too big to download resources (requires more space), so you could force stop that Gitpod task, and exec `gp jetbrains gradle resume` maually)
- Case 3: With repo `2`, click the `Cancel` button on notification, the pausing should be stopped, you should see two gradle process

Context repo:
1. Exec gradle cmd in init tasks: https://github.com/mustard-mh/elasticsearch/tree/no_intellij_warmup
2. Use new gp jetbrains gradle pause and exec gradle cmd in init task: https://github.com/mustard-mh/elasticsearch/tree/pause-gradle

|Case 1| Case 2|Case 3|
|:-:|:-:|:-:|
|<img width="1605" alt="SCR-20241115-brwd" src="https://github.com/user-attachments/assets/e7cb9418-d853-4c24-bae6-38ce9d06c527">|<img width="1647" alt="SCR-20241115-ccxn" src="https://github.com/user-attachments/assets/f81cc00d-990a-4a03-b9e3-9634a0fd3001">|<img width="1702" alt="SCR-20241115-btoq" src="https://github.com/user-attachments/assets/7bc1c901-b2e2-446c-9267-aa7f998b2fb5"><img width="1706" alt="SCR-20241115-btuf" src="https://github.com/user-attachments/assets/a9b0b371-fb7f-4c08-aee8-53b0066edec8">|

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-gradle-pause</li>
	<li><b>🔗 URL</b> - <a href="https://hw-gradle-pause.preview.gitpod-dev.com/workspaces" target="_blank">hw-gradle-pause.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-gradle-pause-gha.30091</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-gradle-pause%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
