### PR TITLE
[dashboard] Fix bottom page margins for Prebuilds, Repositories and Insights

### DIFF
--- a/components/dashboard/src/Insights.tsx
+++ b/components/dashboard/src/Insights.tsx
@@ -56,7 +56,7 @@ export const Insights = () => {
     return (
         <>
             <Header title="Insights" subtitle="Insights into workspace sessions in your organization" />
-            <div className="app-container pt-5">
+            <div className="app-container pt-5 pb-8">
                 <div
                     className={classNames(
                         "flex flex-col items-start space-y-3 justify-between",
@@ -142,7 +142,7 @@ export const Insights = () => {
                     </ItemsList>
                 </div>
 
-                <div className="mt-4 mb-8 flex flex-row justify-center">
+                <div className="mt-4 flex flex-row justify-center">
                     {hasNextPage ? (
                         <LoadingButton
                             variant="secondary"

--- a/components/dashboard/src/prebuilds/list/PrebuildListPage.tsx
+++ b/components/dashboard/src/prebuilds/list/PrebuildListPage.tsx
@@ -12,7 +12,7 @@ const PrebuildListPage = () => {
     useDocumentTitle("Prebuilds");
 
     return (
-        <div className="app-container mb-8">
+        <div className="app-container pb-8">
             <PageHeading title="Prebuilds" subtitle="Review prebuilds of your added repositories." />
             <PrebuildsList />
         </div>

--- a/components/dashboard/src/repositories/list/RepositoryList.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryList.tsx
@@ -92,7 +92,7 @@ const RepositoryListPage: FC = () => {
 
     return (
         <>
-            <div className="app-container mb-8">
+            <div className="app-container pb-8">
                 <PageHeading
                     title="Repository settings"
                     subtitle="Configure and refine the experience of working with a repository in Gitpod."

--- a/components/dashboard/src/repositories/list/RepositoryTable.tsx
+++ b/components/dashboard/src/repositories/list/RepositoryTable.tsx
@@ -132,7 +132,7 @@ export const RepositoryTable: FC<Props> = ({
                     </div>
                 )}
 
-                <div className="mt-4 mb-8 flex flex-row justify-center">
+                <div className="mt-4 flex flex-row justify-center">
                     {hasNextPage ? (
                         <LoadingButton variant="secondary" onClick={onLoadNextPage} loading={isFetchingNextPage}>
                             Load more


### PR DESCRIPTION
## Description

The pages right now did not properly keep their distance from the end of the viewport, making the last element hard to reach on mobile, unreadable and aesthetically displeasing.

| Before | After |
|--------|--------|
| <img width="1319" alt="image" src="https://github.com/user-attachments/assets/cafb6f7c-be1f-4cca-9b73-4b6ba1cf3403" /> | <img width="1319" alt="image" src="https://github.com/user-attachments/assets/f358835d-35bb-422c-954a-615bb95f834d" /> | 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

I tested these changes in a preview environment for another PR (see screenshots). Feel free to trigger a preview env for this one, but you'll also have to fill up the page with entities (such as prebuilds, repos or workspaces for insights) to observe the fixed margins.

/hold
