### PR TITLE
[oidc] Fix the HEAD method call that checks reachability

### DIFF
--- a/components/public-api-server/pkg/apiv1/oidc.go
+++ b/components/public-api-server/pkg/apiv1/oidc.go
@@ -493,7 +493,7 @@ func assertIssuerIsReachable(ctx context.Context, issuer *url.URL) error {
 		},
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodHead, issuer.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, issuer.String()+"/.well-known/openid-configuration", nil)
 	if err != nil {
 		return err
 	}

--- a/components/server/src/user/user-authentication.ts
+++ b/components/server/src/user/user-authentication.ts
@@ -6,7 +6,7 @@
 
 import { injectable, inject } from "inversify";
 import { User, Identity, Token, IdentityLookup } from "@gitpod/gitpod-protocol";
-import { EmailDomainFilterDB, MaybeUser, UserDB } from "@gitpod/gitpod-db/lib";
+import { BUILTIN_INSTLLATION_ADMIN_USER_ID, EmailDomainFilterDB, MaybeUser, UserDB } from "@gitpod/gitpod-db/lib";
 import { HostContextProvider } from "../auth/host-context-provider";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import { Config } from "../config";
@@ -214,7 +214,10 @@ export class UserAuthentication {
         const isMultiOrgEnabled = await getExperimentsClientForBackend().getValueAsync("enable_multi_org", false, {
             gitpodHost: this.config.hostUrl.url.host,
         });
-        return isAllowedToCreateOrganization(user, isDedicated, isMultiOrgEnabled);
+        return (
+            isAllowedToCreateOrganization(user, isDedicated, isMultiOrgEnabled) ||
+            (isDedicated && user.id === BUILTIN_INSTLLATION_ADMIN_USER_ID)
+        );
     }
 
     async isBlocked(params: CheckIsBlockedParams): Promise<boolean> {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

We are checking connectivity with the root of issuer, which might fail if the root is not serving anything. We sometimes get a `503` on this endpoint. So this PR replaces it to call `.well-known/openid-configuration` endpoint which should exist if it is a valid OIDC service

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
