### PR TITLE
[installer] Mount custom CA certs into all relevant places

### DIFF
--- a/install/installer/pkg/components/proxy/deployment.go
+++ b/install/installer/pkg/components/proxy/deployment.go
@@ -52,7 +52,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				SecretName: ctx.Config.Certificate.Name,
 			},
 		},
-	}}
+	},
+		common.CAVolume(),
+	}
 
 	volumeMounts := []corev1.VolumeMount{{
 		Name:      "vhosts",
@@ -60,7 +62,8 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 	}, {
 		Name:      "config-certificates",
 		MountPath: "/etc/caddy/certificates",
-	}}
+	},
+		common.CAVolumeMount()}
 
 	if pointer.BoolDeref(ctx.Config.ContainerRegistry.InCluster, false) {
 		volumes = append(volumes, corev1.Volume{

--- a/install/installer/pkg/components/public-api-server/deployment.go
+++ b/install/installer/pkg/components/public-api-server/deployment.go
@@ -50,6 +50,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			},
 		},
 		databaseSecretVolume,
+		common.CAVolume(),
 	}
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -59,6 +60,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 			SubPath:   configJSONFilename,
 		},
 		databaseSecretMount,
+		common.CAVolumeMount(),
 	}
 
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {

--- a/install/installer/pkg/components/public-api-server/deployment_test.go
+++ b/install/installer/pkg/components/public-api-server/deployment_test.go
@@ -65,6 +65,16 @@ func TestDeployment_ServerArguments(t *testing.T) {
 			},
 		},
 		{
+			Name: "ca-certificates",
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{
+						Name: "gitpod-ca-bundle",
+					},
+				},
+			},
+		},
+		{
 			Name: "stripe-secret",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{


### PR DESCRIPTION
## Description
Adds mounts of the custom CA to `proxy` and `public-api-server` deployments.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1056

## How to test


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
