### PR TITLE
Fix middot for VS Code desktop in IDE selector

### DIFF
--- a/components/dashboard/src/components/SelectIDEComponent.tsx
+++ b/components/dashboard/src/components/SelectIDEComponent.tsx
@@ -192,7 +192,7 @@ const IdeOptionElementSelected = ({
             title={
                 <div>
                     {title}
-                    {!hideVersion && (
+                    {!hideVersion && version && (
                         <>
                             <MiddleDot className="text-pk-content-tertiary" />{" "}
                             <span className="font-normal">{version}</span>{" "}


### PR DESCRIPTION
## Description

Removes the middot when there is nothing to separate.

| Before | After |
|--------|--------|
| <img width="642" alt="image" src="https://github.com/user-attachments/assets/6d3a7a67-bf28-4ee5-9712-c1cb02ddb591"> | <img width="642" alt="image" src="https://github.com/user-attachments/assets/70527ee4-27fb-4ed8-86f4-a63edbaa5db6"> | 

## How to test

https://ft-ide-sel0195905d1a.preview.gitpod-dev.com/new

/hold
