### PR TITLE
[code] Fix gitpod-web dockerfile

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -10,7 +10,7 @@ defaultArgs:
   codeCommit: f84b3d2b3d3c405cc4ade8deadfb8621066ec8ad
   codeVersion: 1.95.3
   codeQuality: stable
-  codeWebExtensionCommit: 7ff72a2938a7a06cbdf3964590f7e9b7525958f3
+  codeWebExtensionCommit: 3953e8160fffa97dd4a4509542b4bf7ff9b704cd
   xtermCommit: d547d4ff4590b66c3ea24342fc62e3afcf6b77bc
   noVerifyJBPlugin: false
   intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz"

--- a/components/ide/code/gitpod-web-extension/leeway.Dockerfile
+++ b/components/ide/code/gitpod-web-extension/leeway.Dockerfile
@@ -18,7 +18,8 @@ WORKDIR /gitpod-code-web
 RUN yarn --frozen-lockfile --network-timeout 180000
 
 # update package.json
-RUN setSegmentKey="setpath([\"segmentKey\"]; \"untrusted-dummy-key\")" && \
+RUN cd gitpod-web && \
+    setSegmentKey="setpath([\"segmentKey\"]; \"untrusted-dummy-key\")" && \
     jqCommands="${setSegmentKey}" && \
     cat package.json | jq "${jqCommands}" > package.json.tmp && \
     mv package.json.tmp package.json


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix gitpod-web dockerfile, it was running jq commands in wrong folder

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - jp-chubby-whippet</li>
	<li><b>🔗 URL</b> - <a href="https://jp-chubby-whippet.preview.gitpod-dev.com/workspaces" target="_blank">jp-chubby-whippet.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - jp-chubby-whippet-gha.30248</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-jp-chubby-whippet%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [x] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
