### PR TITLE
[dashboard] Insights page improvements

### DIFF
--- a/components/dashboard/.vscode/settings.json
+++ b/components/dashboard/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+    "typescript.preferences.autoImportFileExcludePatterns": [
+        "@radix-ui/*"
+    ]
+}


### PR DESCRIPTION
## Description

It's been a week now since [we shipped](https://github.com/gitpod-io/gitpod/pull/20437) the first version of the Insights page, and since then, I've noticed a couple of things that could be improved.

Most importantly, this removes the superfluous time range selection, which is now only used when downloading a CSV out of the page.

Also improves the "no sessions found" message and the loading indicator.

## How to test

https://ft-insight5923783b6e.preview.gitpod-dev.com/insights

You can [join my org](https://ft-insight5923783b6e.preview.gitpod-dev.com/orgs/join?inviteId=c8370f4a-54cb-4bda-bb47-c132637e9ac2) to have a session under `/insights`
