### PR TITLE
[server] Add SCM repo search integration tests

### DIFF
--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
@@ -172,6 +172,11 @@ class TestBitbucketServerRepositoryProvider {
         const result = await this.service.searchRepos(this.user, "/2k-repos-1076", 100);
         expect(result).to.be.empty;
     }
+
+    @test async test_searchRepos_nameSubstring() {
+        const result = await this.service.searchRepos(this.user, "repos-1076", 100);
+        expect(result).to.be.empty;
+    }
 }
 
 module.exports = new TestBitbucketServerRepositoryProvider();

--- a/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
+++ b/components/server/src/bitbucket-server/bitbucket-server-repository-provider.spec.ts
@@ -153,6 +153,25 @@ class TestBitbucketServerRepositoryProvider {
             name: "browser-extension-test",
         });
     }
+
+    @test async test_searchRepos_ok() {
+        const result = await this.service.searchRepos(this.user, "2k-repos-1076", 100);
+        expect(result.length).to.be.eq(1);
+    }
+
+    @test async test_searchRepos_shortSearch() {
+        const resultA = await this.service.searchRepos(this.user, "2", 100);
+        expect(resultA).to.not.be.empty;
+
+        const resultB = await this.service.searchRepos(this.user, "2k", 100);
+        expect(resultB).to.not.be.empty;
+    }
+
+    // bitbucket searches for repo and project names, not for the full path
+    @test async test_searchRepos_pathSubstring() {
+        const result = await this.service.searchRepos(this.user, "/2k-repos-1076", 100);
+        expect(result).to.be.empty;
+    }
 }
 
 module.exports = new TestBitbucketServerRepositoryProvider();

--- a/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
+++ b/components/server/src/bitbucket/bitbucket-repository-provider.spec.ts
@@ -96,6 +96,30 @@ class TestBitbucketRepositoryProvider {
         const result = await this.repoProvider.hasReadAccess(this.user, "foobar", "private-repo");
         expect(result).to.be.false;
     }
+
+    // In contrast to Bitbucket Server, bitbucket.org supports matching against a substring, not just a prefix.
+    @test public async testSearchRepos_matchesSubstring() {
+        const result = await this.repoProvider.searchRepos(this.user, "amp", 100);
+        expect(result).to.deep.include({
+            url: "https://bitbucket.org/gitpod-integration-tests/exampul-repo",
+            name: "exampul-repo",
+        });
+    }
+
+    // Bitbucket supports searching for repos with arbitrary length search strings.
+    @test public async testSearchRepos_shortSearchString() {
+        const resultA = await this.repoProvider.searchRepos(this.user, "e", 100);
+        expect(resultA.length).to.be.gt(0);
+
+        const resultB = await this.repoProvider.searchRepos(this.user, "ex", 100);
+        expect(resultB.length).to.be.gt(0);
+    }
+
+    // Bitbucket only searches for repositories by their name, not by their full path.
+    @test public async testSearchRepos_doesNotMatchPath() {
+        const result = await this.repoProvider.searchRepos(this.user, "gitpod-integration-tests/exampul-repo", 100);
+        expect(result).to.be.empty;
+    }
 }
 
 module.exports = new TestBitbucketRepositoryProvider();

--- a/components/server/src/github/github-repository-provider.spec.ts
+++ b/components/server/src/github/github-repository-provider.spec.ts
@@ -62,7 +62,9 @@ class TestGithubContextRepositoryProvider {
         description: "",
         icon: "",
         host: "github.com",
-        oauth: "not-used" as any,
+        oauth: {
+            callBackUrl: "https://gitpod.example.com/auth/github/callback",
+        } as any,
     };
 
     @test public async testFetchCommitHistory() {
@@ -77,6 +79,26 @@ class TestGithubContextRepositoryProvider {
             "506e5aed317f28023994ecf8ca6ed91430e9c1a4",
             "f5b041513bfab914b5fbf7ae55788d9835004d76",
         ]);
+    }
+
+    @test public async testSearchRepos_onlyMatchesByPrefix() {
+        const resultA = await this.provider.searchRepos(this.user, "xample", 100);
+        expect(resultA.length).to.be.eq(0);
+
+        const resultB = await this.provider.searchRepos(this.user, "e", 100);
+        expect(resultB.length).to.be.eq(1);
+    }
+
+    @test public async testSearchRepos_matchesAgainstWholePath() {
+        const resultMatchesSuffix = await this.provider.searchRepos(this.user, "-integration-test/example", 100);
+        expect(resultMatchesSuffix.length).to.be.eq(1);
+
+        const resultDoesNotMatchSubstring = await this.provider.searchRepos(
+            this.user,
+            "gitpod-integration-test/exampl",
+            100,
+        );
+        expect(resultDoesNotMatchSubstring.length).to.be.eq(0);
     }
 
     @test public async testGetUserRepos() {

--- a/components/server/src/gitlab/gitlab-repository-provider.spec.ts
+++ b/components/server/src/gitlab/gitlab-repository-provider.spec.ts
@@ -64,6 +64,31 @@ class TestGitlabRepositoryProvider {
             "f2d9790f2752a794517b949c65a773eb864844cd",
         ]);
     }
+
+    @test public async testSearchRepos_matchesSubstring() {
+        const result = await this.repositoryProvider.searchRepos(this.user, "est", 100);
+        expect(result.length).to.be.eq(1);
+    }
+
+    // The minimum search string length is 3 characters (unless there is an exact match).
+    @test public async testSearchRepos_shortSearchString_looseMatch() {
+        const resultA = await this.repositoryProvider.searchRepos(this.user, "t", 100);
+        expect(resultA.length).to.be.eq(0);
+
+        const resultB = await this.repositoryProvider.searchRepos(this.user, "te", 100);
+        expect(resultB.length).to.be.eq(0);
+    }
+
+    @test public async testSearchRepos_shortSearchString_exactMatch() {
+        const result = await this.repositoryProvider.searchRepos(this.user, "g", 100);
+        expect(result.length).to.be.eq(1);
+    }
+
+    // GitLab API does not support searching for repositories by their full path, only by their name.
+    @test public async testSearchRepos_noMatchAgainstWholePath() {
+        const result = await this.repositoryProvider.searchRepos(this.user, "gitpod-integration-tests/test", 100);
+        expect(result.length).to.be.eq(0);
+    }
 }
 
 module.exports = new TestGitlabRepositoryProvider();


### PR DESCRIPTION
## Description

Adds integration tests that aim to describe the caveats and differences in searching behavior across SCMs.

Explained in words, the capabilities are as follows:
| Capability | Bitbucket | Bitbucket Server | GitHub | GitLab |
|--------|--------|--------|--------|--------|
| Search by name substring | ✅ | ❌ | ✅ | ✅ |
| Match search against entire path | ❌ | ❌ | ✅ [^1] | ❌ |
| Can search < 3 characters | ✅ | ✅ | ✅ | ❌ |

Azure DevOps does not have any search support yet (see CLC-780)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Is part of explorations for CLC-945

## How to test

See changes

/hold

[^1]: there is a caveat with this: GitHub only supports searching against the full paths when the search string is a suffix of the result.