### PR TITLE
[papi] fix unit tests for workspaces service

### DIFF
--- a/components/public-api-server/pkg/apiv1/workspace.go
+++ b/components/public-api-server/pkg/apiv1/workspace.go
@@ -536,6 +536,11 @@ func convertWorkspaceInstance(wsi *protocol.WorkspaceInstance, wsCtx *protocol.W
 
 	gitStatus := convertGitStatus(wsi.GitStatus)
 
+	var editor *v1.WorkspaceInstanceStatus_EditorReference
+	if wsi.Configuration != nil && wsi.Configuration.IDEConfig != nil {
+		editor = convertIdeConfig(wsi.Configuration.IDEConfig)
+	}
+
 	return &v1.WorkspaceInstance{
 		InstanceId:  wsi.ID,
 		WorkspaceId: wsi.WorkspaceID,
@@ -554,7 +559,7 @@ func convertWorkspaceInstance(wsi *protocol.WorkspaceInstance, wsCtx *protocol.W
 			Ports:         ports,
 			RecentFolders: recentFolders,
 			GitStatus:     gitStatus,
-			Editor:        convertIdeConfig(wsi.Configuration.IDEConfig),
+			Editor:        editor,
 		},
 	}, nil
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Follow up for https://github.com/gitpod-io/gitpod/pull/20405

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/actions/runs/12090605717/job/33717859659

## How to test
<!-- Provide steps to test this PR -->
- Open a workspace with current PR in Gitpod
- Run tests
```
# terminal1 -> wait until it finished
leeway run components/gitpod-db:init-testdb

# terminal2
cd components/public-api-server
go test ./...
```
<img width="891" alt="image" src="https://github.com/user-attachments/assets/18a7ab52-b3fd-4d2c-932b-94f5efb089d7">



## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
