### PR TITLE
[tests] show dotfile installing failure reason

### DIFF
--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -45,6 +45,7 @@ func TestDotfiles(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		// Scopes should larger than https://github.com/gitpod-io/gitpod/blob/main/components/supervisor/pkg/serverapi/publicapi.go#L99-L109
 		tokenId, err := api.CreateOAuth2Token(username, []string{
 			"function:getToken",
 			"function:openPort",

--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -51,6 +51,7 @@ func TestDotfiles(t *testing.T) {
 			"function:getOpenPorts",
 			"function:guessGitTokenScopes",
 			"function:getWorkspace",
+			"function:sendHeartBeat",
 			"function:trackEvent",
 			"resource:token::*::get",
 		})
@@ -70,8 +71,8 @@ func TestDotfiles(t *testing.T) {
 						"token": "%v",
 						"kind": "gitpod",
 						"host": "%v",
-						"scope": ["function:getToken", "function:openPort", "function:getOpenPorts", "function:guessGitTokenScopes", "function:getWorkspace", "function:trackEvent", "resource:token::*::get"],
-						"expiryDate": "2022-10-26T10:38:05.232Z",
+						"scope": ["function:getToken", "function:openPort", "function:sendHeartBeat", "function:getOpenPorts", "function:guessGitTokenScopes", "function:getWorkspace", "function:trackEvent", "resource:token::*::get"],
+						"expiryDate": "2026-10-26T10:38:05.232Z",
 						"reuse": 4
 					}]`, tokenId, getHostUrl(ctx, t, cfg.Client(), cfg.Namespace())),
 				},

--- a/test/tests/components/ws-manager/dotfiles_test.go
+++ b/test/tests/components/ws-manager/dotfiles_test.go
@@ -174,6 +174,15 @@ func assertDotfiles(t *testing.T, rsa *integration.RpcClient) error {
 	}
 
 	if len(dotfiles) > 0 {
+		var cat agent.ExecResponse
+		err := rsa.Call("WorkspaceAgent.Exec", &agent.ExecRequest{
+			Dir:     "/",
+			Command: "cat",
+			Args:    []string{"/home/gitpod/.dotfiles.log"},
+		}, &cat)
+		if err == nil {
+			t.Fatalf("dotfiles were not installed successfully: %+v, .dotfiles.log: %s", dotfiles, cat.Stdout)
+		}
 		t.Fatalf("dotfiles were not installed successfully: %+v", dotfiles)
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Looks like dotfile test failed because of outdated secret of GitHub Secret `WORKSPACE_INTEGRATION_TEST_USER_TOKEN` [[main build](https://github.com/gitpod-io/gitpod/actions/runs/12049138489/job/33596196474)]

PR action https://github.com/gitpod-io/gitpod/actions/runs/12065222732/job/33644087485?pr=20397
<img width="1353" alt="image" src="https://github.com/user-attachments/assets/6769e0ff-be9a-4987-a3f6-52632bcde61e">

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-923

## How to test
<!-- Provide steps to test this PR -->
Check integration tests result of current PR

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-dotfile-test</li>
	<li><b>🔗 URL</b> - <a href="https://hw-dotfile-test.preview.gitpod-dev.com/workspaces" target="_blank">hw-dotfile-test.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-dotfile-test-gha.30334</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-dotfile-test%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=workspace
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
