### PR TITLE
Clean up `repositoryFinderSearch` feature flag

### DIFF
--- a/components/dashboard/src/data/featureflag-query.ts
+++ b/components/dashboard/src/data/featureflag-query.ts
@@ -19,7 +19,6 @@ const featureFlags = {
     // Local SSH feature of VS Code Desktop Extension
     gitpod_desktop_use_local_ssh_proxy: false,
     enabledOrbitalDiscoveries: "",
-    repositoryFinderSearch: false,
     // dummy specified dataops feature, default false
     dataops: false,
     showBrowserExtensionPromotion: false,

--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -7,12 +7,10 @@
 import { useQuery } from "@tanstack/react-query";
 import { useCurrentOrg } from "../organizations/orgs-query";
 import { useDebounce } from "../../hooks/use-debounce";
-import { useFeatureFlag } from "../featureflag-query";
 import { scmClient } from "../../service/public-api";
 
 export const useSearchRepositories = ({ searchString, limit }: { searchString: string; limit: number }) => {
     // This disables the search behavior when flag is disabled
-    const repositoryFinderSearchEnabled = useFeatureFlag("repositoryFinderSearch");
     const { data: org } = useCurrentOrg();
     const debouncedSearchString = useDebounce(searchString);
 
@@ -26,7 +24,7 @@ export const useSearchRepositories = ({ searchString, limit }: { searchString: s
             return repositories;
         },
         {
-            enabled: repositoryFinderSearchEnabled && !!org && debouncedSearchString.length >= 3,
+            enabled: !!org && debouncedSearchString.length >= 3,
             // Need this to keep previous results while we wait for a new search to complete since debouncedSearchString changes and updates the key
             keepPreviousData: true,
             // We intentionally don't want to trigger refetches here to avoid a loading state side effect of focusing

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
@@ -147,9 +147,10 @@ class TestBitbucketServerRepositoryProvider {
 
     @test async test_getUserRepos_ok() {
         const result = await this.service.getUserRepos(this.user);
+        // todo(ft): possibly change to not directly rely on a single returned repository, since the recent repo list for BBS is prone to change
         expect(result).to.deep.include({
-            url: "https://bitbucket.gitpod-dev.com/scm/tes/2k-repos-1076.git",
-            name: "2k-repos-1076",
+            url: "https://bitbucket.gitpod-dev.com/scm/~svenefftinge/browser-extension-test.git",
+            name: "browser-extension-test",
         });
     }
 }

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.ts
@@ -10,8 +10,6 @@ import { RepoURL } from "../repohost";
 import { RepositoryProvider } from "../repohost/repository-provider";
 import { BitbucketServer, BitbucketServerApi } from "./bitbucket-server-api";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
-import { getPrimaryEmail } from "@gitpod/public-api-common/lib/user-utils";
 
 @injectable()
 export class BitbucketServerRepositoryProvider implements RepositoryProvider {
@@ -132,24 +130,8 @@ export class BitbucketServerRepositoryProvider implements RepositoryProvider {
     }
 
     async getUserRepos(user: User): Promise<RepositoryInfo[]> {
-        const repoSearchEnabled = await getExperimentsClientForBackend().getValueAsync(
-            "repositoryFinderSearch",
-            false,
-            {
-                user: {
-                    id: user.id,
-                    email: getPrimaryEmail(user),
-                },
-            },
-        );
-
         try {
-            const repos = repoSearchEnabled
-                ? // Get up to 100 of the most recent repos if repo searching is enabled
-                  await this.api.getRecentRepos(user, { limit: 100 })
-                : // Otherwise continue to get up to 10k repos
-                  await this.api.getRepos(user, { maxPages: 10, permission: "REPO_READ" });
-
+            const repos = await this.api.getRecentRepos(user, { limit: 100 });
             const result: RepositoryInfo[] = [];
             repos.forEach((r) => {
                 const cloneUrl = r.links.clone.find((u) => u.name === "http")?.href;


### PR DESCRIPTION
## Description

The feature flag has been enabled in all environments for quite some time now, making it fit for removal.

After deploying to all connected cells, we can get rid of the ConfigCat value as well.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-946


/hold
