### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,15 +13,15 @@ defaultArgs:
   codeWebExtensionCommit: 3953e8160fffa97dd4a4509542b4bf7ff9b704cd
   xtermCommit: d547d4ff4590b66c3ea24342fc62e3afcf6b77bc
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.3.tar.gz"
-  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.3.tar.gz"
-  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.3.tar.gz"
-  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.3.tar.gz"
-  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.3.tar.gz"
-  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.3.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2024.3.1.1.tar.gz"
+  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2024.3.1.tar.gz"
+  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-professional-2024.3.1.1.tar.gz"
+  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2024.3.1.1.tar.gz"
+  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2024.3.1.1.tar.gz"
+  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2024.3.1.1.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.4.tar.gz"
-  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.3.tar.gz"
-  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2024.3.tar.gz"
+  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2024.3.1.1.tar.gz"
+  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2024.3.2.tar.gz"
   jbBackendVersion: "latest"
   dockerVersion: "20.10.24"
   dockerComposeVersion: "2.27.0-gitpod.0"

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -2,10 +2,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=243.21565
+pluginSinceBuild=243.22562
 pluginUntilBuild=243.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2024.3
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=243.21565-EAP-CANDIDATE-SNAPSHOT
+platformVersion=243.22562-EAP-CANDIDATE-SNAPSHOT

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -2,7 +2,7 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=243.22562
+pluginSinceBuild=243.21565
 pluginUntilBuild=243.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -223,6 +223,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/intellij:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
+          {
             "version": "2024.2.4",
             "image": "{{.Repository}}/ide/intellij:commit-4c69ad0670cc4cfbf43910e1db700ad90acd5ac6",
             "imageLayers": [
@@ -332,6 +340,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/goland:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
+          {
             "version": "2024.2.3",
             "image": "{{.Repository}}/ide/goland:commit-4c69ad0670cc4cfbf43910e1db700ad90acd5ac6",
             "imageLayers": [
@@ -434,6 +450,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/pycharm:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
+          {
             "version": "2024.2.4",
             "image": "{{.Repository}}/ide/pycharm:commit-4c69ad0670cc4cfbf43910e1db700ad90acd5ac6",
             "imageLayers": [
@@ -535,6 +559,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/phpstorm:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
+          {
             "version": "2024.2.4",
             "image": "{{.Repository}}/ide/phpstorm:commit-4c69ad0670cc4cfbf43910e1db700ad90acd5ac6",
             "imageLayers": [
@@ -627,6 +659,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/rubymine:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
           {
             "version": "2024.2.4",
             "image": "{{.Repository}}/ide/rubymine:commit-4c69ad0670cc4cfbf43910e1db700ad90acd5ac6",
@@ -728,6 +768,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/webstorm:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
           {
             "version": "2024.2.4",
             "image": "{{.Repository}}/ide/webstorm:commit-4c69ad0670cc4cfbf43910e1db700ad90acd5ac6",
@@ -891,6 +939,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/clion:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
+          {
             "version": "2024.2.3",
             "image": "{{.Repository}}/ide/clion:commit-08d82bcac5ec4e6a3a6376b664c765f233dfd827",
             "imageLayers": [
@@ -975,6 +1031,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2024.3",
+            "image": "{{.Repository}}/ide/rustrover:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-3a58ac914d4119398141faf90baee2632e7ea842",
+              "{{.Repository}}/ide/jb-launcher:commit-3a58ac914d4119398141faf90baee2632e7ea842"
+            ]
+          },
           {
             "version": "2024.2.5",
             "image": "{{.Repository}}/ide/rustrover:commit-08d82bcac5ec4e6a3a6376b664c765f233dfd827",


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR
8. Warmup is working properly using IntelliJ and spring-petclinic project sample

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_