### PR TITLE
[server] fix private GitHub avatars

### DIFF
--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -102,9 +102,9 @@ export class GitHubAuthProvider extends GenericAuthProvider {
             const publicAvatarURL = new URL(avatar_url);
             if (publicAvatarURL.host === "private-avatars.githubusercontent.com") {
                 // github has recently been rolling out private JWT-signed avatar URLs which expire after a short time
-                // we need to use the public avatar URL instead so that the avatar is displayed correctly and fits into our database (which is capped at 255 chars)
+                // we need to use the public avatar URL instead so that the avatar is displayed correctly and fits into our database column (which is capped at 255 chars)
                 publicAvatarURL.host = "avatars.githubusercontent.com";
-                publicAvatarURL.search = "";
+                publicAvatarURL.searchParams.delete("jwt");
             }
 
             // https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/

--- a/components/server/src/github/github-auth-provider.ts
+++ b/components/server/src/github/github-auth-provider.ts
@@ -99,6 +99,13 @@ export class GitHubAuthProvider extends GenericAuthProvider {
                 data: { id, login, avatar_url, name, company, created_at },
                 headers,
             } = currentUser;
+            const publicAvatarURL = new URL(avatar_url);
+            if (publicAvatarURL.host === "private-avatars.githubusercontent.com") {
+                // github has recently been rolling out private JWT-signed avatar URLs which expire after a short time
+                // we need to use the public avatar URL instead so that the avatar is displayed correctly and fits into our database (which is capped at 255 chars)
+                publicAvatarURL.host = "avatars.githubusercontent.com";
+                publicAvatarURL.search = "";
+            }
 
             // https://developer.github.com/apps/building-oauth-apps/understanding-scopes-for-oauth-apps/
             // e.g. X-OAuth-Scopes: repo, user
@@ -125,7 +132,7 @@ export class GitHubAuthProvider extends GenericAuthProvider {
                 authUser: {
                     authId: String(id),
                     authName: login,
-                    avatarUrl: avatar_url,
+                    avatarUrl: publicAvatarURL.toString(),
                     name,
                     primaryEmail: filterPrimaryEmail(userEmails),
                     company,


### PR DESCRIPTION
## Description

A recent GitHub change changed the way of accessing a user's avatar. Potentially as an anti-bot/spam measure, GitHub now issues JWT-signed URLs for avatars on both https://github.com and as part of their API responses **to some users**, making it impossible for us to continue storing them like we do now - i.e. without any refreshes ever. Additionally, these JWT signatures inflate the URL length, preventing it from fitting into our DB's `avatarUrl` column.

Let's take a look at the new URL structure:
```
https://private-avatars.githubusercontent.com/u/37021919?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTEiLCJleHAiOjE3MzQ0MjYwMDAsIm5iZiI6MTczNDQyNDgwMCwicGF0aCI6Ii91LzM3MDIxOTE5In0.zOrR2kgZWVvZqcVgoUwADtQqQmZ6Yh9Tie1CQPi7ADY&s=200&v=4
```

Here, we can see the `jwt` query param being used to authorize the request. If it's omitted, invalid, or when the underlying JWT expires, we get a 404.

The old avatar URLs seem to still work as before, but don't get issued anymore to the users in this cohort.

```
https://avatars.githubusercontent.com/u/37021919?v=4
```

What this PR does is that it simply rewrites the `private-avatars.githubusercontent.com` URL into a `avatars.githubusercontent.com` if it encounters it.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1050

## How to test

Try logging in into the preview environment, that's all.

https://ft-gh-public-avatars.preview.gitpod-dev.com/workspaces

/hold