### PR TITLE
Fix Bitbucket Server repository provider tests 

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -194,7 +194,7 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
         });
 
         const commits = commitsResult.values || [];
-        return commits.map((c) => c.id);
+        return commits.map((c) => c.id).slice(1);
     }
 
     public async searchRepos(user: User, searchString: string, limit: number): Promise<RepositoryInfo[]> {


### PR DESCRIPTION
## Description

The tests still targetted our old self-hosted instance and had some inconsistencies with actual current behavior.

Additionally, this PR fixes a bug with the `getCommitHistory` method, which wrongly included the current commit as part of the history (this was the only SCM provider left for which we didn't skip the requested revision in the response). 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-932

## How to test

```
GITPOD_TEST_TOKEN_BITBUCKET_SERVER=VALUE_FROM_1PASSWORD yarn mocha './**/bitbucket-server-repository-provider.spec.js' --exclude './node_modules/**' --exit
```

/hold
