### PR TITLE
[code] update code image layers

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -12,7 +12,7 @@
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-b888cca216e44c9ba4b0c0d3a2df781bd0d36db5",
-          "{{.Repository}}/ide/code-codehelper:commit-7f43d48115b891e21545a08480e2f1e4e86e449d"
+          "{{.Repository}}/ide/code-codehelper:commit-7ac347a7713693c2df7f48f56324021925239cc0"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",


### PR DESCRIPTION
## Description
This PR updates the VS Code Browser image layers to the most recent installer version.

## How to test

Test if changes are working.

i.e.
- `code-helper` it can start browser code with extensions installed
- `gitpod-web-extension` extension functionalities are working well
- `code` is not expected it to be changed

### Preview status
gitpod:summary

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment