### PR TITLE
Fix GitHub Integration tests

### DIFF
--- a/components/server/src/dev/dev-data.ts
+++ b/components/server/src/dev/dev-data.ts
@@ -54,7 +54,7 @@ export namespace DevData {
     export function createGitHubTestToken(): Token {
         if (!process.env.GITPOD_TEST_TOKEN_GITHUB) {
             console.error(
-                `GITPOD_TEST_TOKEN_GITHUB env var is not set\n\n\t export GITPOD_TEST_TOKEN_GITHUB='{"username": "gitpod-test", "token": $AZURE_TOKEN}'`,
+                `GITPOD_TEST_TOKEN_GITHUB env var is not set\n\n\t export GITPOD_TEST_TOKEN_GITHUB='{"username": "gitpod-test", "value": $GITHUB_TOKEN}'`,
             );
         }
         return {

--- a/components/server/src/errors/index.ts
+++ b/components/server/src/errors/index.ts
@@ -20,7 +20,7 @@ export namespace NotFoundError {
         repoName: string,
         errorMessage: string = "Repository not found.",
     ) {
-        const lastUpdate = (token && token.updateDate) || "";
+        const lastUpdate = (token && token.updateDate) ?? "";
         const userScopes = token ? [...token.scopes] : [];
 
         const userIsOwner = owner == user.name; // TODO: shouldn't this be a comparison with `identity.authName`?

--- a/components/server/src/github/github-context-parser.spec.ts
+++ b/components/server/src/github/github-context-parser.spec.ts
@@ -87,11 +87,12 @@ class TestGithubContextParser {
 
     static readonly BLO_BLA_ERROR_DATA = {
         host: "github.com",
-        lastUpdate: undefined,
+        lastUpdate: "",
         owner: "blo",
         repoName: "bla",
         userIsOwner: false,
         userScopes: ["user:email", "public_repo", "repo"],
+        errorMessage: "Could not resolve to a Repository with the name 'blo/bla'.",
     };
 
     protected getTestBranches(): BranchRef[] {
@@ -180,12 +181,12 @@ class TestGithubContextParser {
         const result = await this.parser.handle(
             {},
             this.user,
-            "https://github.com/eclipse-theia/theia/tree/master/LICENSE",
+            "https://github.com/eclipse-theia/theia/tree/master/LICENSE-EPL",
         );
         expect(result).to.deep.include({
             ref: "master",
             refType: "branch",
-            path: "LICENSE",
+            path: "LICENSE-EPL",
             isFile: true,
             repository: {
                 host: "github.com",

--- a/components/server/src/github/github-repository-provider.spec.ts
+++ b/components/server/src/github/github-repository-provider.spec.ts
@@ -81,7 +81,7 @@ class TestGithubContextRepositoryProvider {
 
     @test public async testGetUserRepos() {
         const result = await this.provider.getUserRepos(this.user);
-        expect(result).to.include({ url: "https://github.com/gitpod-io/gitpod", name: "gitpod" });
+        expect(result).to.deep.include({ url: "https://github.com/gitpod-integration-test/example", name: "example" });
     }
 }
 module.exports = new TestGithubContextRepositoryProvider(); // Only to circumvent no usage warning :-/

--- a/components/server/src/github/github-repository-provider.ts
+++ b/components/server/src/github/github-repository-provider.ts
@@ -215,19 +215,20 @@ export class GithubRepositoryProvider implements RepositoryProvider {
               }`,
         );
 
-        let repos: RepositoryInfo[] = [];
-
+        const repos: RepositoryInfo[] = [];
         for (const type of ["contributedTo", "original", "forked"]) {
             const nodes = result.data.viewer[type]?.nodes;
             if (nodes) {
-                repos = nodes.map((n: any): RepositoryInfo => {
+                const reposInSection: RepositoryInfo[] = nodes.map((n: any) => {
                     return {
                         name: n.name,
                         url: n.url,
                     };
                 });
+                repos.push(...reposInSection);
             }
         }
+
         return repos;
     }
 


### PR DESCRIPTION
## Description

Looks like we haven't run these in a while (at least a year and a half), and they needed some love. This PR provides that love.

## How to test

Run the GitHub integrations tests in `server`

```
export GITPOD_TEST_TOKEN_GITHUB='{"username": "gitpod-integration-test", "value": "ghp_..."}'
cd components/server
yarn mocha './**/*.spec.js' --exclude './node_modules/**' --exit
```

The token is in 1Password.

## Related issue(s)

Fixes CLC-930

/hold
