### PR TITLE
[scrubber] skip if interface is nil

### DIFF
--- a/components/scrubber/scrubber.go
+++ b/components/scrubber/scrubber.go
@@ -388,6 +388,9 @@ func (s *scrubberImpl) deepCopyStruct(fieldName string, src reflect.Value, scrub
 		return dst
 
 	case reflect.Interface:
+		if src.IsNil() {
+			return src
+		}
 		dst := reflect.New(src.Elem().Type())
 		copied := s.deepCopyStruct(fieldName, src.Elem(), scrubTag, skipScrub)
 		dst.Elem().Set(copied)

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -311,157 +311,157 @@ func TestDeepCopyStruct(t *testing.T) {
 		Expectation Expectation
 		CmpOpts     []cmp.Option
 	}{
-		// {
-		// 	Name: "basic happy path",
-		// 	Struct: &struct {
-		// 		Username     string
-		// 		Email        string
-		// 		Password     string
-		// 		WorkspaceID  string
-		// 		LeaveMeAlone string
-		// 	}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
-		// 	Expectation: Expectation{
-		// 		Result: &struct {
-		// 			Username     string
-		// 			Email        string
-		// 			Password     string
-		// 			WorkspaceID  string
-		// 			LeaveMeAlone string
-		// 		}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
-		// 	},
-		// },
-		// {
-		// 	Name: "stuct without pointer",
-		// 	Struct: struct {
-		// 		Username     string
-		// 		Email        string
-		// 		Password     string
-		// 		WorkspaceID  string
-		// 		LeaveMeAlone string
-		// 	}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
-		// 	Expectation: Expectation{
-		// 		Result: struct {
-		// 			Username     string
-		// 			Email        string
-		// 			Password     string
-		// 			WorkspaceID  string
-		// 			LeaveMeAlone string
-		// 		}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
-		// 	},
-		// },
-		// {
-		// 	Name: "map field",
-		// 	Struct: &struct {
-		// 		WithMap map[string]interface{}
-		// 	}{
-		// 		WithMap: map[string]interface{}{
-		// 			"email": "foo@bar.com",
-		// 		},
-		// 	},
-		// 	Expectation: Expectation{
-		// 		Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted]")}},
-		// 	},
-		// },
-		// {
-		// 	Name: "slices",
-		// 	Struct: &struct {
-		// 		Slice []string
-		// 	}{Slice: []string{"foo", "bar", "foo@bar.com"}},
-		// 	Expectation: Expectation{
-		// 		Result: &struct {
-		// 			Slice []string
-		// 		}{Slice: []string{"foo", "bar", "[redacted:email]"}},
-		// 	},
-		// },
-		// {
-		// 	Name: "struct tags",
-		// 	Struct: &struct {
-		// 		Hashed   string `scrub:"hash"`
-		// 		Redacted string `scrub:"redact"`
-		// 		Email    string `scrub:"ignore"`
-		// 	}{
-		// 		Hashed:   "foo",
-		// 		Redacted: "foo",
-		// 		Email:    "foo",
-		// 	},
-		// 	Expectation: Expectation{
-		// 		Result: &struct {
-		// 			Hashed   string `scrub:"hash"`
-		// 			Redacted string `scrub:"redact"`
-		// 			Email    string `scrub:"ignore"`
-		// 		}{
-		// 			Hashed:   "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
-		// 			Redacted: "[redacted]",
-		// 			Email:    "foo",
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	Name: "trusted struct",
-		// 	Struct: scrubStructToTest(&StructToTest{
-		// 		Username: "foo",
-		// 		Email:    "foo@bar.com",
-		// 		Password: "foobar",
-		// 	}),
-		// 	Expectation: Expectation{
-		// 		Result: &TrustedStructToTest{
-		// 			StructToTest: StructToTest{
-		// 				Username: "foo",
-		// 				Email:    "trusted:[redacted:email]",
-		// 				Password: "trusted:[redacted]",
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	Name: "trusted interface",
-		// 	Struct: scrubStructToTestAsTrustedValue(&StructToTest{
-		// 		Username: "foo",
-		// 		Email:    "foo@bar.com",
-		// 		Password: "foobar",
-		// 	}),
-		// 	Expectation: Expectation{
-		// 		Result: &TrustedStructToTest{
-		// 			StructToTest: StructToTest{
-		// 				Username: "foo",
-		// 				Email:    "trusted:[redacted:email]",
-		// 				Password: "trusted:[redacted]",
-		// 			},
-		// 		},
-		// 	},
-		// },
-		// {
-		// 	Name: "contains unexported pointers",
-		// 	Struct: UnexportedStructToTest{
-		// 		Exported:      "foo",
-		// 		unexportedPtr: nil,
-		// 	},
-		// 	Expectation: Expectation{
-		// 		Result: UnexportedStructToTest{
-		// 			Exported:      "foo",
-		// 			unexportedPtr: nil,
-		// 		},
-		// 	},
-		// 	CmpOpts: []cmp.Option{cmpopts.IgnoreUnexported(UnexportedStructToTest{})},
-		// },
-		// {
-		// 	Name: "nil interface",
-		// 	Struct: &struct {
-		// 		Hashed       string `scrub:"hash"`
-		// 		NilInterface interface{}
-		// 	}{
-		// 		Hashed: "foo",
-		// 	},
-		// 	Expectation: Expectation{
-		// 		Result: &struct {
-		// 			Hashed       string `scrub:"hash"`
-		// 			NilInterface interface{}
-		// 		}{
-		// 			Hashed:       "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
-		// 			NilInterface: nil,
-		// 		},
-		// 	},
-		// },
+		{
+			Name: "basic happy path",
+			Struct: &struct {
+				Username     string
+				Email        string
+				Password     string
+				WorkspaceID  string
+				LeaveMeAlone string
+			}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
+			Expectation: Expectation{
+				Result: &struct {
+					Username     string
+					Email        string
+					Password     string
+					WorkspaceID  string
+					LeaveMeAlone string
+				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
+			},
+		},
+		{
+			Name: "stuct without pointer",
+			Struct: struct {
+				Username     string
+				Email        string
+				Password     string
+				WorkspaceID  string
+				LeaveMeAlone string
+			}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
+			Expectation: Expectation{
+				Result: struct {
+					Username     string
+					Email        string
+					Password     string
+					WorkspaceID  string
+					LeaveMeAlone string
+				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
+			},
+		},
+		{
+			Name: "map field",
+			Struct: &struct {
+				WithMap map[string]interface{}
+			}{
+				WithMap: map[string]interface{}{
+					"email": "foo@bar.com",
+				},
+			},
+			Expectation: Expectation{
+				Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted]")}},
+			},
+		},
+		{
+			Name: "slices",
+			Struct: &struct {
+				Slice []string
+			}{Slice: []string{"foo", "bar", "foo@bar.com"}},
+			Expectation: Expectation{
+				Result: &struct {
+					Slice []string
+				}{Slice: []string{"foo", "bar", "[redacted:email]"}},
+			},
+		},
+		{
+			Name: "struct tags",
+			Struct: &struct {
+				Hashed   string `scrub:"hash"`
+				Redacted string `scrub:"redact"`
+				Email    string `scrub:"ignore"`
+			}{
+				Hashed:   "foo",
+				Redacted: "foo",
+				Email:    "foo",
+			},
+			Expectation: Expectation{
+				Result: &struct {
+					Hashed   string `scrub:"hash"`
+					Redacted string `scrub:"redact"`
+					Email    string `scrub:"ignore"`
+				}{
+					Hashed:   "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
+					Redacted: "[redacted]",
+					Email:    "foo",
+				},
+			},
+		},
+		{
+			Name: "trusted struct",
+			Struct: scrubStructToTest(&StructToTest{
+				Username: "foo",
+				Email:    "foo@bar.com",
+				Password: "foobar",
+			}),
+			Expectation: Expectation{
+				Result: &TrustedStructToTest{
+					StructToTest: StructToTest{
+						Username: "foo",
+						Email:    "trusted:[redacted:email]",
+						Password: "trusted:[redacted]",
+					},
+				},
+			},
+		},
+		{
+			Name: "trusted interface",
+			Struct: scrubStructToTestAsTrustedValue(&StructToTest{
+				Username: "foo",
+				Email:    "foo@bar.com",
+				Password: "foobar",
+			}),
+			Expectation: Expectation{
+				Result: &TrustedStructToTest{
+					StructToTest: StructToTest{
+						Username: "foo",
+						Email:    "trusted:[redacted:email]",
+						Password: "trusted:[redacted]",
+					},
+				},
+			},
+		},
+		{
+			Name: "contains unexported pointers",
+			Struct: UnexportedStructToTest{
+				Exported:      "foo",
+				unexportedPtr: nil,
+			},
+			Expectation: Expectation{
+				Result: UnexportedStructToTest{
+					Exported:      "foo",
+					unexportedPtr: nil,
+				},
+			},
+			CmpOpts: []cmp.Option{cmpopts.IgnoreUnexported(UnexportedStructToTest{})},
+		},
+		{
+			Name: "nil interface",
+			Struct: &struct {
+				Hashed       string `scrub:"hash"`
+				NilInterface interface{}
+			}{
+				Hashed: "foo",
+			},
+			Expectation: Expectation{
+				Result: &struct {
+					Hashed       string `scrub:"hash"`
+					NilInterface interface{}
+				}{
+					Hashed:       "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
+					NilInterface: nil,
+				},
+			},
+		},
 		{
 			Name: "nil point interface",
 			Struct: &struct {

--- a/components/scrubber/scrubber_test.go
+++ b/components/scrubber/scrubber_test.go
@@ -311,138 +311,174 @@ func TestDeepCopyStruct(t *testing.T) {
 		Expectation Expectation
 		CmpOpts     []cmp.Option
 	}{
+		// {
+		// 	Name: "basic happy path",
+		// 	Struct: &struct {
+		// 		Username     string
+		// 		Email        string
+		// 		Password     string
+		// 		WorkspaceID  string
+		// 		LeaveMeAlone string
+		// 	}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
+		// 	Expectation: Expectation{
+		// 		Result: &struct {
+		// 			Username     string
+		// 			Email        string
+		// 			Password     string
+		// 			WorkspaceID  string
+		// 			LeaveMeAlone string
+		// 		}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
+		// 	},
+		// },
+		// {
+		// 	Name: "stuct without pointer",
+		// 	Struct: struct {
+		// 		Username     string
+		// 		Email        string
+		// 		Password     string
+		// 		WorkspaceID  string
+		// 		LeaveMeAlone string
+		// 	}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
+		// 	Expectation: Expectation{
+		// 		Result: struct {
+		// 			Username     string
+		// 			Email        string
+		// 			Password     string
+		// 			WorkspaceID  string
+		// 			LeaveMeAlone string
+		// 		}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
+		// 	},
+		// },
+		// {
+		// 	Name: "map field",
+		// 	Struct: &struct {
+		// 		WithMap map[string]interface{}
+		// 	}{
+		// 		WithMap: map[string]interface{}{
+		// 			"email": "foo@bar.com",
+		// 		},
+		// 	},
+		// 	Expectation: Expectation{
+		// 		Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted]")}},
+		// 	},
+		// },
+		// {
+		// 	Name: "slices",
+		// 	Struct: &struct {
+		// 		Slice []string
+		// 	}{Slice: []string{"foo", "bar", "foo@bar.com"}},
+		// 	Expectation: Expectation{
+		// 		Result: &struct {
+		// 			Slice []string
+		// 		}{Slice: []string{"foo", "bar", "[redacted:email]"}},
+		// 	},
+		// },
+		// {
+		// 	Name: "struct tags",
+		// 	Struct: &struct {
+		// 		Hashed   string `scrub:"hash"`
+		// 		Redacted string `scrub:"redact"`
+		// 		Email    string `scrub:"ignore"`
+		// 	}{
+		// 		Hashed:   "foo",
+		// 		Redacted: "foo",
+		// 		Email:    "foo",
+		// 	},
+		// 	Expectation: Expectation{
+		// 		Result: &struct {
+		// 			Hashed   string `scrub:"hash"`
+		// 			Redacted string `scrub:"redact"`
+		// 			Email    string `scrub:"ignore"`
+		// 		}{
+		// 			Hashed:   "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
+		// 			Redacted: "[redacted]",
+		// 			Email:    "foo",
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	Name: "trusted struct",
+		// 	Struct: scrubStructToTest(&StructToTest{
+		// 		Username: "foo",
+		// 		Email:    "foo@bar.com",
+		// 		Password: "foobar",
+		// 	}),
+		// 	Expectation: Expectation{
+		// 		Result: &TrustedStructToTest{
+		// 			StructToTest: StructToTest{
+		// 				Username: "foo",
+		// 				Email:    "trusted:[redacted:email]",
+		// 				Password: "trusted:[redacted]",
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	Name: "trusted interface",
+		// 	Struct: scrubStructToTestAsTrustedValue(&StructToTest{
+		// 		Username: "foo",
+		// 		Email:    "foo@bar.com",
+		// 		Password: "foobar",
+		// 	}),
+		// 	Expectation: Expectation{
+		// 		Result: &TrustedStructToTest{
+		// 			StructToTest: StructToTest{
+		// 				Username: "foo",
+		// 				Email:    "trusted:[redacted:email]",
+		// 				Password: "trusted:[redacted]",
+		// 			},
+		// 		},
+		// 	},
+		// },
+		// {
+		// 	Name: "contains unexported pointers",
+		// 	Struct: UnexportedStructToTest{
+		// 		Exported:      "foo",
+		// 		unexportedPtr: nil,
+		// 	},
+		// 	Expectation: Expectation{
+		// 		Result: UnexportedStructToTest{
+		// 			Exported:      "foo",
+		// 			unexportedPtr: nil,
+		// 		},
+		// 	},
+		// 	CmpOpts: []cmp.Option{cmpopts.IgnoreUnexported(UnexportedStructToTest{})},
+		// },
+		// {
+		// 	Name: "nil interface",
+		// 	Struct: &struct {
+		// 		Hashed       string `scrub:"hash"`
+		// 		NilInterface interface{}
+		// 	}{
+		// 		Hashed: "foo",
+		// 	},
+		// 	Expectation: Expectation{
+		// 		Result: &struct {
+		// 			Hashed       string `scrub:"hash"`
+		// 			NilInterface interface{}
+		// 		}{
+		// 			Hashed:       "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
+		// 			NilInterface: nil,
+		// 		},
+		// 	},
+		// },
 		{
-			Name: "basic happy path",
+			Name: "nil point interface",
 			Struct: &struct {
-				Username     string
-				Email        string
-				Password     string
-				WorkspaceID  string
-				LeaveMeAlone string
-			}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
-			Expectation: Expectation{
-				Result: &struct {
-					Username     string
-					Email        string
-					Password     string
-					WorkspaceID  string
-					LeaveMeAlone string
-				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
-			},
-		},
-		{
-			Name: "stuct without pointer",
-			Struct: struct {
-				Username     string
-				Email        string
-				Password     string
-				WorkspaceID  string
-				LeaveMeAlone string
-			}{Username: "foo", Email: "foo@bar.com", Password: "foobar", WorkspaceID: "gitpodio-gitpod-uesaddev73c", LeaveMeAlone: "foo"},
-			Expectation: Expectation{
-				Result: struct {
-					Username     string
-					Email        string
-					Password     string
-					WorkspaceID  string
-					LeaveMeAlone string
-				}{Username: "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]", Email: "[redacted]", Password: "[redacted]", WorkspaceID: "[redacted:md5:a35538939333def8477b5c19ac694b35]", LeaveMeAlone: "foo"},
-			},
-		},
-		{
-			Name: "map field",
-			Struct: &struct {
-				WithMap map[string]interface{}
+				Hashed       string `scrub:"hash"`
+				NilInterface *string
 			}{
-				WithMap: map[string]interface{}{
-					"email": "foo@bar.com",
-				},
-			},
-			Expectation: Expectation{
-				Result: &struct{ WithMap map[string]any }{WithMap: map[string]any{"email": string("[redacted]")}},
-			},
-		},
-		{
-			Name: "slices",
-			Struct: &struct {
-				Slice []string
-			}{Slice: []string{"foo", "bar", "foo@bar.com"}},
-			Expectation: Expectation{
-				Result: &struct {
-					Slice []string
-				}{Slice: []string{"foo", "bar", "[redacted:email]"}},
-			},
-		},
-		{
-			Name: "struct tags",
-			Struct: &struct {
-				Hashed   string `scrub:"hash"`
-				Redacted string `scrub:"redact"`
-				Email    string `scrub:"ignore"`
-			}{
-				Hashed:   "foo",
-				Redacted: "foo",
-				Email:    "foo",
+				Hashed: "foo",
 			},
 			Expectation: Expectation{
 				Result: &struct {
-					Hashed   string `scrub:"hash"`
-					Redacted string `scrub:"redact"`
-					Email    string `scrub:"ignore"`
+					Hashed       string `scrub:"hash"`
+					NilInterface *string
 				}{
-					Hashed:   "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
-					Redacted: "[redacted]",
-					Email:    "foo",
+					Hashed:       "[redacted:md5:acbd18db4cc2f85cedef654fccc4a4d8]",
+					NilInterface: nil,
 				},
 			},
-		},
-		{
-			Name: "trusted struct",
-			Struct: scrubStructToTest(&StructToTest{
-				Username: "foo",
-				Email:    "foo@bar.com",
-				Password: "foobar",
-			}),
-			Expectation: Expectation{
-				Result: &TrustedStructToTest{
-					StructToTest: StructToTest{
-						Username: "foo",
-						Email:    "trusted:[redacted:email]",
-						Password: "trusted:[redacted]",
-					},
-				},
-			},
-		},
-		{
-			Name: "trusted interface",
-			Struct: scrubStructToTestAsTrustedValue(&StructToTest{
-				Username: "foo",
-				Email:    "foo@bar.com",
-				Password: "foobar",
-			}),
-			Expectation: Expectation{
-				Result: &TrustedStructToTest{
-					StructToTest: StructToTest{
-						Username: "foo",
-						Email:    "trusted:[redacted:email]",
-						Password: "trusted:[redacted]",
-					},
-				},
-			},
-		},
-		{
-			Name: "contains unexported pointers",
-			Struct: UnexportedStructToTest{
-				Exported:      "foo",
-				unexportedPtr: nil,
-			},
-			Expectation: Expectation{
-				Result: UnexportedStructToTest{
-					Exported:      "foo",
-					unexportedPtr: nil,
-				},
-			},
-			CmpOpts: []cmp.Option{cmpopts.IgnoreUnexported(UnexportedStructToTest{})},
 		},
 	}
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[scrubber] skip if interface is nil 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-875

## How to test
<!-- Provide steps to test this PR -->
see unit test

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
