### PR TITLE
[server] Fix context setting for PRs for insights

### DIFF
--- a/components/dashboard/src/insights/download/download-sessions.ts
+++ b/components/dashboard/src/insights/download/download-sessions.ts
@@ -83,7 +83,7 @@ const downloadUsageCSV = async ({
 }: Args): Promise<DownloadUsageCSVResponse> => {
     const start = dayjs(from?.toDate()).format("YYYYMMDD");
     const end = dayjs(to?.toDate()).format("YYYYMMDD");
-    const filename = `gitpod-usage-${organizationName}-${start}-${end}.csv`;
+    const filename = `gitpod-sessions-${organizationName}-${start}-${end}.csv`;
 
     const records = await getAllWorkspaceSessions({
         organizationId,

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -170,7 +170,7 @@ import {
     WorkspaceSession_Owner,
     WorkspaceSession_WorkspaceContext,
     WorkspaceSession_WorkspaceContext_Repository,
-    WorkspaceSession_WorkspaceContext_RefType
+    WorkspaceSession_WorkspaceContext_RefType,
 } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { BigIntToJson } from "@gitpod/gitpod-protocol/lib/util/stringify";
 import { getPrebuildLogPath } from "./prebuild-utils";
@@ -211,7 +211,9 @@ export class PublicAPIConverter {
         const { metrics } = arg.instance.status;
         result.metrics = new WorkspaceSession_Metrics({
             totalImageSize: metrics?.image?.totalSize ? BigInt(metrics.image.totalSize) : undefined,
-            workspaceImageSize: metrics?.image?.workspaceImageSize ? BigInt(metrics.image.workspaceImageSize) : undefined,
+            workspaceImageSize: metrics?.image?.workspaceImageSize
+                ? BigInt(metrics.image.workspaceImageSize)
+                : undefined,
         });
 
         result.id = arg.instance.id;
@@ -460,10 +462,12 @@ export class PublicAPIConverter {
 
     toWorkspaceSessionContext(arg: WorkspaceContext): WorkspaceSession_WorkspaceContext {
         const result = new WorkspaceSession_WorkspaceContext();
-        if (NavigatorContext.is(arg)) {
+        if (CommitContext.is(arg)) {
             result.revision = arg.revision;
             result.refType = this.toRefType(arg.refType);
-            result.path = arg.path;
+            if (NavigatorContext.is(arg)) {
+                result.path = arg.path;
+            }
             result.repository = new WorkspaceSession_WorkspaceContext_Repository({
                 cloneUrl: arg.repository.cloneUrl,
                 host: arg.repository.host,


### PR DESCRIPTION
## Description

An oopsie was made, and we were checking if the WS context is `NavigatorContext` instead of the proper and looser check against `CommitContext`, which also includes Issue and PR contexts.

This resulted in exported insights CSV reports to not have any of the ctx URL parsed segments available when the WS context was a PR.

Also changes the default download name of the CSV to differentiate it from the usage export.