### PR TITLE
Gpl/970-multi-org-tests

### DIFF
--- a/components/server/src/iam/iam-session-app.spec.ts
+++ b/components/server/src/iam/iam-session-app.spec.ts
@@ -19,7 +19,7 @@ import request from "supertest";
 
 import * as chai from "chai";
 import { OIDCCreateSessionPayload } from "./iam-oidc-create-session-payload";
-import { TeamMemberInfo, TeamMemberRole, User } from "@gitpod/gitpod-protocol";
+import { TeamMemberInfo, User } from "@gitpod/gitpod-protocol";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "../user/user-service";
 import { TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
@@ -40,9 +40,6 @@ class TestIamSessionApp {
     };
 
     protected userServiceMock: Partial<UserService> = {
-        createUser: (params) => {
-            return { id: "id-new-user" } as any;
-        },
         updateUser: (userId, update) => {
             return {} as any;
         },
@@ -67,8 +64,10 @@ class TestIamSessionApp {
         listMembers: async (teamId: string): Promise<TeamMemberInfo[]> => {
             return [];
         },
-        async addOrUpdateMember(userId: string, teamId: string, memberId: string, role: TeamMemberRole): Promise<void> {
-            this.memberships.add(memberId);
+        async createOrgOwnedUser(params): Promise<User> {
+            const user = { id: "id-new-user" } as any as User;
+            this.memberships.add(user.id);
+            return user;
         },
     };
 

--- a/components/server/src/orgs/organization-service.spec.ts
+++ b/components/server/src/orgs/organization-service.spec.ts
@@ -78,7 +78,7 @@ describe("OrganizationService", async () => {
             } as any as InstallationService);
             container.bind(StripeService).toConstantValue({} as any as StripeService);
             container.bind(UsageService).toConstantValue({} as any as UsageService);
-            container.bind(UserAuthentication).toSelf().inSingletonScope();
+            container.bind(UserAuthentication).toConstantValue({} as any as UserAuthentication);
             os = container.get(OrganizationService);
         });
 

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -326,7 +326,8 @@ export class OrganizationService {
     }
 
     /**
-     * Conveniece method, analogue to UserService.createUser()
+     * Convenience method, analogue to UserService.createUser()
+``
      */
     public async createOrgOwnedUser(params: CreateUserParams & { organizationId: string }): Promise<User> {
         return this.userDB.transaction(async (_, ctx) => {

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -13,6 +13,7 @@ import {
     TeamMembershipInvite,
     WorkspaceTimeoutDuration,
     OrgMemberRole,
+    User,
 } from "@gitpod/gitpod-protocol";
 import { IAnalyticsWriter } from "@gitpod/gitpod-protocol/lib/analytics";
 import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
@@ -33,7 +34,7 @@ import { StripeService } from "../billing/stripe-service";
 import { AttributionId } from "@gitpod/gitpod-protocol/lib/attribution";
 import { UsageService } from "./usage-service";
 import { CostCenter_BillingStrategy } from "@gitpod/gitpod-protocol/lib/usage";
-import { UserAuthentication } from "../user/user-authentication";
+import { CreateUserParams, UserAuthentication } from "../user/user-authentication";
 
 @injectable()
 export class OrganizationService {
@@ -322,6 +323,25 @@ export class OrganizationService {
         });
 
         return invite.teamId;
+    }
+
+    /**
+     * Conveniece method, analogue to UserService.createUser()
+     */
+    public async createOrgOwnedUser(params: CreateUserParams & { organizationId: string }): Promise<User> {
+        return this.userDB.transaction(async (_, ctx) => {
+            const user = await this.userService.createUser(params, ctx);
+
+            await this.addOrUpdateMember(
+                SYSTEM_USER_ID,
+                params.organizationId,
+                user.id,
+                "member",
+                { flexibleRole: true },
+                ctx,
+            );
+            return user;
+        });
     }
 
     /**

--- a/components/server/src/user/env-var-service.spec.db.ts
+++ b/components/server/src/user/env-var-service.spec.db.ts
@@ -19,7 +19,7 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
+import { createTestContainer } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "./user-service";
@@ -27,7 +27,6 @@ import { expectError } from "../test/expect-utils";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { EnvVarService } from "./env-var-service";
 import { ProjectsService } from "../projects/projects-service";
-import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -98,9 +97,8 @@ describe("EnvVarService", async () => {
 
         const orgService = container.get<OrganizationService>(OrganizationService);
         org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");
-        const invite = await orgService.getOrCreateInvite(BUILTIN_INSTLLATION_ADMIN_USER_ID, org.id);
 
-        member = await userService.createUser({
+        member = await orgService.createOrgOwnedUser({
             organizationId: org.id,
             identity: {
                 authId: "foo",
@@ -109,7 +107,6 @@ describe("EnvVarService", async () => {
                 primaryEmail: "yolo@yolo.com",
             },
         });
-        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
         stranger = await userService.createUser({
             identity: {
                 authId: "foo2",

--- a/components/server/src/user/gitpod-token-service.spec.db.ts
+++ b/components/server/src/user/gitpod-token-service.spec.db.ts
@@ -10,14 +10,13 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
+import { createTestContainer } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "./user-service";
 import { expectError } from "../test/expect-utils";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
 import { GitpodTokenService } from "./gitpod-token-service";
-import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -35,10 +34,9 @@ describe("GitpodTokenService", async () => {
 
         const orgService = container.get<OrganizationService>(OrganizationService);
         org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");
-        const invite = await orgService.getOrCreateInvite(BUILTIN_INSTLLATION_ADMIN_USER_ID, org.id);
 
         const userService = container.get<UserService>(UserService);
-        member = await userService.createUser({
+        member = await orgService.createOrgOwnedUser({
             organizationId: org.id,
             identity: {
                 authId: "foo",
@@ -47,7 +45,6 @@ describe("GitpodTokenService", async () => {
                 primaryEmail: "yolo@yolo.com",
             },
         });
-        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
         stranger = await userService.createUser({
             identity: {
                 authId: "foo2",

--- a/components/server/src/user/sshkey-service.spec.db.ts
+++ b/components/server/src/user/sshkey-service.spec.db.ts
@@ -10,14 +10,13 @@ import { Experiments } from "@gitpod/gitpod-protocol/lib/experiments/configcat-s
 import * as chai from "chai";
 import { Container } from "inversify";
 import "mocha";
-import { createTestContainer, withTestCtx } from "../test/service-testing-container-module";
+import { createTestContainer } from "../test/service-testing-container-module";
 import { resetDB } from "@gitpod/gitpod-db/lib/test/reset-db";
 import { SSHKeyService } from "./sshkey-service";
 import { OrganizationService } from "../orgs/organization-service";
 import { UserService } from "./user-service";
 import { expectError } from "../test/expect-utils";
 import { ErrorCodes } from "@gitpod/gitpod-protocol/lib/messaging/error";
-import { SYSTEM_USER } from "../authorization/authorizer";
 
 const expect = chai.expect;
 
@@ -46,10 +45,9 @@ describe("SSHKeyService", async () => {
 
         const orgService = container.get<OrganizationService>(OrganizationService);
         org = await orgService.createOrganization(BUILTIN_INSTLLATION_ADMIN_USER_ID, "myOrg");
-        const invite = await orgService.getOrCreateInvite(BUILTIN_INSTLLATION_ADMIN_USER_ID, org.id);
 
         const userService = container.get<UserService>(UserService);
-        member = await userService.createUser({
+        member = await orgService.createOrgOwnedUser({
             organizationId: org.id,
             identity: {
                 authId: "foo",
@@ -58,7 +56,6 @@ describe("SSHKeyService", async () => {
                 primaryEmail: "yolo@yolo.com",
             },
         });
-        await withTestCtx(SYSTEM_USER, () => orgService.joinOrganization(member.id, invite.id));
         stranger = await userService.createUser({
             identity: {
                 authId: "foo2",


### PR DESCRIPTION
## Description
Fixes the tests after the latest "not allowed to join org" changes

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
