### PR TITLE
[dashboard] Fix Arc favourites

### DIFF
--- a/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
+++ b/components/dashboard/src/components/podkit/buttons/LinkButton.tsx
@@ -6,27 +6,30 @@
 
 import { Link } from "react-router-dom";
 import { Button, ButtonProps } from "@podkit/buttons/Button";
-import React from "react";
+import { forwardRef, HTMLAttributeAnchorTarget } from "react";
 
 export interface LinkButtonProps extends ButtonProps {
     asChild?: false;
     href: string;
+    target?: HTMLAttributeAnchorTarget;
     isExternalUrl?: boolean;
 }
 
 /**
  * A HTML anchor element styled as a button.
  */
-export const LinkButton = React.forwardRef<HTMLButtonElement, LinkButtonProps>(
-    ({ asChild, children, href, ...props }, ref) => {
+export const LinkButton = forwardRef<HTMLButtonElement, LinkButtonProps>(
+    ({ asChild, children, href, target, ...props }, ref) => {
         return (
             <Button ref={ref} {...props} asChild>
                 {props.isExternalUrl ? (
-                    <a href={href} target="_blank" rel="noreferrer">
+                    <a href={href} target={target ?? "_blank"} rel="noreferrer">
                         {children}
                     </a>
                 ) : (
-                    <Link to={href}>{children}</Link>
+                    <Link to={href} target={target}>
+                        {children}
+                    </Link>
                 )}
             </Button>
         );

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -107,6 +107,10 @@ export interface StartWorkspaceState {
      * Set to prevent multiple redirects to the same URL when the User Agent ignores our wish to open links in the same tab (by setting window.location.href).
      */
     redirected?: boolean;
+    /**
+     * Determines whether `redirected` has been `true` for long enough to display our "new tab" info banner without racing with same-tab redirection in regular setups
+     */
+    showRedirectMessage?: boolean;
 }
 
 // TODO: use Function Components
@@ -474,6 +478,9 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         }
 
         this.setState({ redirected: true });
+        setTimeout(() => {
+            this.setState({ showRedirectMessage: true });
+        }, 2000);
     }
 
     private openDesktopLink(link: string) {
@@ -767,7 +774,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 workspaceId={this.props.workspaceId}
             >
                 {statusMessage}
-                {this.state.redirected && (
+                {this.state.showRedirectMessage && (
                     <>
                         <Alert type="info" className="mt-4 w-112">
                             We redirected you to your workspace, but your browser probably opened it in another tab.

--- a/components/dashboard/src/start/StartWorkspace.tsx
+++ b/components/dashboard/src/start/StartWorkspace.tsx
@@ -188,7 +188,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
         this.toDispose.dispose();
     }
 
-    componentDidUpdate(prevPros: StartWorkspaceProps, prevState: StartWorkspaceState) {
+    componentDidUpdate(_prevProps: StartWorkspaceProps, prevState: StartWorkspaceState) {
         const newPhase = this.state?.workspace?.status?.phase?.name;
         const oldPhase = prevState.workspace?.status?.phase?.name;
         const type = this.state.workspace?.spec?.type === WorkspaceSpec_WorkspaceType.PREBUILD ? "prebuild" : "regular";
@@ -757,6 +757,7 @@ export default class StartWorkspace extends React.Component<StartWorkspaceProps,
                 );
                 break;
         }
+
         return (
             <StartPage
                 phase={phase}


### PR DESCRIPTION
## Description

There's a funny bug that happened when you favorited the Gitpod Dashboard in Arc: when you open a favorited website, it does not want you to leave its origin and upon redirection to another one opens it in a new tab. This would be cool with us if we didn't try to redirect you on every workspace status update (spoiler alert: we do).

This PR stores a `redirected` property in the React state and prevents multiple redirects from happening. There's also a tiny piece of UI that tells you what happened if you end up back in the favorited tab, with buttons to more easily retry or get back to the dashboard.

<img width="1375" alt="image" src="https://github.com/user-attachments/assets/6b752e82-e208-43e9-b846-8079185c7431" />

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-820

## How to test

1. Get Arc
2. Favorite https://ft-fix-arc-redirects.preview.gitpod-dev.com/workspaces
3. Try opening a workspace

/hold
