### PR TITLE
Properly time out `gp open`

### DIFF
--- a/components/gitpod-cli/cmd/init.go
+++ b/components/gitpod-cli/cmd/init.go
@@ -126,7 +126,10 @@ USER gitpod
 				}
 			}
 
-			openCmd.RunE(cmd, []string{v.File})
+			err = openCmd.RunE(cmd, []string{v.File})
+			if err != nil {
+				return err
+			}
 		}
 		return openCmd.RunE(cmd, []string{".gitpod.yml"})
 	},

--- a/components/gitpod-cli/cmd/open.go
+++ b/components/gitpod-cli/cmd/open.go
@@ -26,7 +26,7 @@ var openCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// TODO(ak) use NotificationService.NotifyActive supervisor API instead
 
-		ctx, cancel := context.WithTimeout(cmd.Context(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(cmd.Context(), 10*time.Second)
 		defer cancel()
 
 		client, err := supervisor.New(ctx)
@@ -57,12 +57,23 @@ var openCmd = &cobra.Command{
 
 		if wait {
 			pargs = append(pargs, "--wait")
+			ctx = cmd.Context()
 		}
-		c := exec.CommandContext(cmd.Context(), pcmd, append(pargs[1:], args...)...)
+		c := exec.CommandContext(ctx, pcmd, append(pargs[1:], args...)...)
 		c.Stdin = os.Stdin
 		c.Stdout = os.Stdout
 		c.Stderr = os.Stderr
-		return c.Run()
+		time.Sleep(10 * time.Second)
+		err = c.Run()
+		if err != nil {
+			if ctx.Err() != nil {
+				return xerrors.Errorf("editor failed to open in time: %w", ctx.Err())
+			}
+
+			return xerrors.Errorf("editor failed to open: %w", err)
+		}
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
## Description

Make sure we don't hang too long when opening files. This can for instance happen when you've got the workspace open in both browser and desktop and supervisor is trying to open it in the editor you don't have in focus.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C04JEP60Q9X/p1731952414858989?thread_ts=1731952175.327349&cid=C04JEP60Q9X

/hold