### PR TITLE
[server] Fix permission check for logs streaming

### DIFF
--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -677,11 +677,10 @@ export class PrebuildManager {
         onLog: (chunk: Uint8Array) => Promise<void>,
     ): Promise<{ taskUrl: string } | undefined> {
         const prebuild = await this.getPrebuild({}, userId, prebuildId);
-        const organizationId = prebuild?.info.teamId;
-        if (!prebuild || !organizationId) {
+        if (!prebuild) {
             throw new ApplicationError(ErrorCodes.PRECONDITION_FAILED, "prebuild workspace not found");
         }
-        await this.auth.checkPermissionOnProject(userId, "read_prebuild", organizationId);
+        await this.auth.checkPermissionOnProject(userId, "read_prebuild", prebuild.info.projectId);
 
         const instance = await this.workspaceService.getCurrentInstance(userId, prebuild.workspace.id, {
             skipPermissionCheck: true,

--- a/components/server/src/projects/projects-service.ts
+++ b/components/server/src/projects/projects-service.ts
@@ -447,8 +447,10 @@ export class ProjectsService {
                 partialProject.settings.prebuilds.triggerStrategy = "activity-based";
             }
         }
+
         return this.projectDB.updateProject(partialProject);
     }
+
     private async checkProjectSettings(userId: string, settings?: PartialProject["settings"]) {
         if (!settings) {
             return;

--- a/components/server/src/workspace/headless-log-service.ts
+++ b/components/server/src/workspace/headless-log-service.ts
@@ -102,7 +102,7 @@ export class HeadlessLogService {
             }
         }
 
-        // we were unable to get a repsonse from supervisor - let's try content service next
+        // we were unable to get a response from supervisor - let's try content service next
         return await this.contentServiceListLogs(wsi, ownerId);
     }
 


### PR DESCRIPTION
## Description

Fixes an oopsie I made in https://github.com/gitpod-io/gitpod/pull/20353 regarding permission checks. The change was supposed to unblock collaborators so that they can stream prebuild logs leveraging their permissions on the project level (in contrast to organization level), but I forgot to update the argument we pass to `checkPermissionOnProject` to be the `projectId` instead of the `organizationId` that was there before.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1011

## How to test

There's a preview env: https://ft-fix-prebuilds.preview.gitpod-dev.com/prebuilds/
You can [join my org](https://ft-fix-prebuilds.preview.gitpod-dev.com/orgs/join?inviteId=55fdb16d-215e-4744-b1a7-5103d7ab914b) and look at [this prebuild](https://ft-fix-prebuilds.preview.gitpod-dev.com/prebuilds/6d341044-9811-407c-956c-28aa3d159149) to confirm streaming works again.


/hold
