### PR TITLE
[server] Fix workspace service's workspace ID validation

### DIFF
--- a/components/gitpod-protocol/src/util/parse-workspace-id.spec.ts
+++ b/components/gitpod-protocol/src/util/parse-workspace-id.spec.ts
@@ -7,6 +7,7 @@
 import * as chai from "chai";
 import { suite, test } from "@testdeck/mocha";
 import {
+    isWorkspaceId,
     matchesInstanceIdOrLegacyWorkspaceIdExactly,
     matchesNewWorkspaceIdExactly,
     parseWorkspaceIdFromHostname,
@@ -81,8 +82,17 @@ export class ParseWorkspaceIdTest {
         const actual = matchesNewWorkspaceIdExactly("moccasin-ferret-15599b3");
         expect(actual).to.be.false;
     }
-    @test public matchesWorkspaceIdExactly_new_negative_empty() {
-        const actual = matchesNewWorkspaceIdExactly(undefined);
+
+    @test public isWorkspaceId_positive_new() {
+        const actual = isWorkspaceId("moccasin-ferret-155799b3");
+        expect(actual).to.be.true;
+    }
+    @test public isWorkspaceId_positive_legacy() {
+        const actual = isWorkspaceId("b7e0eaf8-ec73-44ec-81ea-04859263b656");
+        expect(actual).to.be.true;
+    }
+    @test public isWorkspaceId_negative_empty() {
+        const actual = isWorkspaceId(undefined);
         expect(actual).to.be.false;
     }
 }

--- a/components/gitpod-protocol/src/util/parse-workspace-id.ts
+++ b/components/gitpod-protocol/src/util/parse-workspace-id.ts
@@ -49,10 +49,17 @@ export const matchesInstanceIdOrLegacyWorkspaceIdExactly = function (maybeId: st
  * @param maybeWorkspaceId
  * @returns
  */
-export const matchesNewWorkspaceIdExactly = function (maybeWorkspaceId?: string): boolean {
+export const matchesNewWorkspaceIdExactly = function (maybeWorkspaceId: string): boolean {
+    return REGEX_WORKSPACE_ID_EXACT.test(maybeWorkspaceId);
+};
+
+/**
+ * Matches both new and legacy workspace ids
+ */
+export const isWorkspaceId = function (maybeWorkspaceId?: string): boolean {
     if (!maybeWorkspaceId) {
         return false;
     }
 
-    return REGEX_WORKSPACE_ID_EXACT.test(maybeWorkspaceId);
+    return matchesNewWorkspaceIdExactly(maybeWorkspaceId) || REGEX_WORKSPACE_ID_LEGACY_EXACT.test(maybeWorkspaceId);
 };

--- a/components/server/src/api/workspace-service-api.ts
+++ b/components/server/src/api/workspace-service-api.ts
@@ -59,7 +59,7 @@ import { ApplicationError, ErrorCodes } from "@gitpod/gitpod-protocol/lib/messag
 import { ContextService } from "../workspace/context-service";
 import { UserService } from "../user/user-service";
 import { ContextParser } from "../workspace/context-parser-service";
-import { matchesNewWorkspaceIdExactly as isWorkspaceId } from "@gitpod/gitpod-protocol/lib/util/parse-workspace-id";
+import { isWorkspaceId } from "@gitpod/gitpod-protocol/lib/util/parse-workspace-id";
 import { SYSTEM_USER, SYSTEM_USER_ID } from "../authorization/authorizer";
 
 @injectable()


### PR DESCRIPTION
## Description

Fixes a regression from https://github.com/gitpod-io/gitpod/pull/20269 which resulted in treating requests against legacy workspace IDs as invalid ones.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1055

## How to test

Try doing a `GetWorkspace` with a UUIDv4 as the `workspaceId`.

/hold