### PR TITLE
[server] log all deletion eligibility time updates

### DIFF
--- a/components/gitpod-protocol/go/gitpod-config-types.go
+++ b/components/gitpod-protocol/go/gitpod-config-types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2025 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -590,6 +590,22 @@ export class WorkspaceService {
                 );
                 return;
             }
+
+            log.info(
+                { userId, workspaceId, instanceId: instance?.id },
+                "[updateDeletionEligibilityTime] Updating deletion eligibility time for regular workspace",
+                {
+                    hasGitChanges,
+                    timestamps: new TrustedValue({
+                        deletionEligibilityTime: deletionEligibilityTime.toISOString(),
+                        instanceStoppingTime: instance?.stoppingTime,
+                        instanceStartedTime: instance?.startedTime,
+                        instanceCreationTime: instance?.creationTime,
+                        workspaceCreationTime: workspace.creationTime,
+                        lastActive,
+                    }),
+                },
+            );
             await this.db.updatePartial(workspaceId, {
                 deletionEligibilityTime: deletionEligibilityTime.toISOString(),
             });


### PR DESCRIPTION
## Description

With this PR, I propose to log all garbage collection threshold changes for all regular workspaces. With, we'll be able to better understand the GC lifecycle of a single workspace when investigating false soft deletions.

The drawback I see here is that we'll most likely get a lot of these logs - most notably since we call `updateDeletionEligibilityTime` every time on `updateGitStatus`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to https://gitpod.slack.com/archives/C071G5TTS49/p1734686954620309

## How to test

1. [Start a workspace](https://ft-deletioef73c7c5bf.preview.gitpod-dev.com/new#https://github.com/gitpod-demos/voting-app)
2. Make a git change
3. [Observe logs](https://cloudlogging.app.goo.gl/xkrKKeuPYQE6QKTj6)
