### PR TITLE
[server] increase `getToken` bucket size

### DIFF
--- a/components/gitpod-cli/cmd/credential-helper.go
+++ b/components/gitpod-cli/cmd/credential-helper.go
@@ -86,8 +86,8 @@ var credentialHelper = &cobra.Command{
 			Kind: "git",
 		})
 		if err != nil {
-			log.WithError(err).Print("error getting token from supervisior")
-			return GpError{Err: xerrors.Errorf("error getting token from supervisior: %w", err), Silence: true, ExitCode: &exitCode}
+			log.WithError(err).Print("error getting token from supervisor")
+			return GpError{Err: xerrors.Errorf("error getting token from supervisor: %w", err), Silence: true, ExitCode: &exitCode}
 		}
 
 		user = resp.User

--- a/components/server/src/auth/rate-limiter.ts
+++ b/components/server/src/auth/rate-limiter.ts
@@ -208,7 +208,7 @@ function getConfig(config: RateLimiterConfig): RateLimiterConfig {
             durationsSec: 60,
         },
         getToken: {
-            points: 200, // 200 calls per user, per connection, per minute
+            points: 500, // 500 calls per user, per connection, per minute
             durationsSec: 60,
         },
         startWorkspace: {


### PR DESCRIPTION
## Description

It seems like the rate limits we put in place with https://github.com/gitpod-io/gitpod/pull/20391 were not enough. This PR bumps the rate limits further to 500 reqs / minute. At this point, you'd have to be querying for the token 8 times per second to get rate limited.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C083C24UMHN

## How to test

1. [Join my org](https://ft-bump-gec41629acd9.preview.gitpod-dev.com/orgs/join?inviteId=5c4119ff-c3e2-48fc-adac-e47a814e23b9)
2. Auth against our self-hosted bitbucket
3. Start a workspace from https://ft-bump-gec41629acd9.preview.gitpod-dev.com/orgs/join?inviteId=5c4119ff-c3e2-48fc-adac-e47a814e23b9
