### PR TITLE
Allow short search strings on new workspace page

### DIFF
--- a/components/dashboard/src/data/git-providers/search-repositories-query.ts
+++ b/components/dashboard/src/data/git-providers/search-repositories-query.ts
@@ -24,7 +24,7 @@ export const useSearchRepositories = ({ searchString, limit }: { searchString: s
             return repositories;
         },
         {
-            enabled: !!org && debouncedSearchString.length >= 3,
+            enabled: !!org && debouncedSearchString.length > 0,
             // Need this to keep previous results while we wait for a new search to complete since debouncedSearchString changes and updates the key
             keepPreviousData: true,
             // We intentionally don't want to trigger refetches here to avoid a loading state side effect of focusing

--- a/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
+++ b/components/dashboard/src/data/git-providers/unified-repositories-search-query.ts
@@ -62,7 +62,7 @@ export const useUnifiedRepositorySearch = ({
     }, [configurationSearch.data, excludeConfigurations]);
 
     const filteredRepos = useMemo(() => {
-        const repos = [suggestedQuery.data || [], searchQuery.data || [], flattenedConfigurations ?? []].flat();
+        const repos = [suggestedQuery.data || [], flattenedConfigurations ?? [], searchQuery.data || []].flat();
         return deduplicateAndFilterRepositories(searchString, excludeConfigurations, onlyConfigurations, repos);
     }, [
         searchString,
@@ -113,7 +113,7 @@ export function deduplicateAndFilterRepositories(
         }
 
         // filter out entries that don't match the search string
-        if (!`${repo.url}${repo.configurationName || ""}`.toLowerCase().includes(searchString.trim().toLowerCase())) {
+        if (!`${repo.url}${repo.configurationName ?? ""}`.toLowerCase().includes(searchString.trim().toLowerCase())) {
             continue;
         }
         // filter out duplicates

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -4,7 +4,10 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import { User } from "@gitpod/public-api/lib/gitpod/v1/user_pb";
+import { AuthProviderDescription, AuthProviderType } from "@gitpod/public-api/lib/gitpod/v1/authprovider_pb";
 import EventEmitter from "events";
+import { uniq } from "lodash";
 
 export interface PollOptions<T> {
     backoffFactor: number;
@@ -230,3 +233,53 @@ export function isTrustedUrlOrPath(urlOrPath: string) {
     }
     return isTrusted;
 }
+
+type UnifiedAuthProvider = "Bitbucket" | "GitLab" | "GitHub" | "Azure DevOps";
+
+const isIdentity = (identity?: AuthProviderDescription): identity is AuthProviderDescription => !!identity;
+const unifyProviderType = (type: AuthProviderType): UnifiedAuthProvider | undefined => {
+    switch (type) {
+        case AuthProviderType.BITBUCKET:
+        case AuthProviderType.BITBUCKET_SERVER:
+            return "Bitbucket";
+        case AuthProviderType.GITHUB:
+            return "GitHub";
+        case AuthProviderType.GITLAB:
+            return "GitLab";
+        case AuthProviderType.AZURE_DEVOPS:
+            return "Azure DevOps";
+        default:
+            return undefined;
+    }
+};
+
+const isAuthProviderType = (type?: UnifiedAuthProvider): type is UnifiedAuthProvider => !!type;
+export const getDeduplicatedScmProviders = (
+    user: User,
+    descriptions: AuthProviderDescription[],
+): UnifiedAuthProvider[] => {
+    const userIdentities = user.identities.map((identity) => identity.authProviderId);
+    const userProviders = userIdentities
+        .map((id) => descriptions?.find((provider) => provider.id === id))
+        .filter(isIdentity)
+        .map((provider) => provider.type);
+
+    const unifiedProviders = userProviders
+        .map((type) => unifyProviderType(type))
+        .filter(isAuthProviderType)
+        .sort();
+
+    return uniq(unifiedProviders);
+};
+
+export const disjunctScmProviders = (providers: UnifiedAuthProvider[]): string => {
+    const formatter = new Intl.ListFormat("en", { style: "long", type: "disjunction" });
+
+    return formatter.format(providers);
+};
+
+export const conjunctScmProviders = (providers: UnifiedAuthProvider[]): string => {
+    const formatter = new Intl.ListFormat("en", { style: "long", type: "conjunction" });
+
+    return formatter.format(providers);
+};


### PR DESCRIPTION
## Description

Make it possible to search for repos that are 1 or 2 characters in length by removing the "please type at least 3 characters to search" limit.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-945

## How to test

1. Log into the [preview env](https://ft-shorter792d221b24.preview.gitpod-dev.com/new)
2. Try searching for repos, it should already search with 1 character

/hold
