### PR TITLE
Fix Dockerfile paths with relative decorators

### DIFF
--- a/components/server/src/workspace/config-provider.ts
+++ b/components/server/src/workspace/config-provider.ts
@@ -260,7 +260,7 @@ export class ConfigProvider {
             }
             const repoHost = hostContext.services;
             const lastDockerFileSha = await repoHost.fileProvider
-                .getLastChangeRevision(repository, revisionOrTagOrBranch, user, dockerFilePath)
+                .getLastChangeRevision(repository, revisionOrTagOrBranch, user, path.normalize(dockerFilePath))
                 .catch((e) => {
                     if (e instanceof RevisionNotFoundError) {
                         return ImageFileRevisionMissing;

--- a/components/server/src/workspace/image-source-provider.ts
+++ b/components/server/src/workspace/image-source-provider.ts
@@ -5,6 +5,8 @@
  */
 
 import { injectable, inject } from "inversify";
+import { createHash } from "crypto";
+import path from "path";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import {
@@ -18,7 +20,6 @@ import {
     User,
     AdditionalContentContext,
 } from "@gitpod/gitpod-protocol";
-import { createHash } from "crypto";
 import { ImageFileRevisionMissing, RevisionNotFoundError } from "../repohost";
 
 @injectable()
@@ -45,7 +46,12 @@ export class ImageSourceProvider {
                     throw new Error(`Cannot fetch workspace image source for host: ${repository.host}`);
                 }
                 const lastDockerFileSha = await hostContext.services.fileProvider
-                    .getLastChangeRevision(repository, imgcfg.externalSource.revision, user, imgcfg.file)
+                    .getLastChangeRevision(
+                        repository,
+                        imgcfg.externalSource.revision,
+                        user,
+                        path.normalize(imgcfg.file),
+                    )
                     .catch((e) => {
                         if (e instanceof RevisionNotFoundError) {
                             return ImageFileRevisionMissing;
@@ -76,7 +82,7 @@ export class ImageSourceProvider {
                     throw new Error(`Cannot fetch workspace image source for host: ${context.repository.host}`);
                 }
                 const lastDockerFileSha = await hostContext.services.fileProvider
-                    .getLastChangeRevision(context.repository, context.revision, user, imgcfg.file)
+                    .getLastChangeRevision(context.repository, context.revision, user, path.normalize(imgcfg.file))
                     .catch((e) => {
                         if (e instanceof RevisionNotFoundError) {
                             return ImageFileRevisionMissing;


### PR DESCRIPTION
## Description

If you pointed to your Dockerfile with `./.gitpod.Dockerfile` instead of `.gitpod.Dockerfile`, it would fail. That is simply because SCM APIs (at least GitHub, which I've checked) expect a path without any relative decorators relative to the repository root.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-926

## How to test
<!-- Provide steps to test this PR -->

Try to open https://github.com/filiptronicek/test-foofies/commit/2b2ae74d74a36640d089c8072e0bbd6c9493e852 in the e and in Catfood. It will give you a warning in Catfood, but should not in the preview env.

/hold
