### PR TITLE
Don't be so chatty when `hasReadAccess` throws

### DIFF
--- a/components/server/src/bitbucket/bitbucket-repository-provider.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.ts
@@ -123,15 +123,14 @@ export class BitbucketRepositoryProvider implements RepositoryProvider {
 
     async hasReadAccess(user: User, owner: string, repo: string): Promise<boolean> {
         const api = await this.apiFactory.create(user);
-        try {
-            await api.repositories.get({ workspace: owner, repo_slug: repo });
-            // we assume that if the current token is good to read the repository details,
-            // then the repository is accessible
-            return true;
-        } catch (err) {
-            console.warn({ userId: user.id }, "hasReadAccess error", err, { owner, repo });
-            return false;
-        }
+        const result = await api.repositories.get({ workspace: owner, repo_slug: repo }).catch((e) => {
+            console.warn({ userId: user.id }, "hasReadAccess error", { owner, repo, status: e.status });
+            return null;
+        });
+
+        // we assume that if the current token is good to read the repository details,
+        // then the repository is accessible
+        return result !== null;
     }
 
     public async getCommitHistory(


### PR DESCRIPTION
## Description

Follow-up for https://github.com/gitpod-io/gitpod/pull/20379 to not leak our auth tokens in CI 🤭.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C071G5TTS49/p1732805834179759

## How to test

Let tests run. ~~I'll need to edit repo secrets to make them pass though, so this is a draft for now~~

