### PR TITLE
Introduce org-level GITPOD_IMAGE_AUTH

### DIFF
--- a/components/dashboard/src/data/organizations/org-envvar-queries.ts
+++ b/components/dashboard/src/data/organizations/org-envvar-queries.ts
@@ -1,0 +1,108 @@
+/**
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { OrganizationEnvironmentVariable } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
+import { envVarClient } from "../../service/public-api";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+const getListOrgEnvVarQueryKey = (orgId: string) => {
+    const key: any[] = ["organization", orgId, "envvar", "list"];
+
+    return key;
+};
+
+const getOrgEnvVarQueryKey = (orgId: string, variableId: string) => {
+    const key: any[] = ["organization", orgId, "envvar", { variableId }];
+
+    return key;
+};
+
+export const useListOrganizationEnvironmentVariables = (orgId: string) => {
+    return useQuery<OrganizationEnvironmentVariable[]>(getListOrgEnvVarQueryKey(orgId), {
+        queryFn: async () => {
+            const { environmentVariables } = await envVarClient.listOrganizationEnvironmentVariables({
+                organizationId: orgId,
+            });
+
+            return environmentVariables;
+        },
+        cacheTime: 1000 * 60 * 60 * 24, // one day
+    });
+};
+
+type DeleteEnvironmentVariableArgs = {
+    variableId: string;
+    organizationId: string;
+};
+export const useDeleteOrganizationEnvironmentVariable = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<void, Error, DeleteEnvironmentVariableArgs>({
+        mutationFn: async ({ variableId }) => {
+            void (await envVarClient.deleteOrganizationEnvironmentVariable({
+                environmentVariableId: variableId,
+            }));
+        },
+        onSuccess: (_, { organizationId, variableId }) => {
+            queryClient.invalidateQueries({ queryKey: getListOrgEnvVarQueryKey(organizationId) });
+            queryClient.invalidateQueries({ queryKey: getOrgEnvVarQueryKey(organizationId, variableId) });
+        },
+    });
+};
+
+type CreateEnvironmentVariableArgs = {
+    organizationId: string;
+    name: string;
+    value: string;
+};
+export const useCreateOrganizationEnvironmentVariable = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<OrganizationEnvironmentVariable, Error, CreateEnvironmentVariableArgs>({
+        mutationFn: async ({ organizationId, name, value }) => {
+            const { environmentVariable } = await envVarClient.createOrganizationEnvironmentVariable({
+                organizationId,
+                name,
+                value,
+            });
+            if (!environmentVariable) {
+                throw new Error("Failed to create environment variable");
+            }
+
+            return environmentVariable;
+        },
+        onSuccess: (_, { organizationId }) => {
+            queryClient.invalidateQueries({ queryKey: getListOrgEnvVarQueryKey(organizationId) });
+        },
+    });
+};
+
+type UpdateEnvironmentVariableArgs = CreateEnvironmentVariableArgs & {
+    variableId: string;
+};
+export const useUpdateOrganizationEnvironmentVariable = () => {
+    const queryClient = useQueryClient();
+
+    return useMutation<OrganizationEnvironmentVariable, Error, UpdateEnvironmentVariableArgs>({
+        mutationFn: async ({ variableId, name, value, organizationId }: UpdateEnvironmentVariableArgs) => {
+            const { environmentVariable } = await envVarClient.updateOrganizationEnvironmentVariable({
+                environmentVariableId: variableId,
+                organizationId,
+                name,
+                value,
+            });
+            if (!environmentVariable) {
+                throw new Error("Failed to update environment variable");
+            }
+
+            return environmentVariable;
+        },
+        onSuccess: (_, { organizationId, variableId }) => {
+            queryClient.invalidateQueries({ queryKey: getListOrgEnvVarQueryKey(organizationId) });
+            queryClient.invalidateQueries({ queryKey: getOrgEnvVarQueryKey(organizationId, variableId) });
+        },
+    });
+};

--- a/components/dashboard/src/service/json-rpc-envvar-client.ts
+++ b/components/dashboard/src/service/json-rpc-envvar-client.ts
@@ -10,21 +10,29 @@ import { EnvironmentVariableService } from "@gitpod/public-api/lib/gitpod/v1/env
 import {
     CreateConfigurationEnvironmentVariableRequest,
     CreateConfigurationEnvironmentVariableResponse,
+    CreateOrganizationEnvironmentVariableRequest,
+    CreateOrganizationEnvironmentVariableResponse,
     CreateUserEnvironmentVariableRequest,
     CreateUserEnvironmentVariableResponse,
     DeleteConfigurationEnvironmentVariableRequest,
     DeleteConfigurationEnvironmentVariableResponse,
+    DeleteOrganizationEnvironmentVariableRequest,
+    DeleteOrganizationEnvironmentVariableResponse,
     DeleteUserEnvironmentVariableRequest,
     DeleteUserEnvironmentVariableResponse,
     EnvironmentVariableAdmission,
     ListConfigurationEnvironmentVariablesRequest,
     ListConfigurationEnvironmentVariablesResponse,
+    ListOrganizationEnvironmentVariablesRequest,
+    ListOrganizationEnvironmentVariablesResponse,
     ListUserEnvironmentVariablesRequest,
     ListUserEnvironmentVariablesResponse,
     ResolveWorkspaceEnvironmentVariablesRequest,
     ResolveWorkspaceEnvironmentVariablesResponse,
     UpdateConfigurationEnvironmentVariableRequest,
     UpdateConfigurationEnvironmentVariableResponse,
+    UpdateOrganizationEnvironmentVariableRequest,
+    UpdateOrganizationEnvironmentVariableResponse,
     UpdateUserEnvironmentVariableRequest,
     UpdateUserEnvironmentVariableResponse,
 } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
@@ -163,7 +171,9 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
                 req.configurationId,
                 req.name ?? projectEnvVarfound.name,
                 req.value ?? "",
-                req.admission === EnvironmentVariableAdmission.PREBUILD ?? projectEnvVarfound.censored,
+                req.admission === EnvironmentVariableAdmission.UNSPECIFIED
+                    ? projectEnvVarfound.censored
+                    : req.admission === EnvironmentVariableAdmission.PREBUILD,
                 req.environmentVariableId,
             );
 
@@ -222,6 +232,30 @@ export class JsonRpcEnvvarClient implements PromiseClient<typeof EnvironmentVari
 
         const response = new DeleteConfigurationEnvironmentVariableResponse();
         return response;
+    }
+
+    async listOrganizationEnvironmentVariables(
+        req: PartialMessage<ListOrganizationEnvironmentVariablesRequest>,
+    ): Promise<ListOrganizationEnvironmentVariablesResponse> {
+        throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unimplemented");
+    }
+
+    async updateOrganizationEnvironmentVariable(
+        req: PartialMessage<UpdateOrganizationEnvironmentVariableRequest>,
+    ): Promise<UpdateOrganizationEnvironmentVariableResponse> {
+        throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unimplemented");
+    }
+
+    async createOrganizationEnvironmentVariable(
+        req: PartialMessage<CreateOrganizationEnvironmentVariableRequest>,
+    ): Promise<CreateOrganizationEnvironmentVariableResponse> {
+        throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unimplemented");
+    }
+
+    async deleteOrganizationEnvironmentVariable(
+        req: PartialMessage<DeleteOrganizationEnvironmentVariableRequest>,
+    ): Promise<DeleteOrganizationEnvironmentVariableResponse> {
+        throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Unimplemented");
     }
 
     async resolveWorkspaceEnvironmentVariables(

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -34,7 +34,7 @@ import { PlainMessage } from "@bufbuild/protobuf";
 import { useToast } from "../components/toasts/Toasts";
 import { NamedOrganizationEnvvarItem } from "./variables/NamedOrganizationEnvvarItem";
 import { useListOrganizationEnvironmentVariables } from "../data/organizations/org-envvar-queries";
-import { UserEnvVar } from "@gitpod/gitpod-protocol";
+import { EnvVar } from "@gitpod/gitpod-protocol";
 
 export default function TeamSettingsPage() {
     useDocumentTitle("Organization Settings - General");
@@ -50,7 +50,7 @@ export default function TeamSettingsPage() {
     const [updated, setUpdated] = useState(false);
 
     const orgEnvVars = useListOrganizationEnvironmentVariables(org?.id || "");
-    const gitpodImageAuthEnvVar = orgEnvVars.data?.find((v) => v.name === UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME);
+    const gitpodImageAuthEnvVar = orgEnvVars.data?.find((v) => v.name === EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME);
 
     const updateOrg = useUpdateOrgMutation();
 
@@ -227,9 +227,9 @@ export default function TeamSettingsPage() {
                             <Subheading>Configure Docker registry permissions for the whole organization.</Subheading>
 
                             <NamedOrganizationEnvvarItem
-                                key={`envvar-named-${UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}`}
+                                key={`envvar-named-${EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}`}
                                 disabled={!isOwner}
-                                name={UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}
+                                name={EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}
                                 organizationId={org.id}
                                 variable={gitpodImageAuthEnvVar}
                             />

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -227,7 +227,6 @@ export default function TeamSettingsPage() {
                             <Subheading>Configure Docker registry permissions for the whole organization.</Subheading>
 
                             <NamedOrganizationEnvvarItem
-                                key={`envvar-named-${EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}`}
                                 disabled={!isOwner}
                                 name={EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}
                                 organizationId={org.id}

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -32,6 +32,9 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useDocumentTitle } from "../hooks/use-document-title";
 import { PlainMessage } from "@bufbuild/protobuf";
 import { useToast } from "../components/toasts/Toasts";
+import { NamedOrganizationEnvvarItem } from "./variables/NamedOrganizationEnvvarItem";
+import { useListOrganizationEnvironmentVariables } from "../data/organizations/org-envvar-queries";
+import { UserEnvVar } from "@gitpod/gitpod-protocol";
 
 export default function TeamSettingsPage() {
     useDocumentTitle("Organization Settings - General");
@@ -45,6 +48,9 @@ export default function TeamSettingsPage() {
     const [teamNameToDelete, setTeamNameToDelete] = useState("");
     const [teamName, setTeamName] = useState(org?.name || "");
     const [updated, setUpdated] = useState(false);
+
+    const orgEnvVars = useListOrganizationEnvironmentVariables(org?.id || "");
+    const gitpodImageAuthEnvVar = orgEnvVars.data?.find((v) => v.name === UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME);
 
     const updateOrg = useUpdateOrgMutation();
 
@@ -213,6 +219,21 @@ export default function TeamSettingsPage() {
                             installationDefaultWorkspaceImage={installationDefaultImage}
                             onClose={() => setShowImageEditModal(false)}
                         />
+                    )}
+
+                    {org?.id && (
+                        <ConfigurationSettingsField>
+                            <Heading3>Docker Registry authentication</Heading3>
+                            <Subheading>Configure Docker registry permissions for the whole organization.</Subheading>
+
+                            <NamedOrganizationEnvvarItem
+                                key={`envvar-named-${UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}`}
+                                disabled={!isOwner}
+                                name={UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}
+                                organizationId={org.id}
+                                variable={gitpodImageAuthEnvVar}
+                            />
+                        </ConfigurationSettingsField>
                     )}
 
                     {user?.organizationId !== org?.id && isOwner && (

--- a/components/dashboard/src/teams/variables/NamedOrganizationEnvvarItem.tsx
+++ b/components/dashboard/src/teams/variables/NamedOrganizationEnvvarItem.tsx
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { OrganizationEnvironmentVariable } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
+import { useCallback, useState } from "react";
+import { OrganizationRemoveEnvvarModal } from "./OrganizationRemoveEnvvarModal";
+import { InputField } from "../../components/forms/InputField";
+import { ReactComponent as Stack } from "../../icons/Repository.svg";
+import { Button } from "@podkit/buttons/Button";
+import { useCreateOrganizationEnvironmentVariable } from "../../data/organizations/org-envvar-queries";
+import Modal, { ModalBody, ModalFooter, ModalFooterAlert, ModalHeader } from "../../components/Modal";
+import { TextInputField } from "../../components/forms/TextInputField";
+import { useToast } from "../../components/toasts/Toasts";
+import { LoadingButton } from "@podkit/buttons/LoadingButton";
+
+type Props = {
+    disabled?: boolean;
+    organizationId: string;
+    name: string;
+    variable: OrganizationEnvironmentVariable | undefined;
+};
+export const NamedOrganizationEnvvarItem = ({ disabled, organizationId, name, variable }: Props) => {
+    const [showRemoveModal, setShowRemoveModal] = useState<boolean>(false);
+    const [showAddModal, setShowAddModal] = useState<boolean>(false);
+
+    const value = variable ? "*****" : "not set";
+
+    return (
+        <>
+            {variable && showRemoveModal && (
+                <OrganizationRemoveEnvvarModal
+                    variable={variable}
+                    organizationId={organizationId}
+                    onClose={() => setShowRemoveModal(false)}
+                />
+            )}
+
+            {showAddModal && (
+                <AddOrgEnvironmentVariableModal
+                    organizationId={organizationId}
+                    staticName={name}
+                    onClose={() => setShowAddModal(false)}
+                />
+            )}
+
+            <InputField disabled={disabled} className="w-full max-w-lg">
+                <div className="flex flex-col bg-gray-50 dark:bg-gray-800 p-3 rounded-lg">
+                    <div className="flex items-center justify-between">
+                        <div className="flex-1 flex items-center overflow-hidden h-8" title={value}>
+                            <span className="w-5 h-5 mr-1">
+                                <Stack />
+                            </span>
+                            <span className="truncate font-medium text-gray-700 dark:text-gray-200">{name}</span>
+                        </div>
+                        {!disabled && !variable && (
+                            <Button variant="link" onClick={() => setShowAddModal(true)}>
+                                Add
+                            </Button>
+                        )}
+                        {!disabled && variable && (
+                            <Button variant="link" onClick={() => setShowRemoveModal(true)}>
+                                Delete
+                            </Button>
+                        )}
+                    </div>
+                    <div className="mx-6 text-gray-400 dark:text-gray-500 truncate">
+                        <>{value}</>
+                        {disabled && (
+                            <>
+                                &nbsp;&middot;&nbsp; Requires <span className="font-medium">Owner</span> permissions to
+                                change
+                            </>
+                        )}
+                    </div>
+                </div>
+            </InputField>
+        </>
+    );
+};
+
+type AddOrgEnvironmentVariableModalProps = {
+    organizationId: string;
+    staticName?: string;
+    onClose: () => void;
+};
+export const AddOrgEnvironmentVariableModal = ({
+    organizationId,
+    staticName,
+    onClose,
+}: AddOrgEnvironmentVariableModalProps) => {
+    const { toast } = useToast();
+
+    const [name, setName] = useState(staticName || "");
+    const [value, setValue] = useState("");
+    const createVariable = useCreateOrganizationEnvironmentVariable();
+
+    const addVariable = useCallback(() => {
+        createVariable.mutateAsync(
+            {
+                organizationId,
+                name,
+                value,
+            },
+            {
+                onSuccess: () => {
+                    toast("Variable added");
+                    onClose();
+                },
+            },
+        );
+    }, [createVariable, organizationId, name, value, onClose, toast]);
+
+    return (
+        <Modal visible onClose={onClose} onSubmit={addVariable}>
+            <ModalHeader>Add a variable</ModalHeader>
+            <ModalBody>
+                <div className="mt-8">
+                    <TextInputField
+                        disabled={staticName !== undefined}
+                        label="Name"
+                        autoComplete={"off"}
+                        className="w-full"
+                        value={name}
+                        placeholder="Variable name"
+                        onChange={(name) => setName(name)}
+                        autoFocus
+                        required
+                    />
+                </div>
+                <div className="mt-4">
+                    <TextInputField
+                        label="Value"
+                        autoComplete={"off"}
+                        className="w-full"
+                        value={value}
+                        placeholder="Variable value"
+                        onChange={(value) => setValue(value)}
+                        required
+                    />
+                </div>
+            </ModalBody>
+            <ModalFooter
+                alert={
+                    createVariable.isError ? (
+                        <ModalFooterAlert type="danger">
+                            {String(createVariable.error).replace(/Error: Request \w+ failed with message: /, "")}
+                        </ModalFooterAlert>
+                    ) : null
+                }
+            >
+                <Button variant="secondary" onClick={onClose}>
+                    Cancel
+                </Button>
+                <LoadingButton type="submit" loading={createVariable.isLoading}>
+                    Add Variable
+                </LoadingButton>
+            </ModalFooter>
+        </Modal>
+    );
+};

--- a/components/dashboard/src/teams/variables/NamedOrganizationEnvvarItem.tsx
+++ b/components/dashboard/src/teams/variables/NamedOrganizationEnvvarItem.tsx
@@ -49,8 +49,8 @@ export const NamedOrganizationEnvvarItem = ({ disabled, organizationId, name, va
             <InputField disabled={disabled} className="w-full max-w-lg">
                 <div className="flex flex-col bg-gray-50 dark:bg-gray-800 p-3 rounded-lg">
                     <div className="flex items-center justify-between">
-                        <div className="flex-1 flex items-center overflow-hidden h-8" title={value}>
-                            <span className="w-5 h-5 mr-1">
+                        <div className="flex-1 flex items-center overflow-hidden h-8 gap-2" title={value}>
+                            <span className="w-5 h-5">
                                 <Stack />
                             </span>
                             <span className="truncate font-medium text-gray-700 dark:text-gray-200">{name}</span>

--- a/components/dashboard/src/teams/variables/NamedOrganizationEnvvarItem.tsx
+++ b/components/dashboard/src/teams/variables/NamedOrganizationEnvvarItem.tsx
@@ -66,7 +66,7 @@ export const NamedOrganizationEnvvarItem = ({ disabled, organizationId, name, va
                             </Button>
                         )}
                     </div>
-                    <div className="mx-6 text-gray-400 dark:text-gray-500 truncate">
+                    <div className="mx-7 text-gray-400 dark:text-gray-500 truncate">
                         <>{value}</>
                         {disabled && (
                             <>

--- a/components/dashboard/src/teams/variables/OrganizationRemoveEnvvarModal.tsx
+++ b/components/dashboard/src/teams/variables/OrganizationRemoveEnvvarModal.tsx
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { FunctionComponent, useCallback } from "react";
+import { useToast } from "../../components/toasts/Toasts";
+import ConfirmationModal from "../../components/ConfirmationModal";
+import type { OrganizationEnvironmentVariable } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
+import { useDeleteOrganizationEnvironmentVariable } from "../../data/organizations/org-envvar-queries";
+
+type Props = {
+    variable: OrganizationEnvironmentVariable;
+    organizationId: string;
+    onClose(): void;
+};
+export const OrganizationRemoveEnvvarModal: FunctionComponent<Props> = ({ variable, organizationId, onClose }) => {
+    const deleteVariable = useDeleteOrganizationEnvironmentVariable();
+    const { toast } = useToast();
+
+    const handleConfirmation = useCallback(() => {
+        deleteVariable.mutate(
+            { variableId: variable.id, organizationId },
+            {
+                onSuccess: () => {
+                    toast("Your variable was deleted");
+                    onClose();
+                },
+                onError: (err) => {
+                    toast(`Could not delete variable: ${err.message}`);
+                },
+            },
+        );
+    }, [organizationId, deleteVariable, onClose, toast, variable.id]);
+
+    return (
+        <ConfirmationModal
+            title="Delete variable"
+            areYouSureText="Are you sure you want to delete this variable?"
+            children={{
+                name: variable.name,
+            }}
+            buttonText="Delete variable"
+            warningText={deleteVariable.isError ? "There was a problem deleting this variable." : undefined}
+            onClose={onClose}
+            onConfirm={handleConfirmation}
+            visible
+        />
+    );
+};

--- a/components/dashboard/src/teams/variables/OrganizationRemoveEnvvarModal.tsx
+++ b/components/dashboard/src/teams/variables/OrganizationRemoveEnvvarModal.tsx
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2023 Gitpod GmbH. All rights reserved.
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
  * Licensed under the GNU Affero General Public License (AGPL).
  * See License.AGPL.txt in the project root for license information.
  */

--- a/components/gitpod-db/src/project-db.ts
+++ b/components/gitpod-db/src/project-db.ts
@@ -16,10 +16,7 @@ export interface ProjectDB extends TransactionalDB<ProjectDB> {
     storeProject(project: Project): Promise<Project>;
     updateProject(partialProject: PartialProject): Promise<Project>;
     markDeleted(projectId: string): Promise<void>;
-    findProjectEnvironmentVariable(
-        projectId: string,
-        envVar: ProjectEnvVarWithValue,
-    ): Promise<ProjectEnvVar | undefined>;
+    findProjectEnvironmentVariableByName(projectId: string, name: string): Promise<ProjectEnvVar | undefined>;
     addProjectEnvironmentVariable(projectId: string, envVar: ProjectEnvVarWithValue): Promise<ProjectEnvVar>;
     updateProjectEnvironmentVariable(
         projectId: string,
@@ -28,7 +25,9 @@ export interface ProjectDB extends TransactionalDB<ProjectDB> {
     getProjectEnvironmentVariables(projectId: string): Promise<ProjectEnvVar[]>;
     getProjectEnvironmentVariableById(variableId: string): Promise<ProjectEnvVar | undefined>;
     deleteProjectEnvironmentVariable(variableId: string): Promise<void>;
-    getProjectEnvironmentVariableValues(envVars: ProjectEnvVar[]): Promise<ProjectEnvVarWithValue[]>;
+    getProjectEnvironmentVariableValues(
+        envVars: Pick<ProjectEnvVar, "id" | "projectId">[],
+    ): Promise<ProjectEnvVarWithValue[]>;
     findCachedProjectOverview(projectId: string): Promise<Project.Overview | undefined>;
     storeCachedProjectOverview(projectId: string, overview: Project.Overview): Promise<void>;
     getProjectUsage(projectId: string): Promise<ProjectUsage | undefined>;

--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -10,6 +10,8 @@ import {
     TeamMemberRole,
     TeamMembershipInvite,
     OrganizationSettings,
+    OrgEnvVar,
+    OrgEnvVarWithValue,
 } from "@gitpod/gitpod-protocol";
 import { DBTeamMembership } from "./typeorm/entity/db-team-membership";
 import { TransactionalDB } from "./typeorm/transactional-db-impl";
@@ -43,4 +45,12 @@ export interface TeamDB extends TransactionalDB<TeamDB> {
     setOrgSettings(teamId: string, settings: Partial<OrganizationSettings>): Promise<OrganizationSettings>;
 
     hasActiveSSO(organizationId: string): Promise<boolean>;
+
+    addOrgEnvironmentVariable(orgId: string, envVar: OrgEnvVarWithValue): Promise<OrgEnvVar>;
+    updateOrgEnvironmentVariable(orgId: string, envVar: Partial<OrgEnvVarWithValue>): Promise<OrgEnvVar | undefined>;
+    getOrgEnvironmentVariableById(id: string): Promise<OrgEnvVar | undefined>;
+    findOrgEnvironmentVariableByName(orgId: string, name: string): Promise<OrgEnvVar | undefined>;
+    getOrgEnvironmentVariables(orgId: string): Promise<OrgEnvVar[]>;
+    getOrgEnvironmentVariableValues(envVars: OrgEnvVar[]): Promise<OrgEnvVarWithValue[]>;
+    deleteOrgEnvironmentVariable(id: string): Promise<void>;
 }

--- a/components/gitpod-db/src/team-db.ts
+++ b/components/gitpod-db/src/team-db.ts
@@ -51,6 +51,6 @@ export interface TeamDB extends TransactionalDB<TeamDB> {
     getOrgEnvironmentVariableById(id: string): Promise<OrgEnvVar | undefined>;
     findOrgEnvironmentVariableByName(orgId: string, name: string): Promise<OrgEnvVar | undefined>;
     getOrgEnvironmentVariables(orgId: string): Promise<OrgEnvVar[]>;
-    getOrgEnvironmentVariableValues(envVars: OrgEnvVar[]): Promise<OrgEnvVarWithValue[]>;
+    getOrgEnvironmentVariableValues(envVars: Pick<OrgEnvVar, "id" | "orgId">[]): Promise<OrgEnvVarWithValue[]>;
     deleteOrgEnvironmentVariable(id: string): Promise<void>;
 }

--- a/components/gitpod-db/src/typeorm/entity/db-org-env-var.ts
+++ b/components/gitpod-db/src/typeorm/entity/db-org-env-var.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { PrimaryColumn, Entity, Column } from "typeorm";
+import { TypeORM } from "../typeorm";
+import { OrgEnvVarWithValue } from "@gitpod/gitpod-protocol";
+import { Transformer } from "../transformer";
+import { getGlobalEncryptionService } from "@gitpod/gitpod-protocol/lib/encryption/encryption-service";
+
+@Entity()
+// on DB but not Typeorm: @Index("ind_lastModified", ["_lastModified"])   // DBSync
+export class DBOrgEnvVar implements OrgEnvVarWithValue {
+    @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
+    id: string;
+
+    // `orgId` is part of the primary key for safety reasons: This way it's impossible that a user
+    // (maliciously or by accident) sends us an environment variable that has the same private key (`id`)
+    // as the environment variable from another project.
+    @PrimaryColumn(TypeORM.UUID_COLUMN_TYPE)
+    orgId: string;
+
+    @Column()
+    name: string;
+
+    @Column({
+        type: "simple-json",
+        transformer: Transformer.compose(
+            Transformer.SIMPLE_JSON([]),
+            Transformer.encrypted(getGlobalEncryptionService),
+        ),
+    })
+    value: string;
+
+    @Column({
+        type: "varchar",
+        length: 36,
+    })
+    creationTime: string;
+}

--- a/components/gitpod-db/src/typeorm/migration/1737449780009-OrgEnvVars.ts
+++ b/components/gitpod-db/src/typeorm/migration/1737449780009-OrgEnvVars.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class OrgEnvVars1737449780009 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            "CREATE TABLE IF NOT EXISTS `d_b_org_env_var` (`id` char(36) NOT NULL, `orgId` char(36) NOT NULL, `name` varchar(255) NOT NULL, `value` text NOT NULL, `creationTime` varchar(36) NOT NULL, `_lastModified` timestamp(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6), PRIMARY KEY (`id`, `orgId`), KEY `ind_orgid` (orgId), KEY `ind_dbsync` (`_lastModified`)) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;",
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {}
+}

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -166,12 +166,12 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
         await projectUsageRepo.delete({ projectId });
     }
 
-    public async findProjectEnvironmentVariable(
+    public async findProjectEnvironmentVariableByName(
         projectId: string,
-        envVar: ProjectEnvVarWithValue,
+        name: string,
     ): Promise<ProjectEnvVar | undefined> {
         const envVarRepo = await this.getProjectEnvVarRepo();
-        return envVarRepo.findOne({ projectId, name: envVar.name, deleted: false });
+        return envVarRepo.findOne({ projectId, name, deleted: false });
     }
 
     public async addProjectEnvironmentVariable(
@@ -237,9 +237,13 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
         await envVarRepo.delete({ id: variableId });
     }
 
-    public async getProjectEnvironmentVariableValues(envVars: ProjectEnvVar[]): Promise<ProjectEnvVarWithValue[]> {
+    public async getProjectEnvironmentVariableValues(
+        envVars: Pick<ProjectEnvVar, "id" | "projectId">[],
+    ): Promise<ProjectEnvVarWithValue[]> {
         const envVarRepo = await this.getProjectEnvVarRepo();
-        const envVarsWithValues = await envVarRepo.findByIds(envVars);
+        const envVarsWithValues = await envVarRepo.findByIds(
+            envVars.map((v) => ({ id: v.id, projectId: v.projectId })),
+        );
         return envVarsWithValues;
     }
 

--- a/components/gitpod-db/src/typeorm/project-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/project-db-impl.ts
@@ -222,11 +222,11 @@ export class ProjectDBImpl extends TransactionalDBImpl<ProjectDB> implements Pro
         return envVars;
     }
 
-    public async getProjectEnvironmentVariableById(variableId: string): Promise<ProjectEnvVar | undefined> {
+    public async getProjectEnvironmentVariableById(id: string): Promise<ProjectEnvVar | undefined> {
         const envVarRepo = await this.getProjectEnvVarRepo();
-        const envVarWithValue = await envVarRepo.findOne({ id: variableId, deleted: false });
+        const envVarWithValue = await envVarRepo.findOne({ id, deleted: false });
         if (!envVarWithValue) {
-            return;
+            return undefined;
         }
         const envVar = toProjectEnvVar(envVarWithValue);
         return envVar;

--- a/components/gitpod-db/src/typeorm/team-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/team-db-impl.ts
@@ -480,9 +480,11 @@ export class TeamDBImpl extends TransactionalDBImpl<TeamDB> implements TeamDB {
         return envVars;
     }
 
-    public async getOrgEnvironmentVariableValues(envVars: OrgEnvVar[]): Promise<OrgEnvVarWithValue[]> {
+    public async getOrgEnvironmentVariableValues(
+        envVars: Pick<OrgEnvVar, "id" | "orgId">[],
+    ): Promise<OrgEnvVarWithValue[]> {
         const envVarRepo = await this.getOrgEnvVarRepo();
-        const envVarsWithValues = await envVarRepo.findByIds(envVars);
+        const envVarsWithValues = await envVarRepo.findByIds(envVars.map((v) => ({ id: v.id, orgId: v.orgId })));
         return envVarsWithValues;
     }
 

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -270,6 +270,18 @@ export interface UserEnvVar extends UserEnvVarValue {
     deleted?: boolean;
 }
 
+export namespace EnvVar {
+    export const GITPOD_IMAGE_AUTH_ENV_VAR_NAME = "GITPOD_IMAGE_AUTH";
+    /**
+     * - GITPOD_IMAGE_AUTH is documented https://www.gitpod.io/docs/configure/workspaces/workspace-image#use-a-private-docker-image
+     */
+    export const WhiteListFromReserved = [GITPOD_IMAGE_AUTH_ENV_VAR_NAME];
+
+    export function is(data: any): data is EnvVar {
+        return data.hasOwnProperty("name") && data.hasOwnProperty("value");
+    }
+}
+
 export namespace UserEnvVar {
     export const DELIMITER = "/";
     export const WILDCARD_ASTERISK = "*";
@@ -277,15 +289,18 @@ export namespace UserEnvVar {
     export const WILDCARD_DOUBLE_ASTERISK = "**";
     const WILDCARD_SHARP = "#"; // TODO(gpl) Where does this come from? Bc we have/had patterns as part of URLs somewhere, maybe...?
     const MIN_PATTERN_SEGMENTS = 2;
-    export const GITPOD_IMAGE_AUTH_ENV_VAR_NAME = "GITPOD_IMAGE_AUTH";
-
-    /**
-     * - GITPOD_IMAGE_AUTH is documented https://www.gitpod.io/docs/configure/workspaces/workspace-image#use-a-private-docker-image
-     */
-    export const WhiteListFromReserved = [GITPOD_IMAGE_AUTH_ENV_VAR_NAME];
 
     function isWildcard(c: string): boolean {
         return c === WILDCARD_ASTERISK || c === WILDCARD_SHARP;
+    }
+
+    export function is(data: any): data is UserEnvVar {
+        return (
+            EnvVar.is(data) &&
+            data.hasOwnProperty("id") &&
+            data.hasOwnProperty("userId") &&
+            data.hasOwnProperty("repositoryPattern")
+        );
     }
 
     /**
@@ -295,7 +310,7 @@ export namespace UserEnvVar {
     export function validate(variable: UserEnvVarValue): string | undefined {
         const name = variable.name;
         const pattern = variable.repositoryPattern;
-        if (!WhiteListFromReserved.includes(name) && name.startsWith("GITPOD_")) {
+        if (!EnvVar.WhiteListFromReserved.includes(name) && name.startsWith("GITPOD_")) {
             return "Name with prefix 'GITPOD_' is reserved.";
         }
         if (name.trim() === "") {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -277,11 +277,12 @@ export namespace UserEnvVar {
     export const WILDCARD_DOUBLE_ASTERISK = "**";
     const WILDCARD_SHARP = "#"; // TODO(gpl) Where does this come from? Bc we have/had patterns as part of URLs somewhere, maybe...?
     const MIN_PATTERN_SEGMENTS = 2;
+    export const GITPOD_IMAGE_AUTH_ENV_VAR_NAME = "GITPOD_IMAGE_AUTH";
 
     /**
      * - GITPOD_IMAGE_AUTH is documented https://www.gitpod.io/docs/configure/workspaces/workspace-image#use-a-private-docker-image
      */
-    export const WhiteListFromReserved = ["GITPOD_IMAGE_AUTH"];
+    export const WhiteListFromReserved = [GITPOD_IMAGE_AUTH_ENV_VAR_NAME];
 
     function isWildcard(c: string): boolean {
         return c === WILDCARD_ASTERISK || c === WILDCARD_SHARP;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -233,7 +233,7 @@ export namespace NamedWorkspaceFeatureFlag {
     }
 }
 
-export type EnvVar = UserEnvVar | ProjectEnvVarWithValue | EnvVarWithValue;
+export type EnvVar = UserEnvVar | ProjectEnvVarWithValue | OrgEnvVarWithValue | EnvVarWithValue;
 
 export interface EnvVarWithValue {
     name: string;
@@ -242,12 +242,22 @@ export interface EnvVarWithValue {
 
 export interface ProjectEnvVarWithValue extends EnvVarWithValue {
     id?: string;
+    /** If a project-scoped env var is "censored", it is only visible in Prebuilds */
     censored: boolean;
 }
 
 export interface ProjectEnvVar extends Omit<ProjectEnvVarWithValue, "value"> {
     id: string;
     projectId: string;
+}
+
+export interface OrgEnvVarWithValue extends EnvVarWithValue {
+    id?: string;
+}
+
+export interface OrgEnvVar extends Omit<OrgEnvVarWithValue, "value"> {
+    id: string;
+    orgId: string;
 }
 
 export interface UserEnvVarValue extends EnvVarWithValue {

--- a/components/public-api/gitpod/v1/envvar.proto
+++ b/components/public-api/gitpod/v1/envvar.proto
@@ -40,6 +40,22 @@ service EnvironmentVariableService {
   // a configuration.
   rpc DeleteConfigurationEnvironmentVariable(DeleteConfigurationEnvironmentVariableRequest) returns (DeleteConfigurationEnvironmentVariableResponse) {}
 
+  // ListOrganizationEnvironmentVariables returns all environment variables in
+  // an organization.
+  rpc ListOrganizationEnvironmentVariables(ListOrganizationEnvironmentVariablesRequest) returns (ListOrganizationEnvironmentVariablesResponse) {}
+
+  // UpdateOrganizationEnvironmentVariable updates an environment variable in
+  // an organization.
+  rpc UpdateOrganizationEnvironmentVariable(UpdateOrganizationEnvironmentVariableRequest) returns (UpdateOrganizationEnvironmentVariableResponse) {}
+
+  // CreateOrganizationEnvironmentVariable creates a new environment variable
+  // in an organization.
+  rpc CreateOrganizationEnvironmentVariable(CreateOrganizationEnvironmentVariableRequest) returns (CreateOrganizationEnvironmentVariableResponse) {}
+
+  // DeleteOrganizationEnvironmentVariable deletes an environment variable in
+  // an organization.
+  rpc DeleteOrganizationEnvironmentVariable(DeleteOrganizationEnvironmentVariableRequest) returns (DeleteOrganizationEnvironmentVariableResponse) {}
+
   rpc ResolveWorkspaceEnvironmentVariables(ResolveWorkspaceEnvironmentVariablesRequest) returns (ResolveWorkspaceEnvironmentVariablesResponse) {}
 }
 
@@ -137,6 +153,49 @@ message DeleteConfigurationEnvironmentVariableRequest {
 }
 
 message DeleteConfigurationEnvironmentVariableResponse {}
+
+message OrganizationEnvironmentVariable {
+  string id = 1;
+  string name = 2;
+  string organization_id = 3;
+}
+
+message ListOrganizationEnvironmentVariablesRequest {
+  string organization_id = 1;
+  PaginationRequest pagination = 2;
+}
+
+message ListOrganizationEnvironmentVariablesResponse {
+  repeated OrganizationEnvironmentVariable environment_variables = 1;
+  PaginationResponse pagination = 2;
+}
+
+message UpdateOrganizationEnvironmentVariableRequest {
+  string organization_id = 1;
+  string environment_variable_id = 2;
+  optional string name = 3;
+  optional string value = 4;
+}
+
+message UpdateOrganizationEnvironmentVariableResponse {
+  OrganizationEnvironmentVariable environment_variable = 1;
+}
+
+message CreateOrganizationEnvironmentVariableRequest {
+  string organization_id = 1;
+  string name = 2;
+  string value = 3;
+}
+
+message CreateOrganizationEnvironmentVariableResponse {
+  OrganizationEnvironmentVariable environment_variable = 1;
+}
+
+message DeleteOrganizationEnvironmentVariableRequest {
+  string environment_variable_id = 1;
+}
+
+message DeleteOrganizationEnvironmentVariableResponse {}
 
 message ResolveWorkspaceEnvironmentVariablesRequest {
   string workspace_id = 1;

--- a/components/public-api/go/v1/envvar.pb.go
+++ b/components/public-api/go/v1/envvar.pb.go
@@ -1069,6 +1069,492 @@ func (*DeleteConfigurationEnvironmentVariableResponse) Descriptor() ([]byte, []i
 	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{17}
 }
 
+type OrganizationEnvironmentVariable struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Id             string `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Name           string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	OrganizationId string `protobuf:"bytes,3,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+}
+
+func (x *OrganizationEnvironmentVariable) Reset() {
+	*x = OrganizationEnvironmentVariable{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[18]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *OrganizationEnvironmentVariable) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*OrganizationEnvironmentVariable) ProtoMessage() {}
+
+func (x *OrganizationEnvironmentVariable) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[18]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use OrganizationEnvironmentVariable.ProtoReflect.Descriptor instead.
+func (*OrganizationEnvironmentVariable) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *OrganizationEnvironmentVariable) GetId() string {
+	if x != nil {
+		return x.Id
+	}
+	return ""
+}
+
+func (x *OrganizationEnvironmentVariable) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *OrganizationEnvironmentVariable) GetOrganizationId() string {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return ""
+}
+
+type ListOrganizationEnvironmentVariablesRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OrganizationId string             `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+	Pagination     *PaginationRequest `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (x *ListOrganizationEnvironmentVariablesRequest) Reset() {
+	*x = ListOrganizationEnvironmentVariablesRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[19]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ListOrganizationEnvironmentVariablesRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOrganizationEnvironmentVariablesRequest) ProtoMessage() {}
+
+func (x *ListOrganizationEnvironmentVariablesRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[19]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOrganizationEnvironmentVariablesRequest.ProtoReflect.Descriptor instead.
+func (*ListOrganizationEnvironmentVariablesRequest) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *ListOrganizationEnvironmentVariablesRequest) GetOrganizationId() string {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return ""
+}
+
+func (x *ListOrganizationEnvironmentVariablesRequest) GetPagination() *PaginationRequest {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+type ListOrganizationEnvironmentVariablesResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	EnvironmentVariables []*OrganizationEnvironmentVariable `protobuf:"bytes,1,rep,name=environment_variables,json=environmentVariables,proto3" json:"environment_variables,omitempty"`
+	Pagination           *PaginationResponse                `protobuf:"bytes,2,opt,name=pagination,proto3" json:"pagination,omitempty"`
+}
+
+func (x *ListOrganizationEnvironmentVariablesResponse) Reset() {
+	*x = ListOrganizationEnvironmentVariablesResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[20]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *ListOrganizationEnvironmentVariablesResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ListOrganizationEnvironmentVariablesResponse) ProtoMessage() {}
+
+func (x *ListOrganizationEnvironmentVariablesResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[20]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ListOrganizationEnvironmentVariablesResponse.ProtoReflect.Descriptor instead.
+func (*ListOrganizationEnvironmentVariablesResponse) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *ListOrganizationEnvironmentVariablesResponse) GetEnvironmentVariables() []*OrganizationEnvironmentVariable {
+	if x != nil {
+		return x.EnvironmentVariables
+	}
+	return nil
+}
+
+func (x *ListOrganizationEnvironmentVariablesResponse) GetPagination() *PaginationResponse {
+	if x != nil {
+		return x.Pagination
+	}
+	return nil
+}
+
+type UpdateOrganizationEnvironmentVariableRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OrganizationId        string  `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+	EnvironmentVariableId string  `protobuf:"bytes,2,opt,name=environment_variable_id,json=environmentVariableId,proto3" json:"environment_variable_id,omitempty"`
+	Name                  *string `protobuf:"bytes,3,opt,name=name,proto3,oneof" json:"name,omitempty"`
+	Value                 *string `protobuf:"bytes,4,opt,name=value,proto3,oneof" json:"value,omitempty"`
+}
+
+func (x *UpdateOrganizationEnvironmentVariableRequest) Reset() {
+	*x = UpdateOrganizationEnvironmentVariableRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[21]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *UpdateOrganizationEnvironmentVariableRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateOrganizationEnvironmentVariableRequest) ProtoMessage() {}
+
+func (x *UpdateOrganizationEnvironmentVariableRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[21]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateOrganizationEnvironmentVariableRequest.ProtoReflect.Descriptor instead.
+func (*UpdateOrganizationEnvironmentVariableRequest) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *UpdateOrganizationEnvironmentVariableRequest) GetOrganizationId() string {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return ""
+}
+
+func (x *UpdateOrganizationEnvironmentVariableRequest) GetEnvironmentVariableId() string {
+	if x != nil {
+		return x.EnvironmentVariableId
+	}
+	return ""
+}
+
+func (x *UpdateOrganizationEnvironmentVariableRequest) GetName() string {
+	if x != nil && x.Name != nil {
+		return *x.Name
+	}
+	return ""
+}
+
+func (x *UpdateOrganizationEnvironmentVariableRequest) GetValue() string {
+	if x != nil && x.Value != nil {
+		return *x.Value
+	}
+	return ""
+}
+
+type UpdateOrganizationEnvironmentVariableResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	EnvironmentVariable *OrganizationEnvironmentVariable `protobuf:"bytes,1,opt,name=environment_variable,json=environmentVariable,proto3" json:"environment_variable,omitempty"`
+}
+
+func (x *UpdateOrganizationEnvironmentVariableResponse) Reset() {
+	*x = UpdateOrganizationEnvironmentVariableResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[22]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *UpdateOrganizationEnvironmentVariableResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UpdateOrganizationEnvironmentVariableResponse) ProtoMessage() {}
+
+func (x *UpdateOrganizationEnvironmentVariableResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[22]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UpdateOrganizationEnvironmentVariableResponse.ProtoReflect.Descriptor instead.
+func (*UpdateOrganizationEnvironmentVariableResponse) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *UpdateOrganizationEnvironmentVariableResponse) GetEnvironmentVariable() *OrganizationEnvironmentVariable {
+	if x != nil {
+		return x.EnvironmentVariable
+	}
+	return nil
+}
+
+type CreateOrganizationEnvironmentVariableRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	OrganizationId string `protobuf:"bytes,1,opt,name=organization_id,json=organizationId,proto3" json:"organization_id,omitempty"`
+	Name           string `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`
+	Value          string `protobuf:"bytes,3,opt,name=value,proto3" json:"value,omitempty"`
+}
+
+func (x *CreateOrganizationEnvironmentVariableRequest) Reset() {
+	*x = CreateOrganizationEnvironmentVariableRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[23]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *CreateOrganizationEnvironmentVariableRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateOrganizationEnvironmentVariableRequest) ProtoMessage() {}
+
+func (x *CreateOrganizationEnvironmentVariableRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[23]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateOrganizationEnvironmentVariableRequest.ProtoReflect.Descriptor instead.
+func (*CreateOrganizationEnvironmentVariableRequest) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *CreateOrganizationEnvironmentVariableRequest) GetOrganizationId() string {
+	if x != nil {
+		return x.OrganizationId
+	}
+	return ""
+}
+
+func (x *CreateOrganizationEnvironmentVariableRequest) GetName() string {
+	if x != nil {
+		return x.Name
+	}
+	return ""
+}
+
+func (x *CreateOrganizationEnvironmentVariableRequest) GetValue() string {
+	if x != nil {
+		return x.Value
+	}
+	return ""
+}
+
+type CreateOrganizationEnvironmentVariableResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	EnvironmentVariable *OrganizationEnvironmentVariable `protobuf:"bytes,1,opt,name=environment_variable,json=environmentVariable,proto3" json:"environment_variable,omitempty"`
+}
+
+func (x *CreateOrganizationEnvironmentVariableResponse) Reset() {
+	*x = CreateOrganizationEnvironmentVariableResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[24]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *CreateOrganizationEnvironmentVariableResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateOrganizationEnvironmentVariableResponse) ProtoMessage() {}
+
+func (x *CreateOrganizationEnvironmentVariableResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[24]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateOrganizationEnvironmentVariableResponse.ProtoReflect.Descriptor instead.
+func (*CreateOrganizationEnvironmentVariableResponse) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *CreateOrganizationEnvironmentVariableResponse) GetEnvironmentVariable() *OrganizationEnvironmentVariable {
+	if x != nil {
+		return x.EnvironmentVariable
+	}
+	return nil
+}
+
+type DeleteOrganizationEnvironmentVariableRequest struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	EnvironmentVariableId string `protobuf:"bytes,1,opt,name=environment_variable_id,json=environmentVariableId,proto3" json:"environment_variable_id,omitempty"`
+}
+
+func (x *DeleteOrganizationEnvironmentVariableRequest) Reset() {
+	*x = DeleteOrganizationEnvironmentVariableRequest{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[25]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DeleteOrganizationEnvironmentVariableRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteOrganizationEnvironmentVariableRequest) ProtoMessage() {}
+
+func (x *DeleteOrganizationEnvironmentVariableRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[25]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteOrganizationEnvironmentVariableRequest.ProtoReflect.Descriptor instead.
+func (*DeleteOrganizationEnvironmentVariableRequest) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *DeleteOrganizationEnvironmentVariableRequest) GetEnvironmentVariableId() string {
+	if x != nil {
+		return x.EnvironmentVariableId
+	}
+	return ""
+}
+
+type DeleteOrganizationEnvironmentVariableResponse struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+}
+
+func (x *DeleteOrganizationEnvironmentVariableResponse) Reset() {
+	*x = DeleteOrganizationEnvironmentVariableResponse{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[26]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *DeleteOrganizationEnvironmentVariableResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeleteOrganizationEnvironmentVariableResponse) ProtoMessage() {}
+
+func (x *DeleteOrganizationEnvironmentVariableResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[26]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeleteOrganizationEnvironmentVariableResponse.ProtoReflect.Descriptor instead.
+func (*DeleteOrganizationEnvironmentVariableResponse) Descriptor() ([]byte, []int) {
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{26}
+}
+
 type ResolveWorkspaceEnvironmentVariablesRequest struct {
 	state         protoimpl.MessageState
 	sizeCache     protoimpl.SizeCache
@@ -1080,7 +1566,7 @@ type ResolveWorkspaceEnvironmentVariablesRequest struct {
 func (x *ResolveWorkspaceEnvironmentVariablesRequest) Reset() {
 	*x = ResolveWorkspaceEnvironmentVariablesRequest{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_gitpod_v1_envvar_proto_msgTypes[18]
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[27]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1093,7 +1579,7 @@ func (x *ResolveWorkspaceEnvironmentVariablesRequest) String() string {
 func (*ResolveWorkspaceEnvironmentVariablesRequest) ProtoMessage() {}
 
 func (x *ResolveWorkspaceEnvironmentVariablesRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_gitpod_v1_envvar_proto_msgTypes[18]
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[27]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1106,7 +1592,7 @@ func (x *ResolveWorkspaceEnvironmentVariablesRequest) ProtoReflect() protoreflec
 
 // Deprecated: Use ResolveWorkspaceEnvironmentVariablesRequest.ProtoReflect.Descriptor instead.
 func (*ResolveWorkspaceEnvironmentVariablesRequest) Descriptor() ([]byte, []int) {
-	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{18}
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{27}
 }
 
 func (x *ResolveWorkspaceEnvironmentVariablesRequest) GetWorkspaceId() string {
@@ -1127,7 +1613,7 @@ type ResolveWorkspaceEnvironmentVariablesResponse struct {
 func (x *ResolveWorkspaceEnvironmentVariablesResponse) Reset() {
 	*x = ResolveWorkspaceEnvironmentVariablesResponse{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_gitpod_v1_envvar_proto_msgTypes[19]
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[28]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1140,7 +1626,7 @@ func (x *ResolveWorkspaceEnvironmentVariablesResponse) String() string {
 func (*ResolveWorkspaceEnvironmentVariablesResponse) ProtoMessage() {}
 
 func (x *ResolveWorkspaceEnvironmentVariablesResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_gitpod_v1_envvar_proto_msgTypes[19]
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[28]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1153,7 +1639,7 @@ func (x *ResolveWorkspaceEnvironmentVariablesResponse) ProtoReflect() protorefle
 
 // Deprecated: Use ResolveWorkspaceEnvironmentVariablesResponse.ProtoReflect.Descriptor instead.
 func (*ResolveWorkspaceEnvironmentVariablesResponse) Descriptor() ([]byte, []int) {
-	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{19}
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{28}
 }
 
 func (x *ResolveWorkspaceEnvironmentVariablesResponse) GetEnvironmentVariables() []*EnvironmentVariable {
@@ -1175,7 +1661,7 @@ type EnvironmentVariable struct {
 func (x *EnvironmentVariable) Reset() {
 	*x = EnvironmentVariable{}
 	if protoimpl.UnsafeEnabled {
-		mi := &file_gitpod_v1_envvar_proto_msgTypes[20]
+		mi := &file_gitpod_v1_envvar_proto_msgTypes[29]
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		ms.StoreMessageInfo(mi)
 	}
@@ -1188,7 +1674,7 @@ func (x *EnvironmentVariable) String() string {
 func (*EnvironmentVariable) ProtoMessage() {}
 
 func (x *EnvironmentVariable) ProtoReflect() protoreflect.Message {
-	mi := &file_gitpod_v1_envvar_proto_msgTypes[20]
+	mi := &file_gitpod_v1_envvar_proto_msgTypes[29]
 	if protoimpl.UnsafeEnabled && x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1201,7 +1687,7 @@ func (x *EnvironmentVariable) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use EnvironmentVariable.ProtoReflect.Descriptor instead.
 func (*EnvironmentVariable) Descriptor() ([]byte, []int) {
-	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{20}
+	return file_gitpod_v1_envvar_proto_rawDescGZIP(), []int{29}
 }
 
 func (x *EnvironmentVariable) GetName() string {
@@ -1394,6 +1880,85 @@ var file_gitpod_v1_envvar_proto_rawDesc = []byte{
 	0x49, 0x64, 0x22, 0x30, 0x0a, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x43, 0x6f, 0x6e, 0x66,
 	0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e,
 	0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70,
+	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x6e, 0x0a, 0x1f, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56,
+	0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12, 0x0e, 0x0a, 0x02, 0x69, 0x64, 0x18, 0x01, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x02, 0x69, 0x64, 0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18,
+	0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x12, 0x27, 0x0a, 0x0f, 0x6f,
+	0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x03,
+	0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x6f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69,
+	0x6f, 0x6e, 0x49, 0x64, 0x22, 0x94, 0x01, 0x0a, 0x2b, 0x4c, 0x69, 0x73, 0x74, 0x4f, 0x72, 0x67,
+	0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x12, 0x27, 0x0a, 0x0f, 0x6f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x6f,
+	0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64, 0x12, 0x3c, 0x0a,
+	0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x1c, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61,
+	0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x52,
+	0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xce, 0x01, 0x0a, 0x2c,
+	0x4c, 0x69, 0x73, 0x74, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e,
+	0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61,
+	0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x5f, 0x0a, 0x15,
+	0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x72, 0x69,
+	0x61, 0x62, 0x6c, 0x65, 0x73, 0x18, 0x01, 0x20, 0x03, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x67, 0x69,
+	0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56,
+	0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x14, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x12, 0x3d, 0x0a,
+	0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x18, 0x02, 0x20, 0x01, 0x28,
+	0x0b, 0x32, 0x1d, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x50, 0x61,
+	0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x52, 0x0a, 0x70, 0x61, 0x67, 0x69, 0x6e, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x22, 0xd6, 0x01, 0x0a,
+	0x2c, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61,
+	0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x27, 0x0a,
+	0x0f, 0x6f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64,
+	0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0e, 0x6f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64, 0x12, 0x36, 0x0a, 0x17, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f,
+	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x5f, 0x69,
+	0x64, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x15, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x49, 0x64, 0x12, 0x17,
+	0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x03, 0x20, 0x01, 0x28, 0x09, 0x48, 0x00, 0x52, 0x04,
+	0x6e, 0x61, 0x6d, 0x65, 0x88, 0x01, 0x01, 0x12, 0x19, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65,
+	0x18, 0x04, 0x20, 0x01, 0x28, 0x09, 0x48, 0x01, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x88,
+	0x01, 0x01, 0x42, 0x07, 0x0a, 0x05, 0x5f, 0x6e, 0x61, 0x6d, 0x65, 0x42, 0x08, 0x0a, 0x06, 0x5f,
+	0x76, 0x61, 0x6c, 0x75, 0x65, 0x22, 0x8e, 0x01, 0x0a, 0x2d, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65,
+	0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69,
+	0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52,
+	0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x5d, 0x0a, 0x14, 0x65, 0x6e, 0x76, 0x69, 0x72,
+	0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x18,
+	0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76,
+	0x31, 0x2e, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e,
+	0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c,
+	0x65, 0x52, 0x13, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61,
+	0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x22, 0x81, 0x01, 0x0a, 0x2c, 0x43, 0x72, 0x65, 0x61, 0x74,
+	0x65, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76,
+	0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65,
+	0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x27, 0x0a, 0x0f, 0x6f, 0x72, 0x67, 0x61, 0x6e,
+	0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09,
+	0x52, 0x0e, 0x6f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x49, 0x64,
+	0x12, 0x12, 0x0a, 0x04, 0x6e, 0x61, 0x6d, 0x65, 0x18, 0x02, 0x20, 0x01, 0x28, 0x09, 0x52, 0x04,
+	0x6e, 0x61, 0x6d, 0x65, 0x12, 0x14, 0x0a, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x18, 0x03, 0x20,
+	0x01, 0x28, 0x09, 0x52, 0x05, 0x76, 0x61, 0x6c, 0x75, 0x65, 0x22, 0x8e, 0x01, 0x0a, 0x2d, 0x43,
+	0x72, 0x65, 0x61, 0x74, 0x65, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f,
+	0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69,
+	0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x12, 0x5d, 0x0a, 0x14,
+	0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x72, 0x69,
+	0x61, 0x62, 0x6c, 0x65, 0x18, 0x01, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x2a, 0x2e, 0x67, 0x69, 0x74,
+	0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61,
+	0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x13, 0x65, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d,
+	0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x22, 0x66, 0x0a, 0x2c, 0x44,
+	0x65, 0x6c, 0x65, 0x74, 0x65, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f,
+	0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69,
+	0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x12, 0x36, 0x0a, 0x17, 0x65,
+	0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x5f, 0x76, 0x61, 0x72, 0x69, 0x61,
+	0x62, 0x6c, 0x65, 0x5f, 0x69, 0x64, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x15, 0x65, 0x6e,
+	0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c,
+	0x65, 0x49, 0x64, 0x22, 0x2f, 0x0a, 0x2d, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x4f, 0x72, 0x67,
+	0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70,
 	0x6f, 0x6e, 0x73, 0x65, 0x22, 0x50, 0x0a, 0x2b, 0x52, 0x65, 0x73, 0x6f, 0x6c, 0x76, 0x65, 0x57,
 	0x6f, 0x72, 0x6b, 0x73, 0x70, 0x61, 0x63, 0x65, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d,
 	0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75,
@@ -1422,7 +1987,7 @@ var file_gitpod_v1_envvar_proto_rawDesc = []byte{
 	0x5f, 0x50, 0x52, 0x45, 0x42, 0x55, 0x49, 0x4c, 0x44, 0x10, 0x01, 0x12, 0x2d, 0x0a, 0x29, 0x45,
 	0x4e, 0x56, 0x49, 0x52, 0x4f, 0x4e, 0x4d, 0x45, 0x4e, 0x54, 0x5f, 0x56, 0x41, 0x52, 0x49, 0x41,
 	0x42, 0x4c, 0x45, 0x5f, 0x41, 0x44, 0x4d, 0x49, 0x53, 0x53, 0x49, 0x4f, 0x4e, 0x5f, 0x45, 0x56,
-	0x45, 0x52, 0x59, 0x57, 0x48, 0x45, 0x52, 0x45, 0x10, 0x02, 0x32, 0xd6, 0x0a, 0x0a, 0x1a, 0x45,
+	0x45, 0x52, 0x59, 0x57, 0x48, 0x45, 0x52, 0x45, 0x10, 0x02, 0x32, 0xcf, 0x0f, 0x0a, 0x1a, 0x45,
 	0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62,
 	0x6c, 0x65, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65, 0x12, 0x81, 0x01, 0x0a, 0x1c, 0x4c, 0x69,
 	0x73, 0x74, 0x55, 0x73, 0x65, 0x72, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e,
@@ -1498,22 +2063,62 @@ var file_gitpod_v1_envvar_proto_rawDesc = []byte{
 	0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x43, 0x6f, 0x6e,
 	0x66, 0x69, 0x67, 0x75, 0x72, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f,
 	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x73,
-	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x99, 0x01, 0x0a, 0x24, 0x52, 0x65, 0x73, 0x6f,
-	0x6c, 0x76, 0x65, 0x57, 0x6f, 0x72, 0x6b, 0x73, 0x70, 0x61, 0x63, 0x65, 0x45, 0x6e, 0x76, 0x69,
+	0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x12, 0x99, 0x01, 0x0a, 0x24, 0x4c, 0x69, 0x73, 0x74,
+	0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69,
 	0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73,
-	0x12, 0x36, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x73,
-	0x6f, 0x6c, 0x76, 0x65, 0x57, 0x6f, 0x72, 0x6b, 0x73, 0x70, 0x61, 0x63, 0x65, 0x45, 0x6e, 0x76,
+	0x12, 0x36, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x73,
+	0x74, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76,
 	0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65,
 	0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x37, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f,
-	0x64, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x73, 0x6f, 0x6c, 0x76, 0x65, 0x57, 0x6f, 0x72, 0x6b,
-	0x73, 0x70, 0x61, 0x63, 0x65, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
+	0x64, 0x2e, 0x76, 0x31, 0x2e, 0x4c, 0x69, 0x73, 0x74, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
 	0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73,
-	0x65, 0x22, 0x00, 0x42, 0x51, 0x0a, 0x16, 0x69, 0x6f, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64,
-	0x2e, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x61, 0x70, 0x69, 0x2e, 0x76, 0x31, 0x5a, 0x37, 0x67,
-	0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64,
-	0x2d, 0x69, 0x6f, 0x2f, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2f, 0x63, 0x6f, 0x6d, 0x70, 0x6f,
-	0x6e, 0x65, 0x6e, 0x74, 0x73, 0x2f, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d, 0x61, 0x70, 0x69,
-	0x2f, 0x67, 0x6f, 0x2f, 0x76, 0x31, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x65, 0x22, 0x00, 0x12, 0x9c, 0x01, 0x0a, 0x25, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x4f, 0x72,
+	0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f,
+	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12, 0x37, 0x2e,
+	0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65,
+	0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69,
+	0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52,
+	0x65, 0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x38, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e,
+	0x76, 0x31, 0x2e, 0x55, 0x70, 0x64, 0x61, 0x74, 0x65, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a,
+	0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
+	0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65,
+	0x22, 0x00, 0x12, 0x9c, 0x01, 0x0a, 0x25, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x4f, 0x72, 0x67,
+	0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e,
+	0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12, 0x37, 0x2e, 0x67,
+	0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x4f,
+	0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72,
+	0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65,
+	0x71, 0x75, 0x65, 0x73, 0x74, 0x1a, 0x38, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76,
+	0x31, 0x2e, 0x43, 0x72, 0x65, 0x61, 0x74, 0x65, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61,
+	0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56,
+	0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22,
+	0x00, 0x12, 0x9c, 0x01, 0x0a, 0x25, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x4f, 0x72, 0x67, 0x61,
+	0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d,
+	0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x12, 0x37, 0x2e, 0x67, 0x69,
+	0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x4f, 0x72,
+	0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74, 0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f,
+	0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x71,
+	0x75, 0x65, 0x73, 0x74, 0x1a, 0x38, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31,
+	0x2e, 0x44, 0x65, 0x6c, 0x65, 0x74, 0x65, 0x4f, 0x72, 0x67, 0x61, 0x6e, 0x69, 0x7a, 0x61, 0x74,
+	0x69, 0x6f, 0x6e, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61,
+	0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00,
+	0x12, 0x99, 0x01, 0x0a, 0x24, 0x52, 0x65, 0x73, 0x6f, 0x6c, 0x76, 0x65, 0x57, 0x6f, 0x72, 0x6b,
+	0x73, 0x70, 0x61, 0x63, 0x65, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74,
+	0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x12, 0x36, 0x2e, 0x67, 0x69, 0x74, 0x70,
+	0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65, 0x73, 0x6f, 0x6c, 0x76, 0x65, 0x57, 0x6f, 0x72,
+	0x6b, 0x73, 0x70, 0x61, 0x63, 0x65, 0x45, 0x6e, 0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e,
+	0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c, 0x65, 0x73, 0x52, 0x65, 0x71, 0x75, 0x65, 0x73,
+	0x74, 0x1a, 0x37, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x76, 0x31, 0x2e, 0x52, 0x65,
+	0x73, 0x6f, 0x6c, 0x76, 0x65, 0x57, 0x6f, 0x72, 0x6b, 0x73, 0x70, 0x61, 0x63, 0x65, 0x45, 0x6e,
+	0x76, 0x69, 0x72, 0x6f, 0x6e, 0x6d, 0x65, 0x6e, 0x74, 0x56, 0x61, 0x72, 0x69, 0x61, 0x62, 0x6c,
+	0x65, 0x73, 0x52, 0x65, 0x73, 0x70, 0x6f, 0x6e, 0x73, 0x65, 0x22, 0x00, 0x42, 0x51, 0x0a, 0x16,
+	0x69, 0x6f, 0x2e, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2e, 0x70, 0x75, 0x62, 0x6c, 0x69, 0x63,
+	0x61, 0x70, 0x69, 0x2e, 0x76, 0x31, 0x5a, 0x37, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63,
+	0x6f, 0x6d, 0x2f, 0x67, 0x69, 0x74, 0x70, 0x6f, 0x64, 0x2d, 0x69, 0x6f, 0x2f, 0x67, 0x69, 0x74,
+	0x70, 0x6f, 0x64, 0x2f, 0x63, 0x6f, 0x6d, 0x70, 0x6f, 0x6e, 0x65, 0x6e, 0x74, 0x73, 0x2f, 0x70,
+	0x75, 0x62, 0x6c, 0x69, 0x63, 0x2d, 0x61, 0x70, 0x69, 0x2f, 0x67, 0x6f, 0x2f, 0x76, 0x31, 0x62,
+	0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -1529,7 +2134,7 @@ func file_gitpod_v1_envvar_proto_rawDescGZIP() []byte {
 }
 
 var file_gitpod_v1_envvar_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_gitpod_v1_envvar_proto_msgTypes = make([]protoimpl.MessageInfo, 21)
+var file_gitpod_v1_envvar_proto_msgTypes = make([]protoimpl.MessageInfo, 30)
 var file_gitpod_v1_envvar_proto_goTypes = []interface{}{
 	(EnvironmentVariableAdmission)(0),                      // 0: gitpod.v1.EnvironmentVariableAdmission
 	(*UserEnvironmentVariable)(nil),                        // 1: gitpod.v1.UserEnvironmentVariable
@@ -1550,50 +2155,72 @@ var file_gitpod_v1_envvar_proto_goTypes = []interface{}{
 	(*CreateConfigurationEnvironmentVariableResponse)(nil), // 16: gitpod.v1.CreateConfigurationEnvironmentVariableResponse
 	(*DeleteConfigurationEnvironmentVariableRequest)(nil),  // 17: gitpod.v1.DeleteConfigurationEnvironmentVariableRequest
 	(*DeleteConfigurationEnvironmentVariableResponse)(nil), // 18: gitpod.v1.DeleteConfigurationEnvironmentVariableResponse
-	(*ResolveWorkspaceEnvironmentVariablesRequest)(nil),    // 19: gitpod.v1.ResolveWorkspaceEnvironmentVariablesRequest
-	(*ResolveWorkspaceEnvironmentVariablesResponse)(nil),   // 20: gitpod.v1.ResolveWorkspaceEnvironmentVariablesResponse
-	(*EnvironmentVariable)(nil),                            // 21: gitpod.v1.EnvironmentVariable
-	(*PaginationRequest)(nil),                              // 22: gitpod.v1.PaginationRequest
-	(*PaginationResponse)(nil),                             // 23: gitpod.v1.PaginationResponse
+	(*OrganizationEnvironmentVariable)(nil),                // 19: gitpod.v1.OrganizationEnvironmentVariable
+	(*ListOrganizationEnvironmentVariablesRequest)(nil),    // 20: gitpod.v1.ListOrganizationEnvironmentVariablesRequest
+	(*ListOrganizationEnvironmentVariablesResponse)(nil),   // 21: gitpod.v1.ListOrganizationEnvironmentVariablesResponse
+	(*UpdateOrganizationEnvironmentVariableRequest)(nil),   // 22: gitpod.v1.UpdateOrganizationEnvironmentVariableRequest
+	(*UpdateOrganizationEnvironmentVariableResponse)(nil),  // 23: gitpod.v1.UpdateOrganizationEnvironmentVariableResponse
+	(*CreateOrganizationEnvironmentVariableRequest)(nil),   // 24: gitpod.v1.CreateOrganizationEnvironmentVariableRequest
+	(*CreateOrganizationEnvironmentVariableResponse)(nil),  // 25: gitpod.v1.CreateOrganizationEnvironmentVariableResponse
+	(*DeleteOrganizationEnvironmentVariableRequest)(nil),   // 26: gitpod.v1.DeleteOrganizationEnvironmentVariableRequest
+	(*DeleteOrganizationEnvironmentVariableResponse)(nil),  // 27: gitpod.v1.DeleteOrganizationEnvironmentVariableResponse
+	(*ResolveWorkspaceEnvironmentVariablesRequest)(nil),    // 28: gitpod.v1.ResolveWorkspaceEnvironmentVariablesRequest
+	(*ResolveWorkspaceEnvironmentVariablesResponse)(nil),   // 29: gitpod.v1.ResolveWorkspaceEnvironmentVariablesResponse
+	(*EnvironmentVariable)(nil),                            // 30: gitpod.v1.EnvironmentVariable
+	(*PaginationRequest)(nil),                              // 31: gitpod.v1.PaginationRequest
+	(*PaginationResponse)(nil),                             // 32: gitpod.v1.PaginationResponse
 }
 var file_gitpod_v1_envvar_proto_depIdxs = []int32{
-	22, // 0: gitpod.v1.ListUserEnvironmentVariablesRequest.pagination:type_name -> gitpod.v1.PaginationRequest
+	31, // 0: gitpod.v1.ListUserEnvironmentVariablesRequest.pagination:type_name -> gitpod.v1.PaginationRequest
 	1,  // 1: gitpod.v1.ListUserEnvironmentVariablesResponse.environment_variables:type_name -> gitpod.v1.UserEnvironmentVariable
-	23, // 2: gitpod.v1.ListUserEnvironmentVariablesResponse.pagination:type_name -> gitpod.v1.PaginationResponse
+	32, // 2: gitpod.v1.ListUserEnvironmentVariablesResponse.pagination:type_name -> gitpod.v1.PaginationResponse
 	1,  // 3: gitpod.v1.UpdateUserEnvironmentVariableResponse.environment_variable:type_name -> gitpod.v1.UserEnvironmentVariable
 	1,  // 4: gitpod.v1.CreateUserEnvironmentVariableResponse.environment_variable:type_name -> gitpod.v1.UserEnvironmentVariable
 	0,  // 5: gitpod.v1.ConfigurationEnvironmentVariable.admission:type_name -> gitpod.v1.EnvironmentVariableAdmission
-	22, // 6: gitpod.v1.ListConfigurationEnvironmentVariablesRequest.pagination:type_name -> gitpod.v1.PaginationRequest
+	31, // 6: gitpod.v1.ListConfigurationEnvironmentVariablesRequest.pagination:type_name -> gitpod.v1.PaginationRequest
 	10, // 7: gitpod.v1.ListConfigurationEnvironmentVariablesResponse.environment_variables:type_name -> gitpod.v1.ConfigurationEnvironmentVariable
-	23, // 8: gitpod.v1.ListConfigurationEnvironmentVariablesResponse.pagination:type_name -> gitpod.v1.PaginationResponse
+	32, // 8: gitpod.v1.ListConfigurationEnvironmentVariablesResponse.pagination:type_name -> gitpod.v1.PaginationResponse
 	0,  // 9: gitpod.v1.UpdateConfigurationEnvironmentVariableRequest.admission:type_name -> gitpod.v1.EnvironmentVariableAdmission
 	10, // 10: gitpod.v1.UpdateConfigurationEnvironmentVariableResponse.environment_variable:type_name -> gitpod.v1.ConfigurationEnvironmentVariable
 	0,  // 11: gitpod.v1.CreateConfigurationEnvironmentVariableRequest.admission:type_name -> gitpod.v1.EnvironmentVariableAdmission
 	10, // 12: gitpod.v1.CreateConfigurationEnvironmentVariableResponse.environment_variable:type_name -> gitpod.v1.ConfigurationEnvironmentVariable
-	21, // 13: gitpod.v1.ResolveWorkspaceEnvironmentVariablesResponse.environment_variables:type_name -> gitpod.v1.EnvironmentVariable
-	2,  // 14: gitpod.v1.EnvironmentVariableService.ListUserEnvironmentVariables:input_type -> gitpod.v1.ListUserEnvironmentVariablesRequest
-	4,  // 15: gitpod.v1.EnvironmentVariableService.UpdateUserEnvironmentVariable:input_type -> gitpod.v1.UpdateUserEnvironmentVariableRequest
-	6,  // 16: gitpod.v1.EnvironmentVariableService.CreateUserEnvironmentVariable:input_type -> gitpod.v1.CreateUserEnvironmentVariableRequest
-	8,  // 17: gitpod.v1.EnvironmentVariableService.DeleteUserEnvironmentVariable:input_type -> gitpod.v1.DeleteUserEnvironmentVariableRequest
-	11, // 18: gitpod.v1.EnvironmentVariableService.ListConfigurationEnvironmentVariables:input_type -> gitpod.v1.ListConfigurationEnvironmentVariablesRequest
-	13, // 19: gitpod.v1.EnvironmentVariableService.UpdateConfigurationEnvironmentVariable:input_type -> gitpod.v1.UpdateConfigurationEnvironmentVariableRequest
-	15, // 20: gitpod.v1.EnvironmentVariableService.CreateConfigurationEnvironmentVariable:input_type -> gitpod.v1.CreateConfigurationEnvironmentVariableRequest
-	17, // 21: gitpod.v1.EnvironmentVariableService.DeleteConfigurationEnvironmentVariable:input_type -> gitpod.v1.DeleteConfigurationEnvironmentVariableRequest
-	19, // 22: gitpod.v1.EnvironmentVariableService.ResolveWorkspaceEnvironmentVariables:input_type -> gitpod.v1.ResolveWorkspaceEnvironmentVariablesRequest
-	3,  // 23: gitpod.v1.EnvironmentVariableService.ListUserEnvironmentVariables:output_type -> gitpod.v1.ListUserEnvironmentVariablesResponse
-	5,  // 24: gitpod.v1.EnvironmentVariableService.UpdateUserEnvironmentVariable:output_type -> gitpod.v1.UpdateUserEnvironmentVariableResponse
-	7,  // 25: gitpod.v1.EnvironmentVariableService.CreateUserEnvironmentVariable:output_type -> gitpod.v1.CreateUserEnvironmentVariableResponse
-	9,  // 26: gitpod.v1.EnvironmentVariableService.DeleteUserEnvironmentVariable:output_type -> gitpod.v1.DeleteUserEnvironmentVariableResponse
-	12, // 27: gitpod.v1.EnvironmentVariableService.ListConfigurationEnvironmentVariables:output_type -> gitpod.v1.ListConfigurationEnvironmentVariablesResponse
-	14, // 28: gitpod.v1.EnvironmentVariableService.UpdateConfigurationEnvironmentVariable:output_type -> gitpod.v1.UpdateConfigurationEnvironmentVariableResponse
-	16, // 29: gitpod.v1.EnvironmentVariableService.CreateConfigurationEnvironmentVariable:output_type -> gitpod.v1.CreateConfigurationEnvironmentVariableResponse
-	18, // 30: gitpod.v1.EnvironmentVariableService.DeleteConfigurationEnvironmentVariable:output_type -> gitpod.v1.DeleteConfigurationEnvironmentVariableResponse
-	20, // 31: gitpod.v1.EnvironmentVariableService.ResolveWorkspaceEnvironmentVariables:output_type -> gitpod.v1.ResolveWorkspaceEnvironmentVariablesResponse
-	23, // [23:32] is the sub-list for method output_type
-	14, // [14:23] is the sub-list for method input_type
-	14, // [14:14] is the sub-list for extension type_name
-	14, // [14:14] is the sub-list for extension extendee
-	0,  // [0:14] is the sub-list for field type_name
+	31, // 13: gitpod.v1.ListOrganizationEnvironmentVariablesRequest.pagination:type_name -> gitpod.v1.PaginationRequest
+	19, // 14: gitpod.v1.ListOrganizationEnvironmentVariablesResponse.environment_variables:type_name -> gitpod.v1.OrganizationEnvironmentVariable
+	32, // 15: gitpod.v1.ListOrganizationEnvironmentVariablesResponse.pagination:type_name -> gitpod.v1.PaginationResponse
+	19, // 16: gitpod.v1.UpdateOrganizationEnvironmentVariableResponse.environment_variable:type_name -> gitpod.v1.OrganizationEnvironmentVariable
+	19, // 17: gitpod.v1.CreateOrganizationEnvironmentVariableResponse.environment_variable:type_name -> gitpod.v1.OrganizationEnvironmentVariable
+	30, // 18: gitpod.v1.ResolveWorkspaceEnvironmentVariablesResponse.environment_variables:type_name -> gitpod.v1.EnvironmentVariable
+	2,  // 19: gitpod.v1.EnvironmentVariableService.ListUserEnvironmentVariables:input_type -> gitpod.v1.ListUserEnvironmentVariablesRequest
+	4,  // 20: gitpod.v1.EnvironmentVariableService.UpdateUserEnvironmentVariable:input_type -> gitpod.v1.UpdateUserEnvironmentVariableRequest
+	6,  // 21: gitpod.v1.EnvironmentVariableService.CreateUserEnvironmentVariable:input_type -> gitpod.v1.CreateUserEnvironmentVariableRequest
+	8,  // 22: gitpod.v1.EnvironmentVariableService.DeleteUserEnvironmentVariable:input_type -> gitpod.v1.DeleteUserEnvironmentVariableRequest
+	11, // 23: gitpod.v1.EnvironmentVariableService.ListConfigurationEnvironmentVariables:input_type -> gitpod.v1.ListConfigurationEnvironmentVariablesRequest
+	13, // 24: gitpod.v1.EnvironmentVariableService.UpdateConfigurationEnvironmentVariable:input_type -> gitpod.v1.UpdateConfigurationEnvironmentVariableRequest
+	15, // 25: gitpod.v1.EnvironmentVariableService.CreateConfigurationEnvironmentVariable:input_type -> gitpod.v1.CreateConfigurationEnvironmentVariableRequest
+	17, // 26: gitpod.v1.EnvironmentVariableService.DeleteConfigurationEnvironmentVariable:input_type -> gitpod.v1.DeleteConfigurationEnvironmentVariableRequest
+	20, // 27: gitpod.v1.EnvironmentVariableService.ListOrganizationEnvironmentVariables:input_type -> gitpod.v1.ListOrganizationEnvironmentVariablesRequest
+	22, // 28: gitpod.v1.EnvironmentVariableService.UpdateOrganizationEnvironmentVariable:input_type -> gitpod.v1.UpdateOrganizationEnvironmentVariableRequest
+	24, // 29: gitpod.v1.EnvironmentVariableService.CreateOrganizationEnvironmentVariable:input_type -> gitpod.v1.CreateOrganizationEnvironmentVariableRequest
+	26, // 30: gitpod.v1.EnvironmentVariableService.DeleteOrganizationEnvironmentVariable:input_type -> gitpod.v1.DeleteOrganizationEnvironmentVariableRequest
+	28, // 31: gitpod.v1.EnvironmentVariableService.ResolveWorkspaceEnvironmentVariables:input_type -> gitpod.v1.ResolveWorkspaceEnvironmentVariablesRequest
+	3,  // 32: gitpod.v1.EnvironmentVariableService.ListUserEnvironmentVariables:output_type -> gitpod.v1.ListUserEnvironmentVariablesResponse
+	5,  // 33: gitpod.v1.EnvironmentVariableService.UpdateUserEnvironmentVariable:output_type -> gitpod.v1.UpdateUserEnvironmentVariableResponse
+	7,  // 34: gitpod.v1.EnvironmentVariableService.CreateUserEnvironmentVariable:output_type -> gitpod.v1.CreateUserEnvironmentVariableResponse
+	9,  // 35: gitpod.v1.EnvironmentVariableService.DeleteUserEnvironmentVariable:output_type -> gitpod.v1.DeleteUserEnvironmentVariableResponse
+	12, // 36: gitpod.v1.EnvironmentVariableService.ListConfigurationEnvironmentVariables:output_type -> gitpod.v1.ListConfigurationEnvironmentVariablesResponse
+	14, // 37: gitpod.v1.EnvironmentVariableService.UpdateConfigurationEnvironmentVariable:output_type -> gitpod.v1.UpdateConfigurationEnvironmentVariableResponse
+	16, // 38: gitpod.v1.EnvironmentVariableService.CreateConfigurationEnvironmentVariable:output_type -> gitpod.v1.CreateConfigurationEnvironmentVariableResponse
+	18, // 39: gitpod.v1.EnvironmentVariableService.DeleteConfigurationEnvironmentVariable:output_type -> gitpod.v1.DeleteConfigurationEnvironmentVariableResponse
+	21, // 40: gitpod.v1.EnvironmentVariableService.ListOrganizationEnvironmentVariables:output_type -> gitpod.v1.ListOrganizationEnvironmentVariablesResponse
+	23, // 41: gitpod.v1.EnvironmentVariableService.UpdateOrganizationEnvironmentVariable:output_type -> gitpod.v1.UpdateOrganizationEnvironmentVariableResponse
+	25, // 42: gitpod.v1.EnvironmentVariableService.CreateOrganizationEnvironmentVariable:output_type -> gitpod.v1.CreateOrganizationEnvironmentVariableResponse
+	27, // 43: gitpod.v1.EnvironmentVariableService.DeleteOrganizationEnvironmentVariable:output_type -> gitpod.v1.DeleteOrganizationEnvironmentVariableResponse
+	29, // 44: gitpod.v1.EnvironmentVariableService.ResolveWorkspaceEnvironmentVariables:output_type -> gitpod.v1.ResolveWorkspaceEnvironmentVariablesResponse
+	32, // [32:45] is the sub-list for method output_type
+	19, // [19:32] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_gitpod_v1_envvar_proto_init() }
@@ -1820,7 +2447,7 @@ func file_gitpod_v1_envvar_proto_init() {
 			}
 		}
 		file_gitpod_v1_envvar_proto_msgTypes[18].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ResolveWorkspaceEnvironmentVariablesRequest); i {
+			switch v := v.(*OrganizationEnvironmentVariable); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1832,7 +2459,7 @@ func file_gitpod_v1_envvar_proto_init() {
 			}
 		}
 		file_gitpod_v1_envvar_proto_msgTypes[19].Exporter = func(v interface{}, i int) interface{} {
-			switch v := v.(*ResolveWorkspaceEnvironmentVariablesResponse); i {
+			switch v := v.(*ListOrganizationEnvironmentVariablesRequest); i {
 			case 0:
 				return &v.state
 			case 1:
@@ -1844,6 +2471,114 @@ func file_gitpod_v1_envvar_proto_init() {
 			}
 		}
 		file_gitpod_v1_envvar_proto_msgTypes[20].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ListOrganizationEnvironmentVariablesResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[21].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*UpdateOrganizationEnvironmentVariableRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[22].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*UpdateOrganizationEnvironmentVariableResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[23].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CreateOrganizationEnvironmentVariableRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[24].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*CreateOrganizationEnvironmentVariableResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[25].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DeleteOrganizationEnvironmentVariableRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[26].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*DeleteOrganizationEnvironmentVariableResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[27].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ResolveWorkspaceEnvironmentVariablesRequest); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[28].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*ResolveWorkspaceEnvironmentVariablesResponse); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_gitpod_v1_envvar_proto_msgTypes[29].Exporter = func(v interface{}, i int) interface{} {
 			switch v := v.(*EnvironmentVariable); i {
 			case 0:
 				return &v.state
@@ -1858,13 +2593,14 @@ func file_gitpod_v1_envvar_proto_init() {
 	}
 	file_gitpod_v1_envvar_proto_msgTypes[3].OneofWrappers = []interface{}{}
 	file_gitpod_v1_envvar_proto_msgTypes[12].OneofWrappers = []interface{}{}
+	file_gitpod_v1_envvar_proto_msgTypes[21].OneofWrappers = []interface{}{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_gitpod_v1_envvar_proto_rawDesc,
 			NumEnums:      1,
-			NumMessages:   21,
+			NumMessages:   30,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/components/public-api/go/v1/envvar_grpc.pb.go
+++ b/components/public-api/go/v1/envvar_grpc.pb.go
@@ -50,6 +50,18 @@ type EnvironmentVariableServiceClient interface {
 	// DeleteConfigurationEnvironmentVariable deletes an environment variable in
 	// a configuration.
 	DeleteConfigurationEnvironmentVariable(ctx context.Context, in *DeleteConfigurationEnvironmentVariableRequest, opts ...grpc.CallOption) (*DeleteConfigurationEnvironmentVariableResponse, error)
+	// ListOrganizationEnvironmentVariables returns all environment variables in
+	// an organization.
+	ListOrganizationEnvironmentVariables(ctx context.Context, in *ListOrganizationEnvironmentVariablesRequest, opts ...grpc.CallOption) (*ListOrganizationEnvironmentVariablesResponse, error)
+	// UpdateOrganizationEnvironmentVariable updates an environment variable in
+	// an organization.
+	UpdateOrganizationEnvironmentVariable(ctx context.Context, in *UpdateOrganizationEnvironmentVariableRequest, opts ...grpc.CallOption) (*UpdateOrganizationEnvironmentVariableResponse, error)
+	// CreateOrganizationEnvironmentVariable creates a new environment variable
+	// in an organization.
+	CreateOrganizationEnvironmentVariable(ctx context.Context, in *CreateOrganizationEnvironmentVariableRequest, opts ...grpc.CallOption) (*CreateOrganizationEnvironmentVariableResponse, error)
+	// DeleteOrganizationEnvironmentVariable deletes an environment variable in
+	// an organization.
+	DeleteOrganizationEnvironmentVariable(ctx context.Context, in *DeleteOrganizationEnvironmentVariableRequest, opts ...grpc.CallOption) (*DeleteOrganizationEnvironmentVariableResponse, error)
 	ResolveWorkspaceEnvironmentVariables(ctx context.Context, in *ResolveWorkspaceEnvironmentVariablesRequest, opts ...grpc.CallOption) (*ResolveWorkspaceEnvironmentVariablesResponse, error)
 }
 
@@ -133,6 +145,42 @@ func (c *environmentVariableServiceClient) DeleteConfigurationEnvironmentVariabl
 	return out, nil
 }
 
+func (c *environmentVariableServiceClient) ListOrganizationEnvironmentVariables(ctx context.Context, in *ListOrganizationEnvironmentVariablesRequest, opts ...grpc.CallOption) (*ListOrganizationEnvironmentVariablesResponse, error) {
+	out := new(ListOrganizationEnvironmentVariablesResponse)
+	err := c.cc.Invoke(ctx, "/gitpod.v1.EnvironmentVariableService/ListOrganizationEnvironmentVariables", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *environmentVariableServiceClient) UpdateOrganizationEnvironmentVariable(ctx context.Context, in *UpdateOrganizationEnvironmentVariableRequest, opts ...grpc.CallOption) (*UpdateOrganizationEnvironmentVariableResponse, error) {
+	out := new(UpdateOrganizationEnvironmentVariableResponse)
+	err := c.cc.Invoke(ctx, "/gitpod.v1.EnvironmentVariableService/UpdateOrganizationEnvironmentVariable", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *environmentVariableServiceClient) CreateOrganizationEnvironmentVariable(ctx context.Context, in *CreateOrganizationEnvironmentVariableRequest, opts ...grpc.CallOption) (*CreateOrganizationEnvironmentVariableResponse, error) {
+	out := new(CreateOrganizationEnvironmentVariableResponse)
+	err := c.cc.Invoke(ctx, "/gitpod.v1.EnvironmentVariableService/CreateOrganizationEnvironmentVariable", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *environmentVariableServiceClient) DeleteOrganizationEnvironmentVariable(ctx context.Context, in *DeleteOrganizationEnvironmentVariableRequest, opts ...grpc.CallOption) (*DeleteOrganizationEnvironmentVariableResponse, error) {
+	out := new(DeleteOrganizationEnvironmentVariableResponse)
+	err := c.cc.Invoke(ctx, "/gitpod.v1.EnvironmentVariableService/DeleteOrganizationEnvironmentVariable", in, out, opts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *environmentVariableServiceClient) ResolveWorkspaceEnvironmentVariables(ctx context.Context, in *ResolveWorkspaceEnvironmentVariablesRequest, opts ...grpc.CallOption) (*ResolveWorkspaceEnvironmentVariablesResponse, error) {
 	out := new(ResolveWorkspaceEnvironmentVariablesResponse)
 	err := c.cc.Invoke(ctx, "/gitpod.v1.EnvironmentVariableService/ResolveWorkspaceEnvironmentVariables", in, out, opts...)
@@ -170,6 +218,18 @@ type EnvironmentVariableServiceServer interface {
 	// DeleteConfigurationEnvironmentVariable deletes an environment variable in
 	// a configuration.
 	DeleteConfigurationEnvironmentVariable(context.Context, *DeleteConfigurationEnvironmentVariableRequest) (*DeleteConfigurationEnvironmentVariableResponse, error)
+	// ListOrganizationEnvironmentVariables returns all environment variables in
+	// an organization.
+	ListOrganizationEnvironmentVariables(context.Context, *ListOrganizationEnvironmentVariablesRequest) (*ListOrganizationEnvironmentVariablesResponse, error)
+	// UpdateOrganizationEnvironmentVariable updates an environment variable in
+	// an organization.
+	UpdateOrganizationEnvironmentVariable(context.Context, *UpdateOrganizationEnvironmentVariableRequest) (*UpdateOrganizationEnvironmentVariableResponse, error)
+	// CreateOrganizationEnvironmentVariable creates a new environment variable
+	// in an organization.
+	CreateOrganizationEnvironmentVariable(context.Context, *CreateOrganizationEnvironmentVariableRequest) (*CreateOrganizationEnvironmentVariableResponse, error)
+	// DeleteOrganizationEnvironmentVariable deletes an environment variable in
+	// an organization.
+	DeleteOrganizationEnvironmentVariable(context.Context, *DeleteOrganizationEnvironmentVariableRequest) (*DeleteOrganizationEnvironmentVariableResponse, error)
 	ResolveWorkspaceEnvironmentVariables(context.Context, *ResolveWorkspaceEnvironmentVariablesRequest) (*ResolveWorkspaceEnvironmentVariablesResponse, error)
 	mustEmbedUnimplementedEnvironmentVariableServiceServer()
 }
@@ -201,6 +261,18 @@ func (UnimplementedEnvironmentVariableServiceServer) CreateConfigurationEnvironm
 }
 func (UnimplementedEnvironmentVariableServiceServer) DeleteConfigurationEnvironmentVariable(context.Context, *DeleteConfigurationEnvironmentVariableRequest) (*DeleteConfigurationEnvironmentVariableResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method DeleteConfigurationEnvironmentVariable not implemented")
+}
+func (UnimplementedEnvironmentVariableServiceServer) ListOrganizationEnvironmentVariables(context.Context, *ListOrganizationEnvironmentVariablesRequest) (*ListOrganizationEnvironmentVariablesResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method ListOrganizationEnvironmentVariables not implemented")
+}
+func (UnimplementedEnvironmentVariableServiceServer) UpdateOrganizationEnvironmentVariable(context.Context, *UpdateOrganizationEnvironmentVariableRequest) (*UpdateOrganizationEnvironmentVariableResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method UpdateOrganizationEnvironmentVariable not implemented")
+}
+func (UnimplementedEnvironmentVariableServiceServer) CreateOrganizationEnvironmentVariable(context.Context, *CreateOrganizationEnvironmentVariableRequest) (*CreateOrganizationEnvironmentVariableResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method CreateOrganizationEnvironmentVariable not implemented")
+}
+func (UnimplementedEnvironmentVariableServiceServer) DeleteOrganizationEnvironmentVariable(context.Context, *DeleteOrganizationEnvironmentVariableRequest) (*DeleteOrganizationEnvironmentVariableResponse, error) {
+	return nil, status.Errorf(codes.Unimplemented, "method DeleteOrganizationEnvironmentVariable not implemented")
 }
 func (UnimplementedEnvironmentVariableServiceServer) ResolveWorkspaceEnvironmentVariables(context.Context, *ResolveWorkspaceEnvironmentVariablesRequest) (*ResolveWorkspaceEnvironmentVariablesResponse, error) {
 	return nil, status.Errorf(codes.Unimplemented, "method ResolveWorkspaceEnvironmentVariables not implemented")
@@ -363,6 +435,78 @@ func _EnvironmentVariableService_DeleteConfigurationEnvironmentVariable_Handler(
 	return interceptor(ctx, in, info, handler)
 }
 
+func _EnvironmentVariableService_ListOrganizationEnvironmentVariables_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ListOrganizationEnvironmentVariablesRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EnvironmentVariableServiceServer).ListOrganizationEnvironmentVariables(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gitpod.v1.EnvironmentVariableService/ListOrganizationEnvironmentVariables",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EnvironmentVariableServiceServer).ListOrganizationEnvironmentVariables(ctx, req.(*ListOrganizationEnvironmentVariablesRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _EnvironmentVariableService_UpdateOrganizationEnvironmentVariable_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(UpdateOrganizationEnvironmentVariableRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EnvironmentVariableServiceServer).UpdateOrganizationEnvironmentVariable(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gitpod.v1.EnvironmentVariableService/UpdateOrganizationEnvironmentVariable",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EnvironmentVariableServiceServer).UpdateOrganizationEnvironmentVariable(ctx, req.(*UpdateOrganizationEnvironmentVariableRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _EnvironmentVariableService_CreateOrganizationEnvironmentVariable_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateOrganizationEnvironmentVariableRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EnvironmentVariableServiceServer).CreateOrganizationEnvironmentVariable(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gitpod.v1.EnvironmentVariableService/CreateOrganizationEnvironmentVariable",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EnvironmentVariableServiceServer).CreateOrganizationEnvironmentVariable(ctx, req.(*CreateOrganizationEnvironmentVariableRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _EnvironmentVariableService_DeleteOrganizationEnvironmentVariable_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeleteOrganizationEnvironmentVariableRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(EnvironmentVariableServiceServer).DeleteOrganizationEnvironmentVariable(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: "/gitpod.v1.EnvironmentVariableService/DeleteOrganizationEnvironmentVariable",
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(EnvironmentVariableServiceServer).DeleteOrganizationEnvironmentVariable(ctx, req.(*DeleteOrganizationEnvironmentVariableRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _EnvironmentVariableService_ResolveWorkspaceEnvironmentVariables_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(ResolveWorkspaceEnvironmentVariablesRequest)
 	if err := dec(in); err != nil {
@@ -419,6 +563,22 @@ var EnvironmentVariableService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "DeleteConfigurationEnvironmentVariable",
 			Handler:    _EnvironmentVariableService_DeleteConfigurationEnvironmentVariable_Handler,
+		},
+		{
+			MethodName: "ListOrganizationEnvironmentVariables",
+			Handler:    _EnvironmentVariableService_ListOrganizationEnvironmentVariables_Handler,
+		},
+		{
+			MethodName: "UpdateOrganizationEnvironmentVariable",
+			Handler:    _EnvironmentVariableService_UpdateOrganizationEnvironmentVariable_Handler,
+		},
+		{
+			MethodName: "CreateOrganizationEnvironmentVariable",
+			Handler:    _EnvironmentVariableService_CreateOrganizationEnvironmentVariable_Handler,
+		},
+		{
+			MethodName: "DeleteOrganizationEnvironmentVariable",
+			Handler:    _EnvironmentVariableService_DeleteOrganizationEnvironmentVariable_Handler,
 		},
 		{
 			MethodName: "ResolveWorkspaceEnvironmentVariables",

--- a/components/public-api/go/v1/v1connect/envvar.connect.go
+++ b/components/public-api/go/v1/v1connect/envvar.connect.go
@@ -57,6 +57,18 @@ type EnvironmentVariableServiceClient interface {
 	// DeleteConfigurationEnvironmentVariable deletes an environment variable in
 	// a configuration.
 	DeleteConfigurationEnvironmentVariable(context.Context, *connect_go.Request[v1.DeleteConfigurationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteConfigurationEnvironmentVariableResponse], error)
+	// ListOrganizationEnvironmentVariables returns all environment variables in
+	// an organization.
+	ListOrganizationEnvironmentVariables(context.Context, *connect_go.Request[v1.ListOrganizationEnvironmentVariablesRequest]) (*connect_go.Response[v1.ListOrganizationEnvironmentVariablesResponse], error)
+	// UpdateOrganizationEnvironmentVariable updates an environment variable in
+	// an organization.
+	UpdateOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.UpdateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.UpdateOrganizationEnvironmentVariableResponse], error)
+	// CreateOrganizationEnvironmentVariable creates a new environment variable
+	// in an organization.
+	CreateOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.CreateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.CreateOrganizationEnvironmentVariableResponse], error)
+	// DeleteOrganizationEnvironmentVariable deletes an environment variable in
+	// an organization.
+	DeleteOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.DeleteOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteOrganizationEnvironmentVariableResponse], error)
 	ResolveWorkspaceEnvironmentVariables(context.Context, *connect_go.Request[v1.ResolveWorkspaceEnvironmentVariablesRequest]) (*connect_go.Response[v1.ResolveWorkspaceEnvironmentVariablesResponse], error)
 }
 
@@ -110,6 +122,26 @@ func NewEnvironmentVariableServiceClient(httpClient connect_go.HTTPClient, baseU
 			baseURL+"/gitpod.v1.EnvironmentVariableService/DeleteConfigurationEnvironmentVariable",
 			opts...,
 		),
+		listOrganizationEnvironmentVariables: connect_go.NewClient[v1.ListOrganizationEnvironmentVariablesRequest, v1.ListOrganizationEnvironmentVariablesResponse](
+			httpClient,
+			baseURL+"/gitpod.v1.EnvironmentVariableService/ListOrganizationEnvironmentVariables",
+			opts...,
+		),
+		updateOrganizationEnvironmentVariable: connect_go.NewClient[v1.UpdateOrganizationEnvironmentVariableRequest, v1.UpdateOrganizationEnvironmentVariableResponse](
+			httpClient,
+			baseURL+"/gitpod.v1.EnvironmentVariableService/UpdateOrganizationEnvironmentVariable",
+			opts...,
+		),
+		createOrganizationEnvironmentVariable: connect_go.NewClient[v1.CreateOrganizationEnvironmentVariableRequest, v1.CreateOrganizationEnvironmentVariableResponse](
+			httpClient,
+			baseURL+"/gitpod.v1.EnvironmentVariableService/CreateOrganizationEnvironmentVariable",
+			opts...,
+		),
+		deleteOrganizationEnvironmentVariable: connect_go.NewClient[v1.DeleteOrganizationEnvironmentVariableRequest, v1.DeleteOrganizationEnvironmentVariableResponse](
+			httpClient,
+			baseURL+"/gitpod.v1.EnvironmentVariableService/DeleteOrganizationEnvironmentVariable",
+			opts...,
+		),
 		resolveWorkspaceEnvironmentVariables: connect_go.NewClient[v1.ResolveWorkspaceEnvironmentVariablesRequest, v1.ResolveWorkspaceEnvironmentVariablesResponse](
 			httpClient,
 			baseURL+"/gitpod.v1.EnvironmentVariableService/ResolveWorkspaceEnvironmentVariables",
@@ -128,6 +160,10 @@ type environmentVariableServiceClient struct {
 	updateConfigurationEnvironmentVariable *connect_go.Client[v1.UpdateConfigurationEnvironmentVariableRequest, v1.UpdateConfigurationEnvironmentVariableResponse]
 	createConfigurationEnvironmentVariable *connect_go.Client[v1.CreateConfigurationEnvironmentVariableRequest, v1.CreateConfigurationEnvironmentVariableResponse]
 	deleteConfigurationEnvironmentVariable *connect_go.Client[v1.DeleteConfigurationEnvironmentVariableRequest, v1.DeleteConfigurationEnvironmentVariableResponse]
+	listOrganizationEnvironmentVariables   *connect_go.Client[v1.ListOrganizationEnvironmentVariablesRequest, v1.ListOrganizationEnvironmentVariablesResponse]
+	updateOrganizationEnvironmentVariable  *connect_go.Client[v1.UpdateOrganizationEnvironmentVariableRequest, v1.UpdateOrganizationEnvironmentVariableResponse]
+	createOrganizationEnvironmentVariable  *connect_go.Client[v1.CreateOrganizationEnvironmentVariableRequest, v1.CreateOrganizationEnvironmentVariableResponse]
+	deleteOrganizationEnvironmentVariable  *connect_go.Client[v1.DeleteOrganizationEnvironmentVariableRequest, v1.DeleteOrganizationEnvironmentVariableResponse]
 	resolveWorkspaceEnvironmentVariables   *connect_go.Client[v1.ResolveWorkspaceEnvironmentVariablesRequest, v1.ResolveWorkspaceEnvironmentVariablesResponse]
 }
 
@@ -179,6 +215,30 @@ func (c *environmentVariableServiceClient) DeleteConfigurationEnvironmentVariabl
 	return c.deleteConfigurationEnvironmentVariable.CallUnary(ctx, req)
 }
 
+// ListOrganizationEnvironmentVariables calls
+// gitpod.v1.EnvironmentVariableService.ListOrganizationEnvironmentVariables.
+func (c *environmentVariableServiceClient) ListOrganizationEnvironmentVariables(ctx context.Context, req *connect_go.Request[v1.ListOrganizationEnvironmentVariablesRequest]) (*connect_go.Response[v1.ListOrganizationEnvironmentVariablesResponse], error) {
+	return c.listOrganizationEnvironmentVariables.CallUnary(ctx, req)
+}
+
+// UpdateOrganizationEnvironmentVariable calls
+// gitpod.v1.EnvironmentVariableService.UpdateOrganizationEnvironmentVariable.
+func (c *environmentVariableServiceClient) UpdateOrganizationEnvironmentVariable(ctx context.Context, req *connect_go.Request[v1.UpdateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.UpdateOrganizationEnvironmentVariableResponse], error) {
+	return c.updateOrganizationEnvironmentVariable.CallUnary(ctx, req)
+}
+
+// CreateOrganizationEnvironmentVariable calls
+// gitpod.v1.EnvironmentVariableService.CreateOrganizationEnvironmentVariable.
+func (c *environmentVariableServiceClient) CreateOrganizationEnvironmentVariable(ctx context.Context, req *connect_go.Request[v1.CreateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.CreateOrganizationEnvironmentVariableResponse], error) {
+	return c.createOrganizationEnvironmentVariable.CallUnary(ctx, req)
+}
+
+// DeleteOrganizationEnvironmentVariable calls
+// gitpod.v1.EnvironmentVariableService.DeleteOrganizationEnvironmentVariable.
+func (c *environmentVariableServiceClient) DeleteOrganizationEnvironmentVariable(ctx context.Context, req *connect_go.Request[v1.DeleteOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteOrganizationEnvironmentVariableResponse], error) {
+	return c.deleteOrganizationEnvironmentVariable.CallUnary(ctx, req)
+}
+
 // ResolveWorkspaceEnvironmentVariables calls
 // gitpod.v1.EnvironmentVariableService.ResolveWorkspaceEnvironmentVariables.
 func (c *environmentVariableServiceClient) ResolveWorkspaceEnvironmentVariables(ctx context.Context, req *connect_go.Request[v1.ResolveWorkspaceEnvironmentVariablesRequest]) (*connect_go.Response[v1.ResolveWorkspaceEnvironmentVariablesResponse], error) {
@@ -212,6 +272,18 @@ type EnvironmentVariableServiceHandler interface {
 	// DeleteConfigurationEnvironmentVariable deletes an environment variable in
 	// a configuration.
 	DeleteConfigurationEnvironmentVariable(context.Context, *connect_go.Request[v1.DeleteConfigurationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteConfigurationEnvironmentVariableResponse], error)
+	// ListOrganizationEnvironmentVariables returns all environment variables in
+	// an organization.
+	ListOrganizationEnvironmentVariables(context.Context, *connect_go.Request[v1.ListOrganizationEnvironmentVariablesRequest]) (*connect_go.Response[v1.ListOrganizationEnvironmentVariablesResponse], error)
+	// UpdateOrganizationEnvironmentVariable updates an environment variable in
+	// an organization.
+	UpdateOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.UpdateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.UpdateOrganizationEnvironmentVariableResponse], error)
+	// CreateOrganizationEnvironmentVariable creates a new environment variable
+	// in an organization.
+	CreateOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.CreateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.CreateOrganizationEnvironmentVariableResponse], error)
+	// DeleteOrganizationEnvironmentVariable deletes an environment variable in
+	// an organization.
+	DeleteOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.DeleteOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteOrganizationEnvironmentVariableResponse], error)
 	ResolveWorkspaceEnvironmentVariables(context.Context, *connect_go.Request[v1.ResolveWorkspaceEnvironmentVariablesRequest]) (*connect_go.Response[v1.ResolveWorkspaceEnvironmentVariablesResponse], error)
 }
 
@@ -262,6 +334,26 @@ func NewEnvironmentVariableServiceHandler(svc EnvironmentVariableServiceHandler,
 		svc.DeleteConfigurationEnvironmentVariable,
 		opts...,
 	))
+	mux.Handle("/gitpod.v1.EnvironmentVariableService/ListOrganizationEnvironmentVariables", connect_go.NewUnaryHandler(
+		"/gitpod.v1.EnvironmentVariableService/ListOrganizationEnvironmentVariables",
+		svc.ListOrganizationEnvironmentVariables,
+		opts...,
+	))
+	mux.Handle("/gitpod.v1.EnvironmentVariableService/UpdateOrganizationEnvironmentVariable", connect_go.NewUnaryHandler(
+		"/gitpod.v1.EnvironmentVariableService/UpdateOrganizationEnvironmentVariable",
+		svc.UpdateOrganizationEnvironmentVariable,
+		opts...,
+	))
+	mux.Handle("/gitpod.v1.EnvironmentVariableService/CreateOrganizationEnvironmentVariable", connect_go.NewUnaryHandler(
+		"/gitpod.v1.EnvironmentVariableService/CreateOrganizationEnvironmentVariable",
+		svc.CreateOrganizationEnvironmentVariable,
+		opts...,
+	))
+	mux.Handle("/gitpod.v1.EnvironmentVariableService/DeleteOrganizationEnvironmentVariable", connect_go.NewUnaryHandler(
+		"/gitpod.v1.EnvironmentVariableService/DeleteOrganizationEnvironmentVariable",
+		svc.DeleteOrganizationEnvironmentVariable,
+		opts...,
+	))
 	mux.Handle("/gitpod.v1.EnvironmentVariableService/ResolveWorkspaceEnvironmentVariables", connect_go.NewUnaryHandler(
 		"/gitpod.v1.EnvironmentVariableService/ResolveWorkspaceEnvironmentVariables",
 		svc.ResolveWorkspaceEnvironmentVariables,
@@ -303,6 +395,22 @@ func (UnimplementedEnvironmentVariableServiceHandler) CreateConfigurationEnviron
 
 func (UnimplementedEnvironmentVariableServiceHandler) DeleteConfigurationEnvironmentVariable(context.Context, *connect_go.Request[v1.DeleteConfigurationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteConfigurationEnvironmentVariableResponse], error) {
 	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("gitpod.v1.EnvironmentVariableService.DeleteConfigurationEnvironmentVariable is not implemented"))
+}
+
+func (UnimplementedEnvironmentVariableServiceHandler) ListOrganizationEnvironmentVariables(context.Context, *connect_go.Request[v1.ListOrganizationEnvironmentVariablesRequest]) (*connect_go.Response[v1.ListOrganizationEnvironmentVariablesResponse], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("gitpod.v1.EnvironmentVariableService.ListOrganizationEnvironmentVariables is not implemented"))
+}
+
+func (UnimplementedEnvironmentVariableServiceHandler) UpdateOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.UpdateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.UpdateOrganizationEnvironmentVariableResponse], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("gitpod.v1.EnvironmentVariableService.UpdateOrganizationEnvironmentVariable is not implemented"))
+}
+
+func (UnimplementedEnvironmentVariableServiceHandler) CreateOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.CreateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.CreateOrganizationEnvironmentVariableResponse], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("gitpod.v1.EnvironmentVariableService.CreateOrganizationEnvironmentVariable is not implemented"))
+}
+
+func (UnimplementedEnvironmentVariableServiceHandler) DeleteOrganizationEnvironmentVariable(context.Context, *connect_go.Request[v1.DeleteOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteOrganizationEnvironmentVariableResponse], error) {
+	return nil, connect_go.NewError(connect_go.CodeUnimplemented, errors.New("gitpod.v1.EnvironmentVariableService.DeleteOrganizationEnvironmentVariable is not implemented"))
 }
 
 func (UnimplementedEnvironmentVariableServiceHandler) ResolveWorkspaceEnvironmentVariables(context.Context, *connect_go.Request[v1.ResolveWorkspaceEnvironmentVariablesRequest]) (*connect_go.Response[v1.ResolveWorkspaceEnvironmentVariablesResponse], error) {

--- a/components/public-api/go/v1/v1connect/envvar.proxy.connect.go
+++ b/components/public-api/go/v1/v1connect/envvar.proxy.connect.go
@@ -99,6 +99,46 @@ func (s *ProxyEnvironmentVariableServiceHandler) DeleteConfigurationEnvironmentV
 	return connect_go.NewResponse(resp), nil
 }
 
+func (s *ProxyEnvironmentVariableServiceHandler) ListOrganizationEnvironmentVariables(ctx context.Context, req *connect_go.Request[v1.ListOrganizationEnvironmentVariablesRequest]) (*connect_go.Response[v1.ListOrganizationEnvironmentVariablesResponse], error) {
+	resp, err := s.Client.ListOrganizationEnvironmentVariables(ctx, req.Msg)
+	if err != nil {
+		// TODO(milan): Convert to correct status code
+		return nil, err
+	}
+
+	return connect_go.NewResponse(resp), nil
+}
+
+func (s *ProxyEnvironmentVariableServiceHandler) UpdateOrganizationEnvironmentVariable(ctx context.Context, req *connect_go.Request[v1.UpdateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.UpdateOrganizationEnvironmentVariableResponse], error) {
+	resp, err := s.Client.UpdateOrganizationEnvironmentVariable(ctx, req.Msg)
+	if err != nil {
+		// TODO(milan): Convert to correct status code
+		return nil, err
+	}
+
+	return connect_go.NewResponse(resp), nil
+}
+
+func (s *ProxyEnvironmentVariableServiceHandler) CreateOrganizationEnvironmentVariable(ctx context.Context, req *connect_go.Request[v1.CreateOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.CreateOrganizationEnvironmentVariableResponse], error) {
+	resp, err := s.Client.CreateOrganizationEnvironmentVariable(ctx, req.Msg)
+	if err != nil {
+		// TODO(milan): Convert to correct status code
+		return nil, err
+	}
+
+	return connect_go.NewResponse(resp), nil
+}
+
+func (s *ProxyEnvironmentVariableServiceHandler) DeleteOrganizationEnvironmentVariable(ctx context.Context, req *connect_go.Request[v1.DeleteOrganizationEnvironmentVariableRequest]) (*connect_go.Response[v1.DeleteOrganizationEnvironmentVariableResponse], error) {
+	resp, err := s.Client.DeleteOrganizationEnvironmentVariable(ctx, req.Msg)
+	if err != nil {
+		// TODO(milan): Convert to correct status code
+		return nil, err
+	}
+
+	return connect_go.NewResponse(resp), nil
+}
+
 func (s *ProxyEnvironmentVariableServiceHandler) ResolveWorkspaceEnvironmentVariables(ctx context.Context, req *connect_go.Request[v1.ResolveWorkspaceEnvironmentVariablesRequest]) (*connect_go.Response[v1.ResolveWorkspaceEnvironmentVariablesResponse], error) {
 	resp, err := s.Client.ResolveWorkspaceEnvironmentVariables(ctx, req.Msg)
 	if err != nil {

--- a/components/public-api/java/src/main/java/io/gitpod/publicapi/v1/EnvironmentVariableServiceClient.kt
+++ b/components/public-api/java/src/main/java/io/gitpod/publicapi/v1/EnvironmentVariableServiceClient.kt
@@ -169,6 +169,82 @@ public class EnvironmentVariableServiceClient(
   )
 
 
+  /**
+   *  ListOrganizationEnvironmentVariables returns all environment variables in
+   *  an organization.
+   */
+  override suspend
+      fun listOrganizationEnvironmentVariables(request: Envvar.ListOrganizationEnvironmentVariablesRequest,
+      headers: Headers): ResponseMessage<Envvar.ListOrganizationEnvironmentVariablesResponse> =
+      client.unary(
+    request,
+    headers,
+    MethodSpec(
+    "gitpod.v1.EnvironmentVariableService/ListOrganizationEnvironmentVariables",
+      io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest::class,
+      io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse::class,
+      StreamType.UNARY,
+    ),
+  )
+
+
+  /**
+   *  UpdateOrganizationEnvironmentVariable updates an environment variable in
+   *  an organization.
+   */
+  override suspend
+      fun updateOrganizationEnvironmentVariable(request: Envvar.UpdateOrganizationEnvironmentVariableRequest,
+      headers: Headers): ResponseMessage<Envvar.UpdateOrganizationEnvironmentVariableResponse> =
+      client.unary(
+    request,
+    headers,
+    MethodSpec(
+    "gitpod.v1.EnvironmentVariableService/UpdateOrganizationEnvironmentVariable",
+      io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest::class,
+      io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse::class,
+      StreamType.UNARY,
+    ),
+  )
+
+
+  /**
+   *  CreateOrganizationEnvironmentVariable creates a new environment variable
+   *  in an organization.
+   */
+  override suspend
+      fun createOrganizationEnvironmentVariable(request: Envvar.CreateOrganizationEnvironmentVariableRequest,
+      headers: Headers): ResponseMessage<Envvar.CreateOrganizationEnvironmentVariableResponse> =
+      client.unary(
+    request,
+    headers,
+    MethodSpec(
+    "gitpod.v1.EnvironmentVariableService/CreateOrganizationEnvironmentVariable",
+      io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest::class,
+      io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse::class,
+      StreamType.UNARY,
+    ),
+  )
+
+
+  /**
+   *  DeleteOrganizationEnvironmentVariable deletes an environment variable in
+   *  an organization.
+   */
+  override suspend
+      fun deleteOrganizationEnvironmentVariable(request: Envvar.DeleteOrganizationEnvironmentVariableRequest,
+      headers: Headers): ResponseMessage<Envvar.DeleteOrganizationEnvironmentVariableResponse> =
+      client.unary(
+    request,
+    headers,
+    MethodSpec(
+    "gitpod.v1.EnvironmentVariableService/DeleteOrganizationEnvironmentVariable",
+      io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest::class,
+      io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse::class,
+      StreamType.UNARY,
+    ),
+  )
+
+
   override suspend
       fun resolveWorkspaceEnvironmentVariables(request: Envvar.ResolveWorkspaceEnvironmentVariablesRequest,
       headers: Headers): ResponseMessage<Envvar.ResolveWorkspaceEnvironmentVariablesResponse> =

--- a/components/public-api/java/src/main/java/io/gitpod/publicapi/v1/EnvironmentVariableServiceClientInterface.kt
+++ b/components/public-api/java/src/main/java/io/gitpod/publicapi/v1/EnvironmentVariableServiceClientInterface.kt
@@ -80,6 +80,42 @@ public interface EnvironmentVariableServiceClientInterface {
       headers: Headers = emptyMap()):
       ResponseMessage<Envvar.DeleteConfigurationEnvironmentVariableResponse>
 
+  /**
+   *  ListOrganizationEnvironmentVariables returns all environment variables in
+   *  an organization.
+   */
+  public suspend
+      fun listOrganizationEnvironmentVariables(request: Envvar.ListOrganizationEnvironmentVariablesRequest,
+      headers: Headers = emptyMap()):
+      ResponseMessage<Envvar.ListOrganizationEnvironmentVariablesResponse>
+
+  /**
+   *  UpdateOrganizationEnvironmentVariable updates an environment variable in
+   *  an organization.
+   */
+  public suspend
+      fun updateOrganizationEnvironmentVariable(request: Envvar.UpdateOrganizationEnvironmentVariableRequest,
+      headers: Headers = emptyMap()):
+      ResponseMessage<Envvar.UpdateOrganizationEnvironmentVariableResponse>
+
+  /**
+   *  CreateOrganizationEnvironmentVariable creates a new environment variable
+   *  in an organization.
+   */
+  public suspend
+      fun createOrganizationEnvironmentVariable(request: Envvar.CreateOrganizationEnvironmentVariableRequest,
+      headers: Headers = emptyMap()):
+      ResponseMessage<Envvar.CreateOrganizationEnvironmentVariableResponse>
+
+  /**
+   *  DeleteOrganizationEnvironmentVariable deletes an environment variable in
+   *  an organization.
+   */
+  public suspend
+      fun deleteOrganizationEnvironmentVariable(request: Envvar.DeleteOrganizationEnvironmentVariableRequest,
+      headers: Headers = emptyMap()):
+      ResponseMessage<Envvar.DeleteOrganizationEnvironmentVariableResponse>
+
   public suspend
       fun resolveWorkspaceEnvironmentVariables(request: Envvar.ResolveWorkspaceEnvironmentVariablesRequest,
       headers: Headers = emptyMap()):

--- a/components/public-api/java/src/main/java/io/gitpod/publicapi/v1/Envvar.java
+++ b/components/public-api/java/src/main/java/io/gitpod/publicapi/v1/Envvar.java
@@ -13107,6 +13107,6299 @@ public final class Envvar {
 
   }
 
+  public interface OrganizationEnvironmentVariableOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.OrganizationEnvironmentVariable)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string id = 1 [json_name = "id"];</code>
+     * @return The id.
+     */
+    java.lang.String getId();
+    /**
+     * <code>string id = 1 [json_name = "id"];</code>
+     * @return The bytes for id.
+     */
+    com.google.protobuf.ByteString
+        getIdBytes();
+
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    java.lang.String getOrganizationId();
+    /**
+     * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    com.google.protobuf.ByteString
+        getOrganizationIdBytes();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.OrganizationEnvironmentVariable}
+   */
+  public static final class OrganizationEnvironmentVariable extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.OrganizationEnvironmentVariable)
+      OrganizationEnvironmentVariableOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        OrganizationEnvironmentVariable.class.getName());
+    }
+    // Use OrganizationEnvironmentVariable.newBuilder() to construct.
+    private OrganizationEnvironmentVariable(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private OrganizationEnvironmentVariable() {
+      id_ = "";
+      name_ = "";
+      organizationId_ = "";
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_OrganizationEnvironmentVariable_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_OrganizationEnvironmentVariable_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.class, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder.class);
+    }
+
+    public static final int ID_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object id_ = "";
+    /**
+     * <code>string id = 1 [json_name = "id"];</code>
+     * @return The id.
+     */
+    @java.lang.Override
+    public java.lang.String getId() {
+      java.lang.Object ref = id_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        id_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string id = 1 [json_name = "id"];</code>
+     * @return The bytes for id.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getIdBytes() {
+      java.lang.Object ref = id_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        id_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int NAME_FIELD_NUMBER = 2;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        name_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ORGANIZATION_ID_FIELD_NUMBER = 3;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object organizationId_ = "";
+    /**
+     * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    @java.lang.Override
+    public java.lang.String getOrganizationId() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        organizationId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getOrganizationIdBytes() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        organizationId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(id_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, id_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(name_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 2, name_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 3, organizationId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(id_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, id_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(name_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, name_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(3, organizationId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable other = (io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable) obj;
+
+      if (!getId()
+          .equals(other.getId())) return false;
+      if (!getName()
+          .equals(other.getName())) return false;
+      if (!getOrganizationId()
+          .equals(other.getOrganizationId())) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + ID_FIELD_NUMBER;
+      hash = (53 * hash) + getId().hashCode();
+      hash = (37 * hash) + NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getName().hashCode();
+      hash = (37 * hash) + ORGANIZATION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getOrganizationId().hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.OrganizationEnvironmentVariable}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.OrganizationEnvironmentVariable)
+        io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_OrganizationEnvironmentVariable_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_OrganizationEnvironmentVariable_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.class, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        id_ = "";
+        name_ = "";
+        organizationId_ = "";
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_OrganizationEnvironmentVariable_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable build() {
+        io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable result = new io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.id_ = id_;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.name_ = name_;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.organizationId_ = organizationId_;
+        }
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance()) return this;
+        if (!other.getId().isEmpty()) {
+          id_ = other.id_;
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        if (!other.getName().isEmpty()) {
+          name_ = other.name_;
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
+        if (!other.getOrganizationId().isEmpty()) {
+          organizationId_ = other.organizationId_;
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                id_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 18: {
+                name_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              case 26: {
+                organizationId_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 26
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object id_ = "";
+      /**
+       * <code>string id = 1 [json_name = "id"];</code>
+       * @return The id.
+       */
+      public java.lang.String getId() {
+        java.lang.Object ref = id_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          id_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string id = 1 [json_name = "id"];</code>
+       * @return The bytes for id.
+       */
+      public com.google.protobuf.ByteString
+          getIdBytes() {
+        java.lang.Object ref = id_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          id_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string id = 1 [json_name = "id"];</code>
+       * @param value The id to set.
+       * @return This builder for chaining.
+       */
+      public Builder setId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        id_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string id = 1 [json_name = "id"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearId() {
+        id_ = getDefaultInstance().getId();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string id = 1 [json_name = "id"];</code>
+       * @param value The bytes for id to set.
+       * @return This builder for chaining.
+       */
+      public Builder setIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        id_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object name_ = "";
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          name_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        name_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        name_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object organizationId_ = "";
+      /**
+       * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+       * @return The organizationId.
+       */
+      public java.lang.String getOrganizationId() {
+        java.lang.Object ref = organizationId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          organizationId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+       * @return The bytes for organizationId.
+       */
+      public com.google.protobuf.ByteString
+          getOrganizationIdBytes() {
+        java.lang.Object ref = organizationId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          organizationId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+       * @param value The organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        organizationId_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearOrganizationId() {
+        organizationId_ = getDefaultInstance().getOrganizationId();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 3 [json_name = "organizationId"];</code>
+       * @param value The bytes for organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        organizationId_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.OrganizationEnvironmentVariable)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.OrganizationEnvironmentVariable)
+    private static final io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<OrganizationEnvironmentVariable>
+        PARSER = new com.google.protobuf.AbstractParser<OrganizationEnvironmentVariable>() {
+      @java.lang.Override
+      public OrganizationEnvironmentVariable parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<OrganizationEnvironmentVariable> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<OrganizationEnvironmentVariable> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ListOrganizationEnvironmentVariablesRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.ListOrganizationEnvironmentVariablesRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    java.lang.String getOrganizationId();
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    com.google.protobuf.ByteString
+        getOrganizationIdBytes();
+
+    /**
+     * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+     * @return Whether the pagination field is set.
+     */
+    boolean hasPagination();
+    /**
+     * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+     * @return The pagination.
+     */
+    io.gitpod.publicapi.v1.Pagination.PaginationRequest getPagination();
+    /**
+     * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+     */
+    io.gitpod.publicapi.v1.Pagination.PaginationRequestOrBuilder getPaginationOrBuilder();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.ListOrganizationEnvironmentVariablesRequest}
+   */
+  public static final class ListOrganizationEnvironmentVariablesRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.ListOrganizationEnvironmentVariablesRequest)
+      ListOrganizationEnvironmentVariablesRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        ListOrganizationEnvironmentVariablesRequest.class.getName());
+    }
+    // Use ListOrganizationEnvironmentVariablesRequest.newBuilder() to construct.
+    private ListOrganizationEnvironmentVariablesRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private ListOrganizationEnvironmentVariablesRequest() {
+      organizationId_ = "";
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest.class, io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int ORGANIZATION_ID_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object organizationId_ = "";
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    @java.lang.Override
+    public java.lang.String getOrganizationId() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        organizationId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getOrganizationIdBytes() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        organizationId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int PAGINATION_FIELD_NUMBER = 2;
+    private io.gitpod.publicapi.v1.Pagination.PaginationRequest pagination_;
+    /**
+     * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+     * @return Whether the pagination field is set.
+     */
+    @java.lang.Override
+    public boolean hasPagination() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+     * @return The pagination.
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Pagination.PaginationRequest getPagination() {
+      return pagination_ == null ? io.gitpod.publicapi.v1.Pagination.PaginationRequest.getDefaultInstance() : pagination_;
+    }
+    /**
+     * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Pagination.PaginationRequestOrBuilder getPaginationOrBuilder() {
+      return pagination_ == null ? io.gitpod.publicapi.v1.Pagination.PaginationRequest.getDefaultInstance() : pagination_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, organizationId_);
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(2, getPagination());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, organizationId_);
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getPagination());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest other = (io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest) obj;
+
+      if (!getOrganizationId()
+          .equals(other.getOrganizationId())) return false;
+      if (hasPagination() != other.hasPagination()) return false;
+      if (hasPagination()) {
+        if (!getPagination()
+            .equals(other.getPagination())) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + ORGANIZATION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getOrganizationId().hashCode();
+      if (hasPagination()) {
+        hash = (37 * hash) + PAGINATION_FIELD_NUMBER;
+        hash = (53 * hash) + getPagination().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.ListOrganizationEnvironmentVariablesRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.ListOrganizationEnvironmentVariablesRequest)
+        io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest.class, io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage
+                .alwaysUseFieldBuilders) {
+          getPaginationFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        organizationId_ = "";
+        pagination_ = null;
+        if (paginationBuilder_ != null) {
+          paginationBuilder_.dispose();
+          paginationBuilder_ = null;
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest build() {
+        io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest result = new io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.organizationId_ = organizationId_;
+        }
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.pagination_ = paginationBuilder_ == null
+              ? pagination_
+              : paginationBuilder_.build();
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest.getDefaultInstance()) return this;
+        if (!other.getOrganizationId().isEmpty()) {
+          organizationId_ = other.organizationId_;
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        if (other.hasPagination()) {
+          mergePagination(other.getPagination());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                organizationId_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 18: {
+                input.readMessage(
+                    getPaginationFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object organizationId_ = "";
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return The organizationId.
+       */
+      public java.lang.String getOrganizationId() {
+        java.lang.Object ref = organizationId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          organizationId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return The bytes for organizationId.
+       */
+      public com.google.protobuf.ByteString
+          getOrganizationIdBytes() {
+        java.lang.Object ref = organizationId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          organizationId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @param value The organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        organizationId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearOrganizationId() {
+        organizationId_ = getDefaultInstance().getOrganizationId();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @param value The bytes for organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        organizationId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      private io.gitpod.publicapi.v1.Pagination.PaginationRequest pagination_;
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Pagination.PaginationRequest, io.gitpod.publicapi.v1.Pagination.PaginationRequest.Builder, io.gitpod.publicapi.v1.Pagination.PaginationRequestOrBuilder> paginationBuilder_;
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       * @return Whether the pagination field is set.
+       */
+      public boolean hasPagination() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       * @return The pagination.
+       */
+      public io.gitpod.publicapi.v1.Pagination.PaginationRequest getPagination() {
+        if (paginationBuilder_ == null) {
+          return pagination_ == null ? io.gitpod.publicapi.v1.Pagination.PaginationRequest.getDefaultInstance() : pagination_;
+        } else {
+          return paginationBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder setPagination(io.gitpod.publicapi.v1.Pagination.PaginationRequest value) {
+        if (paginationBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          pagination_ = value;
+        } else {
+          paginationBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder setPagination(
+          io.gitpod.publicapi.v1.Pagination.PaginationRequest.Builder builderForValue) {
+        if (paginationBuilder_ == null) {
+          pagination_ = builderForValue.build();
+        } else {
+          paginationBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder mergePagination(io.gitpod.publicapi.v1.Pagination.PaginationRequest value) {
+        if (paginationBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) != 0) &&
+            pagination_ != null &&
+            pagination_ != io.gitpod.publicapi.v1.Pagination.PaginationRequest.getDefaultInstance()) {
+            getPaginationBuilder().mergeFrom(value);
+          } else {
+            pagination_ = value;
+          }
+        } else {
+          paginationBuilder_.mergeFrom(value);
+        }
+        if (pagination_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder clearPagination() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        pagination_ = null;
+        if (paginationBuilder_ != null) {
+          paginationBuilder_.dispose();
+          paginationBuilder_ = null;
+        }
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       */
+      public io.gitpod.publicapi.v1.Pagination.PaginationRequest.Builder getPaginationBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getPaginationFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       */
+      public io.gitpod.publicapi.v1.Pagination.PaginationRequestOrBuilder getPaginationOrBuilder() {
+        if (paginationBuilder_ != null) {
+          return paginationBuilder_.getMessageOrBuilder();
+        } else {
+          return pagination_ == null ?
+              io.gitpod.publicapi.v1.Pagination.PaginationRequest.getDefaultInstance() : pagination_;
+        }
+      }
+      /**
+       * <code>.gitpod.v1.PaginationRequest pagination = 2 [json_name = "pagination"];</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Pagination.PaginationRequest, io.gitpod.publicapi.v1.Pagination.PaginationRequest.Builder, io.gitpod.publicapi.v1.Pagination.PaginationRequestOrBuilder>
+          getPaginationFieldBuilder() {
+        if (paginationBuilder_ == null) {
+          paginationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              io.gitpod.publicapi.v1.Pagination.PaginationRequest, io.gitpod.publicapi.v1.Pagination.PaginationRequest.Builder, io.gitpod.publicapi.v1.Pagination.PaginationRequestOrBuilder>(
+                  getPagination(),
+                  getParentForChildren(),
+                  isClean());
+          pagination_ = null;
+        }
+        return paginationBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.ListOrganizationEnvironmentVariablesRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.ListOrganizationEnvironmentVariablesRequest)
+    private static final io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ListOrganizationEnvironmentVariablesRequest>
+        PARSER = new com.google.protobuf.AbstractParser<ListOrganizationEnvironmentVariablesRequest>() {
+      @java.lang.Override
+      public ListOrganizationEnvironmentVariablesRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<ListOrganizationEnvironmentVariablesRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ListOrganizationEnvironmentVariablesRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface ListOrganizationEnvironmentVariablesResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.ListOrganizationEnvironmentVariablesResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    java.util.List<io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable>
+        getEnvironmentVariablesList();
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariables(int index);
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    int getEnvironmentVariablesCount();
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    java.util.List<? extends io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>
+        getEnvironmentVariablesOrBuilderList();
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariablesOrBuilder(
+        int index);
+
+    /**
+     * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+     * @return Whether the pagination field is set.
+     */
+    boolean hasPagination();
+    /**
+     * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+     * @return The pagination.
+     */
+    io.gitpod.publicapi.v1.Pagination.PaginationResponse getPagination();
+    /**
+     * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+     */
+    io.gitpod.publicapi.v1.Pagination.PaginationResponseOrBuilder getPaginationOrBuilder();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.ListOrganizationEnvironmentVariablesResponse}
+   */
+  public static final class ListOrganizationEnvironmentVariablesResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.ListOrganizationEnvironmentVariablesResponse)
+      ListOrganizationEnvironmentVariablesResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        ListOrganizationEnvironmentVariablesResponse.class.getName());
+    }
+    // Use ListOrganizationEnvironmentVariablesResponse.newBuilder() to construct.
+    private ListOrganizationEnvironmentVariablesResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private ListOrganizationEnvironmentVariablesResponse() {
+      environmentVariables_ = java.util.Collections.emptyList();
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse.class, io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int ENVIRONMENT_VARIABLES_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private java.util.List<io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable> environmentVariables_;
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    @java.lang.Override
+    public java.util.List<io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable> getEnvironmentVariablesList() {
+      return environmentVariables_;
+    }
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    @java.lang.Override
+    public java.util.List<? extends io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>
+        getEnvironmentVariablesOrBuilderList() {
+      return environmentVariables_;
+    }
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    @java.lang.Override
+    public int getEnvironmentVariablesCount() {
+      return environmentVariables_.size();
+    }
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariables(int index) {
+      return environmentVariables_.get(index);
+    }
+    /**
+     * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariablesOrBuilder(
+        int index) {
+      return environmentVariables_.get(index);
+    }
+
+    public static final int PAGINATION_FIELD_NUMBER = 2;
+    private io.gitpod.publicapi.v1.Pagination.PaginationResponse pagination_;
+    /**
+     * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+     * @return Whether the pagination field is set.
+     */
+    @java.lang.Override
+    public boolean hasPagination() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+     * @return The pagination.
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Pagination.PaginationResponse getPagination() {
+      return pagination_ == null ? io.gitpod.publicapi.v1.Pagination.PaginationResponse.getDefaultInstance() : pagination_;
+    }
+    /**
+     * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Pagination.PaginationResponseOrBuilder getPaginationOrBuilder() {
+      return pagination_ == null ? io.gitpod.publicapi.v1.Pagination.PaginationResponse.getDefaultInstance() : pagination_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      for (int i = 0; i < environmentVariables_.size(); i++) {
+        output.writeMessage(1, environmentVariables_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(2, getPagination());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      for (int i = 0; i < environmentVariables_.size(); i++) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, environmentVariables_.get(i));
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(2, getPagination());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse other = (io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse) obj;
+
+      if (!getEnvironmentVariablesList()
+          .equals(other.getEnvironmentVariablesList())) return false;
+      if (hasPagination() != other.hasPagination()) return false;
+      if (hasPagination()) {
+        if (!getPagination()
+            .equals(other.getPagination())) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (getEnvironmentVariablesCount() > 0) {
+        hash = (37 * hash) + ENVIRONMENT_VARIABLES_FIELD_NUMBER;
+        hash = (53 * hash) + getEnvironmentVariablesList().hashCode();
+      }
+      if (hasPagination()) {
+        hash = (37 * hash) + PAGINATION_FIELD_NUMBER;
+        hash = (53 * hash) + getPagination().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.ListOrganizationEnvironmentVariablesResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.ListOrganizationEnvironmentVariablesResponse)
+        io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse.class, io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage
+                .alwaysUseFieldBuilders) {
+          getEnvironmentVariablesFieldBuilder();
+          getPaginationFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        if (environmentVariablesBuilder_ == null) {
+          environmentVariables_ = java.util.Collections.emptyList();
+        } else {
+          environmentVariables_ = null;
+          environmentVariablesBuilder_.clear();
+        }
+        bitField0_ = (bitField0_ & ~0x00000001);
+        pagination_ = null;
+        if (paginationBuilder_ != null) {
+          paginationBuilder_.dispose();
+          paginationBuilder_ = null;
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse build() {
+        io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse result = new io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse(this);
+        buildPartialRepeatedFields(result);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartialRepeatedFields(io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse result) {
+        if (environmentVariablesBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0)) {
+            environmentVariables_ = java.util.Collections.unmodifiableList(environmentVariables_);
+            bitField0_ = (bitField0_ & ~0x00000001);
+          }
+          result.environmentVariables_ = environmentVariables_;
+        } else {
+          result.environmentVariables_ = environmentVariablesBuilder_.build();
+        }
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.pagination_ = paginationBuilder_ == null
+              ? pagination_
+              : paginationBuilder_.build();
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse.getDefaultInstance()) return this;
+        if (environmentVariablesBuilder_ == null) {
+          if (!other.environmentVariables_.isEmpty()) {
+            if (environmentVariables_.isEmpty()) {
+              environmentVariables_ = other.environmentVariables_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+            } else {
+              ensureEnvironmentVariablesIsMutable();
+              environmentVariables_.addAll(other.environmentVariables_);
+            }
+            onChanged();
+          }
+        } else {
+          if (!other.environmentVariables_.isEmpty()) {
+            if (environmentVariablesBuilder_.isEmpty()) {
+              environmentVariablesBuilder_.dispose();
+              environmentVariablesBuilder_ = null;
+              environmentVariables_ = other.environmentVariables_;
+              bitField0_ = (bitField0_ & ~0x00000001);
+              environmentVariablesBuilder_ =
+                com.google.protobuf.GeneratedMessage.alwaysUseFieldBuilders ?
+                   getEnvironmentVariablesFieldBuilder() : null;
+            } else {
+              environmentVariablesBuilder_.addAllMessages(other.environmentVariables_);
+            }
+          }
+        }
+        if (other.hasPagination()) {
+          mergePagination(other.getPagination());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable m =
+                    input.readMessage(
+                        io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.parser(),
+                        extensionRegistry);
+                if (environmentVariablesBuilder_ == null) {
+                  ensureEnvironmentVariablesIsMutable();
+                  environmentVariables_.add(m);
+                } else {
+                  environmentVariablesBuilder_.addMessage(m);
+                }
+                break;
+              } // case 10
+              case 18: {
+                input.readMessage(
+                    getPaginationFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.util.List<io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable> environmentVariables_ =
+        java.util.Collections.emptyList();
+      private void ensureEnvironmentVariablesIsMutable() {
+        if (!((bitField0_ & 0x00000001) != 0)) {
+          environmentVariables_ = new java.util.ArrayList<io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable>(environmentVariables_);
+          bitField0_ |= 0x00000001;
+         }
+      }
+
+      private com.google.protobuf.RepeatedFieldBuilder<
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder> environmentVariablesBuilder_;
+
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public java.util.List<io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable> getEnvironmentVariablesList() {
+        if (environmentVariablesBuilder_ == null) {
+          return java.util.Collections.unmodifiableList(environmentVariables_);
+        } else {
+          return environmentVariablesBuilder_.getMessageList();
+        }
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public int getEnvironmentVariablesCount() {
+        if (environmentVariablesBuilder_ == null) {
+          return environmentVariables_.size();
+        } else {
+          return environmentVariablesBuilder_.getCount();
+        }
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariables(int index) {
+        if (environmentVariablesBuilder_ == null) {
+          return environmentVariables_.get(index);
+        } else {
+          return environmentVariablesBuilder_.getMessage(index);
+        }
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder setEnvironmentVariables(
+          int index, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable value) {
+        if (environmentVariablesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEnvironmentVariablesIsMutable();
+          environmentVariables_.set(index, value);
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.setMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder setEnvironmentVariables(
+          int index, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder builderForValue) {
+        if (environmentVariablesBuilder_ == null) {
+          ensureEnvironmentVariablesIsMutable();
+          environmentVariables_.set(index, builderForValue.build());
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.setMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder addEnvironmentVariables(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable value) {
+        if (environmentVariablesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEnvironmentVariablesIsMutable();
+          environmentVariables_.add(value);
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.addMessage(value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder addEnvironmentVariables(
+          int index, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable value) {
+        if (environmentVariablesBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          ensureEnvironmentVariablesIsMutable();
+          environmentVariables_.add(index, value);
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.addMessage(index, value);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder addEnvironmentVariables(
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder builderForValue) {
+        if (environmentVariablesBuilder_ == null) {
+          ensureEnvironmentVariablesIsMutable();
+          environmentVariables_.add(builderForValue.build());
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.addMessage(builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder addEnvironmentVariables(
+          int index, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder builderForValue) {
+        if (environmentVariablesBuilder_ == null) {
+          ensureEnvironmentVariablesIsMutable();
+          environmentVariables_.add(index, builderForValue.build());
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.addMessage(index, builderForValue.build());
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder addAllEnvironmentVariables(
+          java.lang.Iterable<? extends io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable> values) {
+        if (environmentVariablesBuilder_ == null) {
+          ensureEnvironmentVariablesIsMutable();
+          com.google.protobuf.AbstractMessageLite.Builder.addAll(
+              values, environmentVariables_);
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.addAllMessages(values);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder clearEnvironmentVariables() {
+        if (environmentVariablesBuilder_ == null) {
+          environmentVariables_ = java.util.Collections.emptyList();
+          bitField0_ = (bitField0_ & ~0x00000001);
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.clear();
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public Builder removeEnvironmentVariables(int index) {
+        if (environmentVariablesBuilder_ == null) {
+          ensureEnvironmentVariablesIsMutable();
+          environmentVariables_.remove(index);
+          onChanged();
+        } else {
+          environmentVariablesBuilder_.remove(index);
+        }
+        return this;
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder getEnvironmentVariablesBuilder(
+          int index) {
+        return getEnvironmentVariablesFieldBuilder().getBuilder(index);
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariablesOrBuilder(
+          int index) {
+        if (environmentVariablesBuilder_ == null) {
+          return environmentVariables_.get(index);  } else {
+          return environmentVariablesBuilder_.getMessageOrBuilder(index);
+        }
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public java.util.List<? extends io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>
+           getEnvironmentVariablesOrBuilderList() {
+        if (environmentVariablesBuilder_ != null) {
+          return environmentVariablesBuilder_.getMessageOrBuilderList();
+        } else {
+          return java.util.Collections.unmodifiableList(environmentVariables_);
+        }
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder addEnvironmentVariablesBuilder() {
+        return getEnvironmentVariablesFieldBuilder().addBuilder(
+            io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder addEnvironmentVariablesBuilder(
+          int index) {
+        return getEnvironmentVariablesFieldBuilder().addBuilder(
+            index, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance());
+      }
+      /**
+       * <code>repeated .gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1 [json_name = "environmentVariables"];</code>
+       */
+      public java.util.List<io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder>
+           getEnvironmentVariablesBuilderList() {
+        return getEnvironmentVariablesFieldBuilder().getBuilderList();
+      }
+      private com.google.protobuf.RepeatedFieldBuilder<
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>
+          getEnvironmentVariablesFieldBuilder() {
+        if (environmentVariablesBuilder_ == null) {
+          environmentVariablesBuilder_ = new com.google.protobuf.RepeatedFieldBuilder<
+              io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>(
+                  environmentVariables_,
+                  ((bitField0_ & 0x00000001) != 0),
+                  getParentForChildren(),
+                  isClean());
+          environmentVariables_ = null;
+        }
+        return environmentVariablesBuilder_;
+      }
+
+      private io.gitpod.publicapi.v1.Pagination.PaginationResponse pagination_;
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Pagination.PaginationResponse, io.gitpod.publicapi.v1.Pagination.PaginationResponse.Builder, io.gitpod.publicapi.v1.Pagination.PaginationResponseOrBuilder> paginationBuilder_;
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       * @return Whether the pagination field is set.
+       */
+      public boolean hasPagination() {
+        return ((bitField0_ & 0x00000002) != 0);
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       * @return The pagination.
+       */
+      public io.gitpod.publicapi.v1.Pagination.PaginationResponse getPagination() {
+        if (paginationBuilder_ == null) {
+          return pagination_ == null ? io.gitpod.publicapi.v1.Pagination.PaginationResponse.getDefaultInstance() : pagination_;
+        } else {
+          return paginationBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder setPagination(io.gitpod.publicapi.v1.Pagination.PaginationResponse value) {
+        if (paginationBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          pagination_ = value;
+        } else {
+          paginationBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder setPagination(
+          io.gitpod.publicapi.v1.Pagination.PaginationResponse.Builder builderForValue) {
+        if (paginationBuilder_ == null) {
+          pagination_ = builderForValue.build();
+        } else {
+          paginationBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder mergePagination(io.gitpod.publicapi.v1.Pagination.PaginationResponse value) {
+        if (paginationBuilder_ == null) {
+          if (((bitField0_ & 0x00000002) != 0) &&
+            pagination_ != null &&
+            pagination_ != io.gitpod.publicapi.v1.Pagination.PaginationResponse.getDefaultInstance()) {
+            getPaginationBuilder().mergeFrom(value);
+          } else {
+            pagination_ = value;
+          }
+        } else {
+          paginationBuilder_.mergeFrom(value);
+        }
+        if (pagination_ != null) {
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       */
+      public Builder clearPagination() {
+        bitField0_ = (bitField0_ & ~0x00000002);
+        pagination_ = null;
+        if (paginationBuilder_ != null) {
+          paginationBuilder_.dispose();
+          paginationBuilder_ = null;
+        }
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       */
+      public io.gitpod.publicapi.v1.Pagination.PaginationResponse.Builder getPaginationBuilder() {
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return getPaginationFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       */
+      public io.gitpod.publicapi.v1.Pagination.PaginationResponseOrBuilder getPaginationOrBuilder() {
+        if (paginationBuilder_ != null) {
+          return paginationBuilder_.getMessageOrBuilder();
+        } else {
+          return pagination_ == null ?
+              io.gitpod.publicapi.v1.Pagination.PaginationResponse.getDefaultInstance() : pagination_;
+        }
+      }
+      /**
+       * <code>.gitpod.v1.PaginationResponse pagination = 2 [json_name = "pagination"];</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Pagination.PaginationResponse, io.gitpod.publicapi.v1.Pagination.PaginationResponse.Builder, io.gitpod.publicapi.v1.Pagination.PaginationResponseOrBuilder>
+          getPaginationFieldBuilder() {
+        if (paginationBuilder_ == null) {
+          paginationBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              io.gitpod.publicapi.v1.Pagination.PaginationResponse, io.gitpod.publicapi.v1.Pagination.PaginationResponse.Builder, io.gitpod.publicapi.v1.Pagination.PaginationResponseOrBuilder>(
+                  getPagination(),
+                  getParentForChildren(),
+                  isClean());
+          pagination_ = null;
+        }
+        return paginationBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.ListOrganizationEnvironmentVariablesResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.ListOrganizationEnvironmentVariablesResponse)
+    private static final io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<ListOrganizationEnvironmentVariablesResponse>
+        PARSER = new com.google.protobuf.AbstractParser<ListOrganizationEnvironmentVariablesResponse>() {
+      @java.lang.Override
+      public ListOrganizationEnvironmentVariablesResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<ListOrganizationEnvironmentVariablesResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<ListOrganizationEnvironmentVariablesResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.ListOrganizationEnvironmentVariablesResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface UpdateOrganizationEnvironmentVariableRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.UpdateOrganizationEnvironmentVariableRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    java.lang.String getOrganizationId();
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    com.google.protobuf.ByteString
+        getOrganizationIdBytes();
+
+    /**
+     * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+     * @return The environmentVariableId.
+     */
+    java.lang.String getEnvironmentVariableId();
+    /**
+     * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+     * @return The bytes for environmentVariableId.
+     */
+    com.google.protobuf.ByteString
+        getEnvironmentVariableIdBytes();
+
+    /**
+     * <code>optional string name = 3 [json_name = "name"];</code>
+     * @return Whether the name field is set.
+     */
+    boolean hasName();
+    /**
+     * <code>optional string name = 3 [json_name = "name"];</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <code>optional string name = 3 [json_name = "name"];</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <code>optional string value = 4 [json_name = "value"];</code>
+     * @return Whether the value field is set.
+     */
+    boolean hasValue();
+    /**
+     * <code>optional string value = 4 [json_name = "value"];</code>
+     * @return The value.
+     */
+    java.lang.String getValue();
+    /**
+     * <code>optional string value = 4 [json_name = "value"];</code>
+     * @return The bytes for value.
+     */
+    com.google.protobuf.ByteString
+        getValueBytes();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.UpdateOrganizationEnvironmentVariableRequest}
+   */
+  public static final class UpdateOrganizationEnvironmentVariableRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.UpdateOrganizationEnvironmentVariableRequest)
+      UpdateOrganizationEnvironmentVariableRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        UpdateOrganizationEnvironmentVariableRequest.class.getName());
+    }
+    // Use UpdateOrganizationEnvironmentVariableRequest.newBuilder() to construct.
+    private UpdateOrganizationEnvironmentVariableRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private UpdateOrganizationEnvironmentVariableRequest() {
+      organizationId_ = "";
+      environmentVariableId_ = "";
+      name_ = "";
+      value_ = "";
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest.class, io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int ORGANIZATION_ID_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object organizationId_ = "";
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    @java.lang.Override
+    public java.lang.String getOrganizationId() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        organizationId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getOrganizationIdBytes() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        organizationId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int ENVIRONMENT_VARIABLE_ID_FIELD_NUMBER = 2;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object environmentVariableId_ = "";
+    /**
+     * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+     * @return The environmentVariableId.
+     */
+    @java.lang.Override
+    public java.lang.String getEnvironmentVariableId() {
+      java.lang.Object ref = environmentVariableId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        environmentVariableId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+     * @return The bytes for environmentVariableId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getEnvironmentVariableIdBytes() {
+      java.lang.Object ref = environmentVariableId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        environmentVariableId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int NAME_FIELD_NUMBER = 3;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
+    /**
+     * <code>optional string name = 3 [json_name = "name"];</code>
+     * @return Whether the name field is set.
+     */
+    @java.lang.Override
+    public boolean hasName() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>optional string name = 3 [json_name = "name"];</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        name_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string name = 3 [json_name = "name"];</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int VALUE_FIELD_NUMBER = 4;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object value_ = "";
+    /**
+     * <code>optional string value = 4 [json_name = "value"];</code>
+     * @return Whether the value field is set.
+     */
+    @java.lang.Override
+    public boolean hasValue() {
+      return ((bitField0_ & 0x00000002) != 0);
+    }
+    /**
+     * <code>optional string value = 4 [json_name = "value"];</code>
+     * @return The value.
+     */
+    @java.lang.Override
+    public java.lang.String getValue() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        value_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>optional string value = 4 [json_name = "value"];</code>
+     * @return The bytes for value.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getValueBytes() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        value_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, organizationId_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(environmentVariableId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 2, environmentVariableId_);
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 3, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 4, value_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, organizationId_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(environmentVariableId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, environmentVariableId_);
+      }
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(3, name_);
+      }
+      if (((bitField0_ & 0x00000002) != 0)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(4, value_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest other = (io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest) obj;
+
+      if (!getOrganizationId()
+          .equals(other.getOrganizationId())) return false;
+      if (!getEnvironmentVariableId()
+          .equals(other.getEnvironmentVariableId())) return false;
+      if (hasName() != other.hasName()) return false;
+      if (hasName()) {
+        if (!getName()
+            .equals(other.getName())) return false;
+      }
+      if (hasValue() != other.hasValue()) return false;
+      if (hasValue()) {
+        if (!getValue()
+            .equals(other.getValue())) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + ORGANIZATION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getOrganizationId().hashCode();
+      hash = (37 * hash) + ENVIRONMENT_VARIABLE_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getEnvironmentVariableId().hashCode();
+      if (hasName()) {
+        hash = (37 * hash) + NAME_FIELD_NUMBER;
+        hash = (53 * hash) + getName().hashCode();
+      }
+      if (hasValue()) {
+        hash = (37 * hash) + VALUE_FIELD_NUMBER;
+        hash = (53 * hash) + getValue().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.UpdateOrganizationEnvironmentVariableRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.UpdateOrganizationEnvironmentVariableRequest)
+        io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest.class, io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        organizationId_ = "";
+        environmentVariableId_ = "";
+        name_ = "";
+        value_ = "";
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest build() {
+        io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest result = new io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.organizationId_ = organizationId_;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.environmentVariableId_ = environmentVariableId_;
+        }
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.name_ = name_;
+          to_bitField0_ |= 0x00000001;
+        }
+        if (((from_bitField0_ & 0x00000008) != 0)) {
+          result.value_ = value_;
+          to_bitField0_ |= 0x00000002;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest.getDefaultInstance()) return this;
+        if (!other.getOrganizationId().isEmpty()) {
+          organizationId_ = other.organizationId_;
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        if (!other.getEnvironmentVariableId().isEmpty()) {
+          environmentVariableId_ = other.environmentVariableId_;
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
+        if (other.hasName()) {
+          name_ = other.name_;
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
+        if (other.hasValue()) {
+          value_ = other.value_;
+          bitField0_ |= 0x00000008;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                organizationId_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 18: {
+                environmentVariableId_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              case 26: {
+                name_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 26
+              case 34: {
+                value_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000008;
+                break;
+              } // case 34
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object organizationId_ = "";
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return The organizationId.
+       */
+      public java.lang.String getOrganizationId() {
+        java.lang.Object ref = organizationId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          organizationId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return The bytes for organizationId.
+       */
+      public com.google.protobuf.ByteString
+          getOrganizationIdBytes() {
+        java.lang.Object ref = organizationId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          organizationId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @param value The organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        organizationId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearOrganizationId() {
+        organizationId_ = getDefaultInstance().getOrganizationId();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @param value The bytes for organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        organizationId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object environmentVariableId_ = "";
+      /**
+       * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+       * @return The environmentVariableId.
+       */
+      public java.lang.String getEnvironmentVariableId() {
+        java.lang.Object ref = environmentVariableId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          environmentVariableId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+       * @return The bytes for environmentVariableId.
+       */
+      public com.google.protobuf.ByteString
+          getEnvironmentVariableIdBytes() {
+        java.lang.Object ref = environmentVariableId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          environmentVariableId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+       * @param value The environmentVariableId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEnvironmentVariableId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        environmentVariableId_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearEnvironmentVariableId() {
+        environmentVariableId_ = getDefaultInstance().getEnvironmentVariableId();
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string environment_variable_id = 2 [json_name = "environmentVariableId"];</code>
+       * @param value The bytes for environmentVariableId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEnvironmentVariableIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        environmentVariableId_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object name_ = "";
+      /**
+       * <code>optional string name = 3 [json_name = "name"];</code>
+       * @return Whether the name field is set.
+       */
+      public boolean hasName() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <code>optional string name = 3 [json_name = "name"];</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          name_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string name = 3 [json_name = "name"];</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string name = 3 [json_name = "name"];</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        name_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string name = 3 [json_name = "name"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string name = 3 [json_name = "name"];</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        name_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object value_ = "";
+      /**
+       * <code>optional string value = 4 [json_name = "value"];</code>
+       * @return Whether the value field is set.
+       */
+      public boolean hasValue() {
+        return ((bitField0_ & 0x00000008) != 0);
+      }
+      /**
+       * <code>optional string value = 4 [json_name = "value"];</code>
+       * @return The value.
+       */
+      public java.lang.String getValue() {
+        java.lang.Object ref = value_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          value_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>optional string value = 4 [json_name = "value"];</code>
+       * @return The bytes for value.
+       */
+      public com.google.protobuf.ByteString
+          getValueBytes() {
+        java.lang.Object ref = value_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          value_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>optional string value = 4 [json_name = "value"];</code>
+       * @param value The value to set.
+       * @return This builder for chaining.
+       */
+      public Builder setValue(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        value_ = value;
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string value = 4 [json_name = "value"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearValue() {
+        value_ = getDefaultInstance().getValue();
+        bitField0_ = (bitField0_ & ~0x00000008);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>optional string value = 4 [json_name = "value"];</code>
+       * @param value The bytes for value to set.
+       * @return This builder for chaining.
+       */
+      public Builder setValueBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        value_ = value;
+        bitField0_ |= 0x00000008;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.UpdateOrganizationEnvironmentVariableRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.UpdateOrganizationEnvironmentVariableRequest)
+    private static final io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<UpdateOrganizationEnvironmentVariableRequest>
+        PARSER = new com.google.protobuf.AbstractParser<UpdateOrganizationEnvironmentVariableRequest>() {
+      @java.lang.Override
+      public UpdateOrganizationEnvironmentVariableRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<UpdateOrganizationEnvironmentVariableRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<UpdateOrganizationEnvironmentVariableRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface UpdateOrganizationEnvironmentVariableResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.UpdateOrganizationEnvironmentVariableResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return Whether the environmentVariable field is set.
+     */
+    boolean hasEnvironmentVariable();
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return The environmentVariable.
+     */
+    io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariable();
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     */
+    io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariableOrBuilder();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.UpdateOrganizationEnvironmentVariableResponse}
+   */
+  public static final class UpdateOrganizationEnvironmentVariableResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.UpdateOrganizationEnvironmentVariableResponse)
+      UpdateOrganizationEnvironmentVariableResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        UpdateOrganizationEnvironmentVariableResponse.class.getName());
+    }
+    // Use UpdateOrganizationEnvironmentVariableResponse.newBuilder() to construct.
+    private UpdateOrganizationEnvironmentVariableResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private UpdateOrganizationEnvironmentVariableResponse() {
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse.class, io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int ENVIRONMENT_VARIABLE_FIELD_NUMBER = 1;
+    private io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable environmentVariable_;
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return Whether the environmentVariable field is set.
+     */
+    @java.lang.Override
+    public boolean hasEnvironmentVariable() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return The environmentVariable.
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariable() {
+      return environmentVariable_ == null ? io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+    }
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariableOrBuilder() {
+      return environmentVariable_ == null ? io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(1, getEnvironmentVariable());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getEnvironmentVariable());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse other = (io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse) obj;
+
+      if (hasEnvironmentVariable() != other.hasEnvironmentVariable()) return false;
+      if (hasEnvironmentVariable()) {
+        if (!getEnvironmentVariable()
+            .equals(other.getEnvironmentVariable())) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEnvironmentVariable()) {
+        hash = (37 * hash) + ENVIRONMENT_VARIABLE_FIELD_NUMBER;
+        hash = (53 * hash) + getEnvironmentVariable().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.UpdateOrganizationEnvironmentVariableResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.UpdateOrganizationEnvironmentVariableResponse)
+        io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse.class, io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage
+                .alwaysUseFieldBuilders) {
+          getEnvironmentVariableFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        environmentVariable_ = null;
+        if (environmentVariableBuilder_ != null) {
+          environmentVariableBuilder_.dispose();
+          environmentVariableBuilder_ = null;
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse build() {
+        io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse result = new io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.environmentVariable_ = environmentVariableBuilder_ == null
+              ? environmentVariable_
+              : environmentVariableBuilder_.build();
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse.getDefaultInstance()) return this;
+        if (other.hasEnvironmentVariable()) {
+          mergeEnvironmentVariable(other.getEnvironmentVariable());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                input.readMessage(
+                    getEnvironmentVariableFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable environmentVariable_;
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder> environmentVariableBuilder_;
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       * @return Whether the environmentVariable field is set.
+       */
+      public boolean hasEnvironmentVariable() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       * @return The environmentVariable.
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariable() {
+        if (environmentVariableBuilder_ == null) {
+          return environmentVariable_ == null ? io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+        } else {
+          return environmentVariableBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder setEnvironmentVariable(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable value) {
+        if (environmentVariableBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          environmentVariable_ = value;
+        } else {
+          environmentVariableBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder setEnvironmentVariable(
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder builderForValue) {
+        if (environmentVariableBuilder_ == null) {
+          environmentVariable_ = builderForValue.build();
+        } else {
+          environmentVariableBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder mergeEnvironmentVariable(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable value) {
+        if (environmentVariableBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0) &&
+            environmentVariable_ != null &&
+            environmentVariable_ != io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance()) {
+            getEnvironmentVariableBuilder().mergeFrom(value);
+          } else {
+            environmentVariable_ = value;
+          }
+        } else {
+          environmentVariableBuilder_.mergeFrom(value);
+        }
+        if (environmentVariable_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder clearEnvironmentVariable() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        environmentVariable_ = null;
+        if (environmentVariableBuilder_ != null) {
+          environmentVariableBuilder_.dispose();
+          environmentVariableBuilder_ = null;
+        }
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder getEnvironmentVariableBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getEnvironmentVariableFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariableOrBuilder() {
+        if (environmentVariableBuilder_ != null) {
+          return environmentVariableBuilder_.getMessageOrBuilder();
+        } else {
+          return environmentVariable_ == null ?
+              io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+        }
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>
+          getEnvironmentVariableFieldBuilder() {
+        if (environmentVariableBuilder_ == null) {
+          environmentVariableBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>(
+                  getEnvironmentVariable(),
+                  getParentForChildren(),
+                  isClean());
+          environmentVariable_ = null;
+        }
+        return environmentVariableBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.UpdateOrganizationEnvironmentVariableResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.UpdateOrganizationEnvironmentVariableResponse)
+    private static final io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<UpdateOrganizationEnvironmentVariableResponse>
+        PARSER = new com.google.protobuf.AbstractParser<UpdateOrganizationEnvironmentVariableResponse>() {
+      @java.lang.Override
+      public UpdateOrganizationEnvironmentVariableResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<UpdateOrganizationEnvironmentVariableResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<UpdateOrganizationEnvironmentVariableResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.UpdateOrganizationEnvironmentVariableResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface CreateOrganizationEnvironmentVariableRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.CreateOrganizationEnvironmentVariableRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    java.lang.String getOrganizationId();
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    com.google.protobuf.ByteString
+        getOrganizationIdBytes();
+
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The name.
+     */
+    java.lang.String getName();
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The bytes for name.
+     */
+    com.google.protobuf.ByteString
+        getNameBytes();
+
+    /**
+     * <code>string value = 3 [json_name = "value"];</code>
+     * @return The value.
+     */
+    java.lang.String getValue();
+    /**
+     * <code>string value = 3 [json_name = "value"];</code>
+     * @return The bytes for value.
+     */
+    com.google.protobuf.ByteString
+        getValueBytes();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.CreateOrganizationEnvironmentVariableRequest}
+   */
+  public static final class CreateOrganizationEnvironmentVariableRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.CreateOrganizationEnvironmentVariableRequest)
+      CreateOrganizationEnvironmentVariableRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        CreateOrganizationEnvironmentVariableRequest.class.getName());
+    }
+    // Use CreateOrganizationEnvironmentVariableRequest.newBuilder() to construct.
+    private CreateOrganizationEnvironmentVariableRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private CreateOrganizationEnvironmentVariableRequest() {
+      organizationId_ = "";
+      name_ = "";
+      value_ = "";
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest.class, io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest.Builder.class);
+    }
+
+    public static final int ORGANIZATION_ID_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object organizationId_ = "";
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The organizationId.
+     */
+    @java.lang.Override
+    public java.lang.String getOrganizationId() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        organizationId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+     * @return The bytes for organizationId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getOrganizationIdBytes() {
+      java.lang.Object ref = organizationId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        organizationId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int NAME_FIELD_NUMBER = 2;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object name_ = "";
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The name.
+     */
+    @java.lang.Override
+    public java.lang.String getName() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        name_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string name = 2 [json_name = "name"];</code>
+     * @return The bytes for name.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getNameBytes() {
+      java.lang.Object ref = name_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        name_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    public static final int VALUE_FIELD_NUMBER = 3;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object value_ = "";
+    /**
+     * <code>string value = 3 [json_name = "value"];</code>
+     * @return The value.
+     */
+    @java.lang.Override
+    public java.lang.String getValue() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        value_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string value = 3 [json_name = "value"];</code>
+     * @return The bytes for value.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getValueBytes() {
+      java.lang.Object ref = value_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        value_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, organizationId_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(name_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 2, name_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(value_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 3, value_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(organizationId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, organizationId_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(name_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(2, name_);
+      }
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(value_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(3, value_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest other = (io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest) obj;
+
+      if (!getOrganizationId()
+          .equals(other.getOrganizationId())) return false;
+      if (!getName()
+          .equals(other.getName())) return false;
+      if (!getValue()
+          .equals(other.getValue())) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + ORGANIZATION_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getOrganizationId().hashCode();
+      hash = (37 * hash) + NAME_FIELD_NUMBER;
+      hash = (53 * hash) + getName().hashCode();
+      hash = (37 * hash) + VALUE_FIELD_NUMBER;
+      hash = (53 * hash) + getValue().hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.CreateOrganizationEnvironmentVariableRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.CreateOrganizationEnvironmentVariableRequest)
+        io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest.class, io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        organizationId_ = "";
+        name_ = "";
+        value_ = "";
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest build() {
+        io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest result = new io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.organizationId_ = organizationId_;
+        }
+        if (((from_bitField0_ & 0x00000002) != 0)) {
+          result.name_ = name_;
+        }
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          result.value_ = value_;
+        }
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest.getDefaultInstance()) return this;
+        if (!other.getOrganizationId().isEmpty()) {
+          organizationId_ = other.organizationId_;
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        if (!other.getName().isEmpty()) {
+          name_ = other.name_;
+          bitField0_ |= 0x00000002;
+          onChanged();
+        }
+        if (!other.getValue().isEmpty()) {
+          value_ = other.value_;
+          bitField0_ |= 0x00000004;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                organizationId_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              case 18: {
+                name_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000002;
+                break;
+              } // case 18
+              case 26: {
+                value_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000004;
+                break;
+              } // case 26
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object organizationId_ = "";
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return The organizationId.
+       */
+      public java.lang.String getOrganizationId() {
+        java.lang.Object ref = organizationId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          organizationId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return The bytes for organizationId.
+       */
+      public com.google.protobuf.ByteString
+          getOrganizationIdBytes() {
+        java.lang.Object ref = organizationId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          organizationId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @param value The organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        organizationId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearOrganizationId() {
+        organizationId_ = getDefaultInstance().getOrganizationId();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string organization_id = 1 [json_name = "organizationId"];</code>
+       * @param value The bytes for organizationId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setOrganizationIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        organizationId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object name_ = "";
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @return The name.
+       */
+      public java.lang.String getName() {
+        java.lang.Object ref = name_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          name_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @return The bytes for name.
+       */
+      public com.google.protobuf.ByteString
+          getNameBytes() {
+        java.lang.Object ref = name_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          name_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @param value The name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setName(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        name_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearName() {
+        name_ = getDefaultInstance().getName();
+        bitField0_ = (bitField0_ & ~0x00000002);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string name = 2 [json_name = "name"];</code>
+       * @param value The bytes for name to set.
+       * @return This builder for chaining.
+       */
+      public Builder setNameBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        name_ = value;
+        bitField0_ |= 0x00000002;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object value_ = "";
+      /**
+       * <code>string value = 3 [json_name = "value"];</code>
+       * @return The value.
+       */
+      public java.lang.String getValue() {
+        java.lang.Object ref = value_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          value_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string value = 3 [json_name = "value"];</code>
+       * @return The bytes for value.
+       */
+      public com.google.protobuf.ByteString
+          getValueBytes() {
+        java.lang.Object ref = value_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          value_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string value = 3 [json_name = "value"];</code>
+       * @param value The value to set.
+       * @return This builder for chaining.
+       */
+      public Builder setValue(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        value_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string value = 3 [json_name = "value"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearValue() {
+        value_ = getDefaultInstance().getValue();
+        bitField0_ = (bitField0_ & ~0x00000004);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string value = 3 [json_name = "value"];</code>
+       * @param value The bytes for value to set.
+       * @return This builder for chaining.
+       */
+      public Builder setValueBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        value_ = value;
+        bitField0_ |= 0x00000004;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.CreateOrganizationEnvironmentVariableRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.CreateOrganizationEnvironmentVariableRequest)
+    private static final io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<CreateOrganizationEnvironmentVariableRequest>
+        PARSER = new com.google.protobuf.AbstractParser<CreateOrganizationEnvironmentVariableRequest>() {
+      @java.lang.Override
+      public CreateOrganizationEnvironmentVariableRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<CreateOrganizationEnvironmentVariableRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<CreateOrganizationEnvironmentVariableRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface CreateOrganizationEnvironmentVariableResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.CreateOrganizationEnvironmentVariableResponse)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return Whether the environmentVariable field is set.
+     */
+    boolean hasEnvironmentVariable();
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return The environmentVariable.
+     */
+    io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariable();
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     */
+    io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariableOrBuilder();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.CreateOrganizationEnvironmentVariableResponse}
+   */
+  public static final class CreateOrganizationEnvironmentVariableResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.CreateOrganizationEnvironmentVariableResponse)
+      CreateOrganizationEnvironmentVariableResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        CreateOrganizationEnvironmentVariableResponse.class.getName());
+    }
+    // Use CreateOrganizationEnvironmentVariableResponse.newBuilder() to construct.
+    private CreateOrganizationEnvironmentVariableResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private CreateOrganizationEnvironmentVariableResponse() {
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse.class, io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse.Builder.class);
+    }
+
+    private int bitField0_;
+    public static final int ENVIRONMENT_VARIABLE_FIELD_NUMBER = 1;
+    private io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable environmentVariable_;
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return Whether the environmentVariable field is set.
+     */
+    @java.lang.Override
+    public boolean hasEnvironmentVariable() {
+      return ((bitField0_ & 0x00000001) != 0);
+    }
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     * @return The environmentVariable.
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariable() {
+      return environmentVariable_ == null ? io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+    }
+    /**
+     * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+     */
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariableOrBuilder() {
+      return environmentVariable_ == null ? io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (((bitField0_ & 0x00000001) != 0)) {
+        output.writeMessage(1, getEnvironmentVariable());
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (((bitField0_ & 0x00000001) != 0)) {
+        size += com.google.protobuf.CodedOutputStream
+          .computeMessageSize(1, getEnvironmentVariable());
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse other = (io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse) obj;
+
+      if (hasEnvironmentVariable() != other.hasEnvironmentVariable()) return false;
+      if (hasEnvironmentVariable()) {
+        if (!getEnvironmentVariable()
+            .equals(other.getEnvironmentVariable())) return false;
+      }
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      if (hasEnvironmentVariable()) {
+        hash = (37 * hash) + ENVIRONMENT_VARIABLE_FIELD_NUMBER;
+        hash = (53 * hash) + getEnvironmentVariable().hashCode();
+      }
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.CreateOrganizationEnvironmentVariableResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.CreateOrganizationEnvironmentVariableResponse)
+        io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse.class, io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse.newBuilder()
+      private Builder() {
+        maybeForceBuilderInitialization();
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+        maybeForceBuilderInitialization();
+      }
+      private void maybeForceBuilderInitialization() {
+        if (com.google.protobuf.GeneratedMessage
+                .alwaysUseFieldBuilders) {
+          getEnvironmentVariableFieldBuilder();
+        }
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        environmentVariable_ = null;
+        if (environmentVariableBuilder_ != null) {
+          environmentVariableBuilder_.dispose();
+          environmentVariableBuilder_ = null;
+        }
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse build() {
+        io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse result = new io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse result) {
+        int from_bitField0_ = bitField0_;
+        int to_bitField0_ = 0;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.environmentVariable_ = environmentVariableBuilder_ == null
+              ? environmentVariable_
+              : environmentVariableBuilder_.build();
+          to_bitField0_ |= 0x00000001;
+        }
+        result.bitField0_ |= to_bitField0_;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse.getDefaultInstance()) return this;
+        if (other.hasEnvironmentVariable()) {
+          mergeEnvironmentVariable(other.getEnvironmentVariable());
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                input.readMessage(
+                    getEnvironmentVariableFieldBuilder().getBuilder(),
+                    extensionRegistry);
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable environmentVariable_;
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder> environmentVariableBuilder_;
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       * @return Whether the environmentVariable field is set.
+       */
+      public boolean hasEnvironmentVariable() {
+        return ((bitField0_ & 0x00000001) != 0);
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       * @return The environmentVariable.
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable getEnvironmentVariable() {
+        if (environmentVariableBuilder_ == null) {
+          return environmentVariable_ == null ? io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+        } else {
+          return environmentVariableBuilder_.getMessage();
+        }
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder setEnvironmentVariable(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable value) {
+        if (environmentVariableBuilder_ == null) {
+          if (value == null) {
+            throw new NullPointerException();
+          }
+          environmentVariable_ = value;
+        } else {
+          environmentVariableBuilder_.setMessage(value);
+        }
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder setEnvironmentVariable(
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder builderForValue) {
+        if (environmentVariableBuilder_ == null) {
+          environmentVariable_ = builderForValue.build();
+        } else {
+          environmentVariableBuilder_.setMessage(builderForValue.build());
+        }
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder mergeEnvironmentVariable(io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable value) {
+        if (environmentVariableBuilder_ == null) {
+          if (((bitField0_ & 0x00000001) != 0) &&
+            environmentVariable_ != null &&
+            environmentVariable_ != io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance()) {
+            getEnvironmentVariableBuilder().mergeFrom(value);
+          } else {
+            environmentVariable_ = value;
+          }
+        } else {
+          environmentVariableBuilder_.mergeFrom(value);
+        }
+        if (environmentVariable_ != null) {
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public Builder clearEnvironmentVariable() {
+        bitField0_ = (bitField0_ & ~0x00000001);
+        environmentVariable_ = null;
+        if (environmentVariableBuilder_ != null) {
+          environmentVariableBuilder_.dispose();
+          environmentVariableBuilder_ = null;
+        }
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder getEnvironmentVariableBuilder() {
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return getEnvironmentVariableFieldBuilder().getBuilder();
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      public io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder getEnvironmentVariableOrBuilder() {
+        if (environmentVariableBuilder_ != null) {
+          return environmentVariableBuilder_.getMessageOrBuilder();
+        } else {
+          return environmentVariable_ == null ?
+              io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.getDefaultInstance() : environmentVariable_;
+        }
+      }
+      /**
+       * <code>.gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1 [json_name = "environmentVariable"];</code>
+       */
+      private com.google.protobuf.SingleFieldBuilder<
+          io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>
+          getEnvironmentVariableFieldBuilder() {
+        if (environmentVariableBuilder_ == null) {
+          environmentVariableBuilder_ = new com.google.protobuf.SingleFieldBuilder<
+              io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariable.Builder, io.gitpod.publicapi.v1.Envvar.OrganizationEnvironmentVariableOrBuilder>(
+                  getEnvironmentVariable(),
+                  getParentForChildren(),
+                  isClean());
+          environmentVariable_ = null;
+        }
+        return environmentVariableBuilder_;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.CreateOrganizationEnvironmentVariableResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.CreateOrganizationEnvironmentVariableResponse)
+    private static final io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<CreateOrganizationEnvironmentVariableResponse>
+        PARSER = new com.google.protobuf.AbstractParser<CreateOrganizationEnvironmentVariableResponse>() {
+      @java.lang.Override
+      public CreateOrganizationEnvironmentVariableResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<CreateOrganizationEnvironmentVariableResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<CreateOrganizationEnvironmentVariableResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.CreateOrganizationEnvironmentVariableResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface DeleteOrganizationEnvironmentVariableRequestOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.DeleteOrganizationEnvironmentVariableRequest)
+      com.google.protobuf.MessageOrBuilder {
+
+    /**
+     * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+     * @return The environmentVariableId.
+     */
+    java.lang.String getEnvironmentVariableId();
+    /**
+     * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+     * @return The bytes for environmentVariableId.
+     */
+    com.google.protobuf.ByteString
+        getEnvironmentVariableIdBytes();
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.DeleteOrganizationEnvironmentVariableRequest}
+   */
+  public static final class DeleteOrganizationEnvironmentVariableRequest extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.DeleteOrganizationEnvironmentVariableRequest)
+      DeleteOrganizationEnvironmentVariableRequestOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        DeleteOrganizationEnvironmentVariableRequest.class.getName());
+    }
+    // Use DeleteOrganizationEnvironmentVariableRequest.newBuilder() to construct.
+    private DeleteOrganizationEnvironmentVariableRequest(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private DeleteOrganizationEnvironmentVariableRequest() {
+      environmentVariableId_ = "";
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest.class, io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest.Builder.class);
+    }
+
+    public static final int ENVIRONMENT_VARIABLE_ID_FIELD_NUMBER = 1;
+    @SuppressWarnings("serial")
+    private volatile java.lang.Object environmentVariableId_ = "";
+    /**
+     * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+     * @return The environmentVariableId.
+     */
+    @java.lang.Override
+    public java.lang.String getEnvironmentVariableId() {
+      java.lang.Object ref = environmentVariableId_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs =
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        environmentVariableId_ = s;
+        return s;
+      }
+    }
+    /**
+     * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+     * @return The bytes for environmentVariableId.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getEnvironmentVariableIdBytes() {
+      java.lang.Object ref = environmentVariableId_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b =
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        environmentVariableId_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(environmentVariableId_)) {
+        com.google.protobuf.GeneratedMessage.writeString(output, 1, environmentVariableId_);
+      }
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      if (!com.google.protobuf.GeneratedMessage.isStringEmpty(environmentVariableId_)) {
+        size += com.google.protobuf.GeneratedMessage.computeStringSize(1, environmentVariableId_);
+      }
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest other = (io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest) obj;
+
+      if (!getEnvironmentVariableId()
+          .equals(other.getEnvironmentVariableId())) return false;
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (37 * hash) + ENVIRONMENT_VARIABLE_ID_FIELD_NUMBER;
+      hash = (53 * hash) + getEnvironmentVariableId().hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.DeleteOrganizationEnvironmentVariableRequest}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.DeleteOrganizationEnvironmentVariableRequest)
+        io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequestOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest.class, io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        bitField0_ = 0;
+        environmentVariableId_ = "";
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest build() {
+        io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest result = new io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest(this);
+        if (bitField0_ != 0) { buildPartial0(result); }
+        onBuilt();
+        return result;
+      }
+
+      private void buildPartial0(io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest result) {
+        int from_bitField0_ = bitField0_;
+        if (((from_bitField0_ & 0x00000001) != 0)) {
+          result.environmentVariableId_ = environmentVariableId_;
+        }
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest.getDefaultInstance()) return this;
+        if (!other.getEnvironmentVariableId().isEmpty()) {
+          environmentVariableId_ = other.environmentVariableId_;
+          bitField0_ |= 0x00000001;
+          onChanged();
+        }
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              case 10: {
+                environmentVariableId_ = input.readStringRequireUtf8();
+                bitField0_ |= 0x00000001;
+                break;
+              } // case 10
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+      private int bitField0_;
+
+      private java.lang.Object environmentVariableId_ = "";
+      /**
+       * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+       * @return The environmentVariableId.
+       */
+      public java.lang.String getEnvironmentVariableId() {
+        java.lang.Object ref = environmentVariableId_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          environmentVariableId_ = s;
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+       * @return The bytes for environmentVariableId.
+       */
+      public com.google.protobuf.ByteString
+          getEnvironmentVariableIdBytes() {
+        java.lang.Object ref = environmentVariableId_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b =
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          environmentVariableId_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+       * @param value The environmentVariableId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEnvironmentVariableId(
+          java.lang.String value) {
+        if (value == null) { throw new NullPointerException(); }
+        environmentVariableId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearEnvironmentVariableId() {
+        environmentVariableId_ = getDefaultInstance().getEnvironmentVariableId();
+        bitField0_ = (bitField0_ & ~0x00000001);
+        onChanged();
+        return this;
+      }
+      /**
+       * <code>string environment_variable_id = 1 [json_name = "environmentVariableId"];</code>
+       * @param value The bytes for environmentVariableId to set.
+       * @return This builder for chaining.
+       */
+      public Builder setEnvironmentVariableIdBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) { throw new NullPointerException(); }
+        checkByteStringIsUtf8(value);
+        environmentVariableId_ = value;
+        bitField0_ |= 0x00000001;
+        onChanged();
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.DeleteOrganizationEnvironmentVariableRequest)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.DeleteOrganizationEnvironmentVariableRequest)
+    private static final io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<DeleteOrganizationEnvironmentVariableRequest>
+        PARSER = new com.google.protobuf.AbstractParser<DeleteOrganizationEnvironmentVariableRequest>() {
+      @java.lang.Override
+      public DeleteOrganizationEnvironmentVariableRequest parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<DeleteOrganizationEnvironmentVariableRequest> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<DeleteOrganizationEnvironmentVariableRequest> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableRequest getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
+  public interface DeleteOrganizationEnvironmentVariableResponseOrBuilder extends
+      // @@protoc_insertion_point(interface_extends:gitpod.v1.DeleteOrganizationEnvironmentVariableResponse)
+      com.google.protobuf.MessageOrBuilder {
+  }
+  /**
+   * Protobuf type {@code gitpod.v1.DeleteOrganizationEnvironmentVariableResponse}
+   */
+  public static final class DeleteOrganizationEnvironmentVariableResponse extends
+      com.google.protobuf.GeneratedMessage implements
+      // @@protoc_insertion_point(message_implements:gitpod.v1.DeleteOrganizationEnvironmentVariableResponse)
+      DeleteOrganizationEnvironmentVariableResponseOrBuilder {
+  private static final long serialVersionUID = 0L;
+    static {
+      com.google.protobuf.RuntimeVersion.validateProtobufGencodeVersion(
+        com.google.protobuf.RuntimeVersion.RuntimeDomain.PUBLIC,
+        /* major= */ 4,
+        /* minor= */ 27,
+        /* patch= */ 2,
+        /* suffix= */ "",
+        DeleteOrganizationEnvironmentVariableResponse.class.getName());
+    }
+    // Use DeleteOrganizationEnvironmentVariableResponse.newBuilder() to construct.
+    private DeleteOrganizationEnvironmentVariableResponse(com.google.protobuf.GeneratedMessage.Builder<?> builder) {
+      super(builder);
+    }
+    private DeleteOrganizationEnvironmentVariableResponse() {
+    }
+
+    public static final com.google.protobuf.Descriptors.Descriptor
+        getDescriptor() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_descriptor;
+    }
+
+    @java.lang.Override
+    protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+        internalGetFieldAccessorTable() {
+      return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_fieldAccessorTable
+          .ensureFieldAccessorsInitialized(
+              io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse.class, io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse.Builder.class);
+    }
+
+    private byte memoizedIsInitialized = -1;
+    @java.lang.Override
+    public final boolean isInitialized() {
+      byte isInitialized = memoizedIsInitialized;
+      if (isInitialized == 1) return true;
+      if (isInitialized == 0) return false;
+
+      memoizedIsInitialized = 1;
+      return true;
+    }
+
+    @java.lang.Override
+    public void writeTo(com.google.protobuf.CodedOutputStream output)
+                        throws java.io.IOException {
+      getUnknownFields().writeTo(output);
+    }
+
+    @java.lang.Override
+    public int getSerializedSize() {
+      int size = memoizedSize;
+      if (size != -1) return size;
+
+      size = 0;
+      size += getUnknownFields().getSerializedSize();
+      memoizedSize = size;
+      return size;
+    }
+
+    @java.lang.Override
+    public boolean equals(final java.lang.Object obj) {
+      if (obj == this) {
+       return true;
+      }
+      if (!(obj instanceof io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse)) {
+        return super.equals(obj);
+      }
+      io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse other = (io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse) obj;
+
+      if (!getUnknownFields().equals(other.getUnknownFields())) return false;
+      return true;
+    }
+
+    @java.lang.Override
+    public int hashCode() {
+      if (memoizedHashCode != 0) {
+        return memoizedHashCode;
+      }
+      int hash = 41;
+      hash = (19 * hash) + getDescriptor().hashCode();
+      hash = (29 * hash) + getUnknownFields().hashCode();
+      memoizedHashCode = hash;
+      return hash;
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        java.nio.ByteBuffer data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        java.nio.ByteBuffer data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.ByteString data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.ByteString data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(byte[] data)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        byte[] data,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws com.google.protobuf.InvalidProtocolBufferException {
+      return PARSER.parseFrom(data, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseDelimitedFrom(java.io.InputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input);
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseDelimitedFrom(
+        java.io.InputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseDelimitedWithIOException(PARSER, input, extensionRegistry);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.CodedInputStream input)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input);
+    }
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse parseFrom(
+        com.google.protobuf.CodedInputStream input,
+        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+        throws java.io.IOException {
+      return com.google.protobuf.GeneratedMessage
+          .parseWithIOException(PARSER, input, extensionRegistry);
+    }
+
+    @java.lang.Override
+    public Builder newBuilderForType() { return newBuilder(); }
+    public static Builder newBuilder() {
+      return DEFAULT_INSTANCE.toBuilder();
+    }
+    public static Builder newBuilder(io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse prototype) {
+      return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
+    }
+    @java.lang.Override
+    public Builder toBuilder() {
+      return this == DEFAULT_INSTANCE
+          ? new Builder() : new Builder().mergeFrom(this);
+    }
+
+    @java.lang.Override
+    protected Builder newBuilderForType(
+        com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+      Builder builder = new Builder(parent);
+      return builder;
+    }
+    /**
+     * Protobuf type {@code gitpod.v1.DeleteOrganizationEnvironmentVariableResponse}
+     */
+    public static final class Builder extends
+        com.google.protobuf.GeneratedMessage.Builder<Builder> implements
+        // @@protoc_insertion_point(builder_implements:gitpod.v1.DeleteOrganizationEnvironmentVariableResponse)
+        io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponseOrBuilder {
+      public static final com.google.protobuf.Descriptors.Descriptor
+          getDescriptor() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_descriptor;
+      }
+
+      @java.lang.Override
+      protected com.google.protobuf.GeneratedMessage.FieldAccessorTable
+          internalGetFieldAccessorTable() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_fieldAccessorTable
+            .ensureFieldAccessorsInitialized(
+                io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse.class, io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse.Builder.class);
+      }
+
+      // Construct using io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse.newBuilder()
+      private Builder() {
+
+      }
+
+      private Builder(
+          com.google.protobuf.GeneratedMessage.BuilderParent parent) {
+        super(parent);
+
+      }
+      @java.lang.Override
+      public Builder clear() {
+        super.clear();
+        return this;
+      }
+
+      @java.lang.Override
+      public com.google.protobuf.Descriptors.Descriptor
+          getDescriptorForType() {
+        return io.gitpod.publicapi.v1.Envvar.internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_descriptor;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse getDefaultInstanceForType() {
+        return io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse.getDefaultInstance();
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse build() {
+        io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse result = buildPartial();
+        if (!result.isInitialized()) {
+          throw newUninitializedMessageException(result);
+        }
+        return result;
+      }
+
+      @java.lang.Override
+      public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse buildPartial() {
+        io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse result = new io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse(this);
+        onBuilt();
+        return result;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(com.google.protobuf.Message other) {
+        if (other instanceof io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse) {
+          return mergeFrom((io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse)other);
+        } else {
+          super.mergeFrom(other);
+          return this;
+        }
+      }
+
+      public Builder mergeFrom(io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse other) {
+        if (other == io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse.getDefaultInstance()) return this;
+        this.mergeUnknownFields(other.getUnknownFields());
+        onChanged();
+        return this;
+      }
+
+      @java.lang.Override
+      public final boolean isInitialized() {
+        return true;
+      }
+
+      @java.lang.Override
+      public Builder mergeFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws java.io.IOException {
+        if (extensionRegistry == null) {
+          throw new java.lang.NullPointerException();
+        }
+        try {
+          boolean done = false;
+          while (!done) {
+            int tag = input.readTag();
+            switch (tag) {
+              case 0:
+                done = true;
+                break;
+              default: {
+                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                  done = true; // was an endgroup tag
+                }
+                break;
+              } // default:
+            } // switch (tag)
+          } // while (!done)
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.unwrapIOException();
+        } finally {
+          onChanged();
+        } // finally
+        return this;
+      }
+
+      // @@protoc_insertion_point(builder_scope:gitpod.v1.DeleteOrganizationEnvironmentVariableResponse)
+    }
+
+    // @@protoc_insertion_point(class_scope:gitpod.v1.DeleteOrganizationEnvironmentVariableResponse)
+    private static final io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse DEFAULT_INSTANCE;
+    static {
+      DEFAULT_INSTANCE = new io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse();
+    }
+
+    public static io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse getDefaultInstance() {
+      return DEFAULT_INSTANCE;
+    }
+
+    private static final com.google.protobuf.Parser<DeleteOrganizationEnvironmentVariableResponse>
+        PARSER = new com.google.protobuf.AbstractParser<DeleteOrganizationEnvironmentVariableResponse>() {
+      @java.lang.Override
+      public DeleteOrganizationEnvironmentVariableResponse parsePartialFrom(
+          com.google.protobuf.CodedInputStream input,
+          com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+          throws com.google.protobuf.InvalidProtocolBufferException {
+        Builder builder = newBuilder();
+        try {
+          builder.mergeFrom(input, extensionRegistry);
+        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+          throw e.setUnfinishedMessage(builder.buildPartial());
+        } catch (com.google.protobuf.UninitializedMessageException e) {
+          throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
+        } catch (java.io.IOException e) {
+          throw new com.google.protobuf.InvalidProtocolBufferException(e)
+              .setUnfinishedMessage(builder.buildPartial());
+        }
+        return builder.buildPartial();
+      }
+    };
+
+    public static com.google.protobuf.Parser<DeleteOrganizationEnvironmentVariableResponse> parser() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public com.google.protobuf.Parser<DeleteOrganizationEnvironmentVariableResponse> getParserForType() {
+      return PARSER;
+    }
+
+    @java.lang.Override
+    public io.gitpod.publicapi.v1.Envvar.DeleteOrganizationEnvironmentVariableResponse getDefaultInstanceForType() {
+      return DEFAULT_INSTANCE;
+    }
+
+  }
+
   public interface ResolveWorkspaceEnvironmentVariablesRequestOrBuilder extends
       // @@protoc_insertion_point(interface_extends:gitpod.v1.ResolveWorkspaceEnvironmentVariablesRequest)
       com.google.protobuf.MessageOrBuilder {
@@ -15106,6 +21399,51 @@ public final class Envvar {
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
       internal_static_gitpod_v1_DeleteConfigurationEnvironmentVariableResponse_fieldAccessorTable;
   private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_OrganizationEnvironmentVariable_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_OrganizationEnvironmentVariable_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
+    internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_descriptor;
+  private static final
+    com.google.protobuf.GeneratedMessage.FieldAccessorTable
+      internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_fieldAccessorTable;
+  private static final com.google.protobuf.Descriptors.Descriptor
     internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesRequest_descriptor;
   private static final
     com.google.protobuf.GeneratedMessage.FieldAccessorTable
@@ -15198,55 +21536,102 @@ public final class Envvar {
       "EnvironmentVariableRequest\0226\n\027environmen" +
       "t_variable_id\030\001 \001(\tR\025environmentVariable" +
       "Id\"0\n.DeleteConfigurationEnvironmentVari" +
-      "ableResponse\"P\n+ResolveWorkspaceEnvironm" +
-      "entVariablesRequest\022!\n\014workspace_id\030\001 \001(" +
-      "\tR\013workspaceId\"\203\001\n,ResolveWorkspaceEnvir" +
-      "onmentVariablesResponse\022S\n\025environment_v" +
-      "ariables\030\001 \003(\0132\036.gitpod.v1.EnvironmentVa" +
-      "riableR\024environmentVariables\"?\n\023Environm" +
-      "entVariable\022\022\n\004name\030\001 \001(\tR\004name\022\024\n\005value" +
-      "\030\002 \001(\tR\005value*\252\001\n\034EnvironmentVariableAdm" +
-      "ission\022.\n*ENVIRONMENT_VARIABLE_ADMISSION" +
-      "_UNSPECIFIED\020\000\022+\n\'ENVIRONMENT_VARIABLE_A" +
-      "DMISSION_PREBUILD\020\001\022-\n)ENVIRONMENT_VARIA" +
-      "BLE_ADMISSION_EVERYWHERE\020\0022\326\n\n\032Environme" +
-      "ntVariableService\022\201\001\n\034ListUserEnvironmen" +
-      "tVariables\022..gitpod.v1.ListUserEnvironme" +
-      "ntVariablesRequest\032/.gitpod.v1.ListUserE" +
-      "nvironmentVariablesResponse\"\000\022\204\001\n\035Update" +
-      "UserEnvironmentVariable\022/.gitpod.v1.Upda" +
-      "teUserEnvironmentVariableRequest\0320.gitpo" +
-      "d.v1.UpdateUserEnvironmentVariableRespon" +
-      "se\"\000\022\204\001\n\035CreateUserEnvironmentVariable\022/" +
-      ".gitpod.v1.CreateUserEnvironmentVariable" +
-      "Request\0320.gitpod.v1.CreateUserEnvironmen" +
-      "tVariableResponse\"\000\022\204\001\n\035DeleteUserEnviro" +
-      "nmentVariable\022/.gitpod.v1.DeleteUserEnvi" +
-      "ronmentVariableRequest\0320.gitpod.v1.Delet" +
-      "eUserEnvironmentVariableResponse\"\000\022\234\001\n%L" +
-      "istConfigurationEnvironmentVariables\0227.g" +
-      "itpod.v1.ListConfigurationEnvironmentVar" +
-      "iablesRequest\0328.gitpod.v1.ListConfigurat" +
-      "ionEnvironmentVariablesResponse\"\000\022\237\001\n&Up" +
-      "dateConfigurationEnvironmentVariable\0228.g" +
-      "itpod.v1.UpdateConfigurationEnvironmentV" +
-      "ariableRequest\0329.gitpod.v1.UpdateConfigu" +
-      "rationEnvironmentVariableResponse\"\000\022\237\001\n&" +
-      "CreateConfigurationEnvironmentVariable\0228" +
-      ".gitpod.v1.CreateConfigurationEnvironmen" +
-      "tVariableRequest\0329.gitpod.v1.CreateConfi" +
-      "gurationEnvironmentVariableResponse\"\000\022\237\001" +
-      "\n&DeleteConfigurationEnvironmentVariable" +
-      "\0228.gitpod.v1.DeleteConfigurationEnvironm" +
-      "entVariableRequest\0329.gitpod.v1.DeleteCon" +
-      "figurationEnvironmentVariableResponse\"\000\022" +
-      "\231\001\n$ResolveWorkspaceEnvironmentVariables" +
-      "\0226.gitpod.v1.ResolveWorkspaceEnvironment" +
-      "VariablesRequest\0327.gitpod.v1.ResolveWork" +
-      "spaceEnvironmentVariablesResponse\"\000BQ\n\026i" +
-      "o.gitpod.publicapi.v1Z7github.com/gitpod" +
-      "-io/gitpod/components/public-api/go/v1b\006" +
-      "proto3"
+      "ableResponse\"n\n\037OrganizationEnvironmentV" +
+      "ariable\022\016\n\002id\030\001 \001(\tR\002id\022\022\n\004name\030\002 \001(\tR\004n" +
+      "ame\022\'\n\017organization_id\030\003 \001(\tR\016organizati" +
+      "onId\"\224\001\n+ListOrganizationEnvironmentVari" +
+      "ablesRequest\022\'\n\017organization_id\030\001 \001(\tR\016o" +
+      "rganizationId\022<\n\npagination\030\002 \001(\0132\034.gitp" +
+      "od.v1.PaginationRequestR\npagination\"\316\001\n," +
+      "ListOrganizationEnvironmentVariablesResp" +
+      "onse\022_\n\025environment_variables\030\001 \003(\0132*.gi" +
+      "tpod.v1.OrganizationEnvironmentVariableR" +
+      "\024environmentVariables\022=\n\npagination\030\002 \001(" +
+      "\0132\035.gitpod.v1.PaginationResponseR\npagina" +
+      "tion\"\326\001\n,UpdateOrganizationEnvironmentVa" +
+      "riableRequest\022\'\n\017organization_id\030\001 \001(\tR\016" +
+      "organizationId\0226\n\027environment_variable_i" +
+      "d\030\002 \001(\tR\025environmentVariableId\022\027\n\004name\030\003" +
+      " \001(\tH\000R\004name\210\001\001\022\031\n\005value\030\004 \001(\tH\001R\005value\210" +
+      "\001\001B\007\n\005_nameB\010\n\006_value\"\216\001\n-UpdateOrganiza" +
+      "tionEnvironmentVariableResponse\022]\n\024envir" +
+      "onment_variable\030\001 \001(\0132*.gitpod.v1.Organi" +
+      "zationEnvironmentVariableR\023environmentVa" +
+      "riable\"\201\001\n,CreateOrganizationEnvironment" +
+      "VariableRequest\022\'\n\017organization_id\030\001 \001(\t" +
+      "R\016organizationId\022\022\n\004name\030\002 \001(\tR\004name\022\024\n\005" +
+      "value\030\003 \001(\tR\005value\"\216\001\n-CreateOrganizatio" +
+      "nEnvironmentVariableResponse\022]\n\024environm" +
+      "ent_variable\030\001 \001(\0132*.gitpod.v1.Organizat" +
+      "ionEnvironmentVariableR\023environmentVaria" +
+      "ble\"f\n,DeleteOrganizationEnvironmentVari" +
+      "ableRequest\0226\n\027environment_variable_id\030\001" +
+      " \001(\tR\025environmentVariableId\"/\n-DeleteOrg" +
+      "anizationEnvironmentVariableResponse\"P\n+" +
+      "ResolveWorkspaceEnvironmentVariablesRequ" +
+      "est\022!\n\014workspace_id\030\001 \001(\tR\013workspaceId\"\203" +
+      "\001\n,ResolveWorkspaceEnvironmentVariablesR" +
+      "esponse\022S\n\025environment_variables\030\001 \003(\0132\036" +
+      ".gitpod.v1.EnvironmentVariableR\024environm" +
+      "entVariables\"?\n\023EnvironmentVariable\022\022\n\004n" +
+      "ame\030\001 \001(\tR\004name\022\024\n\005value\030\002 \001(\tR\005value*\252\001" +
+      "\n\034EnvironmentVariableAdmission\022.\n*ENVIRO" +
+      "NMENT_VARIABLE_ADMISSION_UNSPECIFIED\020\000\022+" +
+      "\n\'ENVIRONMENT_VARIABLE_ADMISSION_PREBUIL" +
+      "D\020\001\022-\n)ENVIRONMENT_VARIABLE_ADMISSION_EV" +
+      "ERYWHERE\020\0022\317\017\n\032EnvironmentVariableServic" +
+      "e\022\201\001\n\034ListUserEnvironmentVariables\022..git" +
+      "pod.v1.ListUserEnvironmentVariablesReque" +
+      "st\032/.gitpod.v1.ListUserEnvironmentVariab" +
+      "lesResponse\"\000\022\204\001\n\035UpdateUserEnvironmentV" +
+      "ariable\022/.gitpod.v1.UpdateUserEnvironmen" +
+      "tVariableRequest\0320.gitpod.v1.UpdateUserE" +
+      "nvironmentVariableResponse\"\000\022\204\001\n\035CreateU" +
+      "serEnvironmentVariable\022/.gitpod.v1.Creat" +
+      "eUserEnvironmentVariableRequest\0320.gitpod" +
+      ".v1.CreateUserEnvironmentVariableRespons" +
+      "e\"\000\022\204\001\n\035DeleteUserEnvironmentVariable\022/." +
+      "gitpod.v1.DeleteUserEnvironmentVariableR" +
+      "equest\0320.gitpod.v1.DeleteUserEnvironment" +
+      "VariableResponse\"\000\022\234\001\n%ListConfiguration" +
+      "EnvironmentVariables\0227.gitpod.v1.ListCon" +
+      "figurationEnvironmentVariablesRequest\0328." +
+      "gitpod.v1.ListConfigurationEnvironmentVa" +
+      "riablesResponse\"\000\022\237\001\n&UpdateConfiguratio" +
+      "nEnvironmentVariable\0228.gitpod.v1.UpdateC" +
+      "onfigurationEnvironmentVariableRequest\0329" +
+      ".gitpod.v1.UpdateConfigurationEnvironmen" +
+      "tVariableResponse\"\000\022\237\001\n&CreateConfigurat" +
+      "ionEnvironmentVariable\0228.gitpod.v1.Creat" +
+      "eConfigurationEnvironmentVariableRequest" +
+      "\0329.gitpod.v1.CreateConfigurationEnvironm" +
+      "entVariableResponse\"\000\022\237\001\n&DeleteConfigur" +
+      "ationEnvironmentVariable\0228.gitpod.v1.Del" +
+      "eteConfigurationEnvironmentVariableReque" +
+      "st\0329.gitpod.v1.DeleteConfigurationEnviro" +
+      "nmentVariableResponse\"\000\022\231\001\n$ListOrganiza" +
+      "tionEnvironmentVariables\0226.gitpod.v1.Lis" +
+      "tOrganizationEnvironmentVariablesRequest" +
+      "\0327.gitpod.v1.ListOrganizationEnvironment" +
+      "VariablesResponse\"\000\022\234\001\n%UpdateOrganizati" +
+      "onEnvironmentVariable\0227.gitpod.v1.Update" +
+      "OrganizationEnvironmentVariableRequest\0328" +
+      ".gitpod.v1.UpdateOrganizationEnvironment" +
+      "VariableResponse\"\000\022\234\001\n%CreateOrganizatio" +
+      "nEnvironmentVariable\0227.gitpod.v1.CreateO" +
+      "rganizationEnvironmentVariableRequest\0328." +
+      "gitpod.v1.CreateOrganizationEnvironmentV" +
+      "ariableResponse\"\000\022\234\001\n%DeleteOrganization" +
+      "EnvironmentVariable\0227.gitpod.v1.DeleteOr" +
+      "ganizationEnvironmentVariableRequest\0328.g" +
+      "itpod.v1.DeleteOrganizationEnvironmentVa" +
+      "riableResponse\"\000\022\231\001\n$ResolveWorkspaceEnv" +
+      "ironmentVariables\0226.gitpod.v1.ResolveWor" +
+      "kspaceEnvironmentVariablesRequest\0327.gitp" +
+      "od.v1.ResolveWorkspaceEnvironmentVariabl" +
+      "esResponse\"\000BQ\n\026io.gitpod.publicapi.v1Z7" +
+      "github.com/gitpod-io/gitpod/components/p" +
+      "ublic-api/go/v1b\006proto3"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -15361,20 +21746,74 @@ public final class Envvar {
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_gitpod_v1_DeleteConfigurationEnvironmentVariableResponse_descriptor,
         new java.lang.String[] { });
-    internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesRequest_descriptor =
+    internal_static_gitpod_v1_OrganizationEnvironmentVariable_descriptor =
       getDescriptor().getMessageTypes().get(18);
+    internal_static_gitpod_v1_OrganizationEnvironmentVariable_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_OrganizationEnvironmentVariable_descriptor,
+        new java.lang.String[] { "Id", "Name", "OrganizationId", });
+    internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_descriptor =
+      getDescriptor().getMessageTypes().get(19);
+    internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesRequest_descriptor,
+        new java.lang.String[] { "OrganizationId", "Pagination", });
+    internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_descriptor =
+      getDescriptor().getMessageTypes().get(20);
+    internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_ListOrganizationEnvironmentVariablesResponse_descriptor,
+        new java.lang.String[] { "EnvironmentVariables", "Pagination", });
+    internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_descriptor =
+      getDescriptor().getMessageTypes().get(21);
+    internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableRequest_descriptor,
+        new java.lang.String[] { "OrganizationId", "EnvironmentVariableId", "Name", "Value", });
+    internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_descriptor =
+      getDescriptor().getMessageTypes().get(22);
+    internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_UpdateOrganizationEnvironmentVariableResponse_descriptor,
+        new java.lang.String[] { "EnvironmentVariable", });
+    internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_descriptor =
+      getDescriptor().getMessageTypes().get(23);
+    internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableRequest_descriptor,
+        new java.lang.String[] { "OrganizationId", "Name", "Value", });
+    internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_descriptor =
+      getDescriptor().getMessageTypes().get(24);
+    internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_CreateOrganizationEnvironmentVariableResponse_descriptor,
+        new java.lang.String[] { "EnvironmentVariable", });
+    internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_descriptor =
+      getDescriptor().getMessageTypes().get(25);
+    internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableRequest_descriptor,
+        new java.lang.String[] { "EnvironmentVariableId", });
+    internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_descriptor =
+      getDescriptor().getMessageTypes().get(26);
+    internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_fieldAccessorTable = new
+      com.google.protobuf.GeneratedMessage.FieldAccessorTable(
+        internal_static_gitpod_v1_DeleteOrganizationEnvironmentVariableResponse_descriptor,
+        new java.lang.String[] { });
+    internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesRequest_descriptor =
+      getDescriptor().getMessageTypes().get(27);
     internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesRequest_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesRequest_descriptor,
         new java.lang.String[] { "WorkspaceId", });
     internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesResponse_descriptor =
-      getDescriptor().getMessageTypes().get(19);
+      getDescriptor().getMessageTypes().get(28);
     internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesResponse_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_gitpod_v1_ResolveWorkspaceEnvironmentVariablesResponse_descriptor,
         new java.lang.String[] { "EnvironmentVariables", });
     internal_static_gitpod_v1_EnvironmentVariable_descriptor =
-      getDescriptor().getMessageTypes().get(20);
+      getDescriptor().getMessageTypes().get(29);
     internal_static_gitpod_v1_EnvironmentVariable_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessage.FieldAccessorTable(
         internal_static_gitpod_v1_EnvironmentVariable_descriptor,

--- a/components/public-api/typescript-common/fixtures/toOrganizationEnvironmentVariable_1.golden
+++ b/components/public-api/typescript-common/fixtures/toOrganizationEnvironmentVariable_1.golden
@@ -1,0 +1,8 @@
+{
+    "result": {
+        "id": "test-id",
+        "name": "TEST_VAR",
+        "organizationId": "org-123"
+    },
+    "err": ""
+}

--- a/components/public-api/typescript-common/fixtures/toOrganizationEnvironmentVariable_1.json
+++ b/components/public-api/typescript-common/fixtures/toOrganizationEnvironmentVariable_1.json
@@ -1,0 +1,5 @@
+{
+  "id": "test-id",
+  "name": "TEST_VAR",
+  "orgId": "org-123"
+}

--- a/components/public-api/typescript-common/src/public-api-converter.spec.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.spec.ts
@@ -106,10 +106,13 @@ describe("PublicAPIConverter", () => {
 
         it("toWorkspaceSession", async () => {
             await startFixtureTest("../fixtures/toWorkspaceSession_*.json", async (input) =>
-                converter.toWorkspaceSession(input, new WorkspaceSession_Owner({
-                    id: "123",
-                    name: "Kum Quat"
-                })),
+                converter.toWorkspaceSession(
+                    input,
+                    new WorkspaceSession_Owner({
+                        id: "123",
+                        name: "Kum Quat",
+                    }),
+                ),
             );
         });
 
@@ -180,6 +183,12 @@ describe("PublicAPIConverter", () => {
         it("toConfigurationEnvironmentVariable", async () => {
             await startFixtureTest("../fixtures/toConfigurationEnvironmentVariable_*.json", async (input) =>
                 converter.toConfigurationEnvironmentVariable(input),
+            );
+        });
+
+        it("toOrganizationEnvironmentVariable", async () => {
+            await startFixtureTest("../fixtures/toOrganizationEnvironmentVariable_*.json", async (input) =>
+                converter.toOrganizationEnvironmentVariable(input),
             );
         });
 

--- a/components/public-api/typescript-common/src/public-api-converter.ts
+++ b/components/public-api/typescript-common/src/public-api-converter.ts
@@ -42,6 +42,7 @@ import {
     Configuration as GitpodServerInstallationConfiguration,
     NavigatorContext,
     RefType,
+    OrgEnvVar,
 } from "@gitpod/gitpod-protocol/lib/protocol";
 import { AuditLog as AuditLogProtocol } from "@gitpod/gitpod-protocol/lib/audit-log";
 import {
@@ -88,6 +89,7 @@ import {
     ConfigurationEnvironmentVariable,
     EnvironmentVariable,
     EnvironmentVariableAdmission,
+    OrganizationEnvironmentVariable,
     UserEnvironmentVariable,
 } from "@gitpod/public-api/lib/gitpod/v1/envvar_pb";
 import {
@@ -834,6 +836,14 @@ export class PublicAPIConverter {
         return result;
     }
 
+    toOrganizationEnvironmentVariable(envVar: OrgEnvVar): OrganizationEnvironmentVariable {
+        const result = new OrganizationEnvironmentVariable();
+        result.id = envVar.id || "";
+        result.name = envVar.name;
+        result.organizationId = envVar.orgId;
+        return result;
+    }
+
     toAdmission(shareable: boolean | undefined): AdmissionLevel {
         if (shareable) {
             return AdmissionLevel.EVERYONE;
@@ -1137,7 +1147,7 @@ export class PublicAPIConverter {
             maxParallelRunningWorkspaces: settings.maxParallelRunningWorkspaces ?? 0,
             onboardingSettings: {
                 internalLink: settings?.onboardingSettings?.internalLink ?? undefined,
-            }
+            },
         });
     }
 

--- a/components/public-api/typescript/src/gitpod/v1/envvar_connect.ts
+++ b/components/public-api/typescript/src/gitpod/v1/envvar_connect.ts
@@ -9,7 +9,7 @@
 /* eslint-disable */
 // @ts-nocheck
 
-import { CreateConfigurationEnvironmentVariableRequest, CreateConfigurationEnvironmentVariableResponse, CreateUserEnvironmentVariableRequest, CreateUserEnvironmentVariableResponse, DeleteConfigurationEnvironmentVariableRequest, DeleteConfigurationEnvironmentVariableResponse, DeleteUserEnvironmentVariableRequest, DeleteUserEnvironmentVariableResponse, ListConfigurationEnvironmentVariablesRequest, ListConfigurationEnvironmentVariablesResponse, ListUserEnvironmentVariablesRequest, ListUserEnvironmentVariablesResponse, ResolveWorkspaceEnvironmentVariablesRequest, ResolveWorkspaceEnvironmentVariablesResponse, UpdateConfigurationEnvironmentVariableRequest, UpdateConfigurationEnvironmentVariableResponse, UpdateUserEnvironmentVariableRequest, UpdateUserEnvironmentVariableResponse } from "./envvar_pb.js";
+import { CreateConfigurationEnvironmentVariableRequest, CreateConfigurationEnvironmentVariableResponse, CreateOrganizationEnvironmentVariableRequest, CreateOrganizationEnvironmentVariableResponse, CreateUserEnvironmentVariableRequest, CreateUserEnvironmentVariableResponse, DeleteConfigurationEnvironmentVariableRequest, DeleteConfigurationEnvironmentVariableResponse, DeleteOrganizationEnvironmentVariableRequest, DeleteOrganizationEnvironmentVariableResponse, DeleteUserEnvironmentVariableRequest, DeleteUserEnvironmentVariableResponse, ListConfigurationEnvironmentVariablesRequest, ListConfigurationEnvironmentVariablesResponse, ListOrganizationEnvironmentVariablesRequest, ListOrganizationEnvironmentVariablesResponse, ListUserEnvironmentVariablesRequest, ListUserEnvironmentVariablesResponse, ResolveWorkspaceEnvironmentVariablesRequest, ResolveWorkspaceEnvironmentVariablesResponse, UpdateConfigurationEnvironmentVariableRequest, UpdateConfigurationEnvironmentVariableResponse, UpdateOrganizationEnvironmentVariableRequest, UpdateOrganizationEnvironmentVariableResponse, UpdateUserEnvironmentVariableRequest, UpdateUserEnvironmentVariableResponse } from "./envvar_pb.js";
 import { MethodKind } from "@bufbuild/protobuf";
 
 /**
@@ -112,6 +112,54 @@ export const EnvironmentVariableService = {
       name: "DeleteConfigurationEnvironmentVariable",
       I: DeleteConfigurationEnvironmentVariableRequest,
       O: DeleteConfigurationEnvironmentVariableResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * ListOrganizationEnvironmentVariables returns all environment variables in
+     * an organization.
+     *
+     * @generated from rpc gitpod.v1.EnvironmentVariableService.ListOrganizationEnvironmentVariables
+     */
+    listOrganizationEnvironmentVariables: {
+      name: "ListOrganizationEnvironmentVariables",
+      I: ListOrganizationEnvironmentVariablesRequest,
+      O: ListOrganizationEnvironmentVariablesResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * UpdateOrganizationEnvironmentVariable updates an environment variable in
+     * an organization.
+     *
+     * @generated from rpc gitpod.v1.EnvironmentVariableService.UpdateOrganizationEnvironmentVariable
+     */
+    updateOrganizationEnvironmentVariable: {
+      name: "UpdateOrganizationEnvironmentVariable",
+      I: UpdateOrganizationEnvironmentVariableRequest,
+      O: UpdateOrganizationEnvironmentVariableResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * CreateOrganizationEnvironmentVariable creates a new environment variable
+     * in an organization.
+     *
+     * @generated from rpc gitpod.v1.EnvironmentVariableService.CreateOrganizationEnvironmentVariable
+     */
+    createOrganizationEnvironmentVariable: {
+      name: "CreateOrganizationEnvironmentVariable",
+      I: CreateOrganizationEnvironmentVariableRequest,
+      O: CreateOrganizationEnvironmentVariableResponse,
+      kind: MethodKind.Unary,
+    },
+    /**
+     * DeleteOrganizationEnvironmentVariable deletes an environment variable in
+     * an organization.
+     *
+     * @generated from rpc gitpod.v1.EnvironmentVariableService.DeleteOrganizationEnvironmentVariable
+     */
+    deleteOrganizationEnvironmentVariable: {
+      name: "DeleteOrganizationEnvironmentVariable",
+      I: DeleteOrganizationEnvironmentVariableRequest,
+      O: DeleteOrganizationEnvironmentVariableResponse,
       kind: MethodKind.Unary,
     },
     /**

--- a/components/public-api/typescript/src/gitpod/v1/envvar_pb.ts
+++ b/components/public-api/typescript/src/gitpod/v1/envvar_pb.ts
@@ -820,6 +820,387 @@ export class DeleteConfigurationEnvironmentVariableResponse extends Message<Dele
 }
 
 /**
+ * @generated from message gitpod.v1.OrganizationEnvironmentVariable
+ */
+export class OrganizationEnvironmentVariable extends Message<OrganizationEnvironmentVariable> {
+  /**
+   * @generated from field: string id = 1;
+   */
+  id = "";
+
+  /**
+   * @generated from field: string name = 2;
+   */
+  name = "";
+
+  /**
+   * @generated from field: string organization_id = 3;
+   */
+  organizationId = "";
+
+  constructor(data?: PartialMessage<OrganizationEnvironmentVariable>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.OrganizationEnvironmentVariable";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): OrganizationEnvironmentVariable {
+    return new OrganizationEnvironmentVariable().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): OrganizationEnvironmentVariable {
+    return new OrganizationEnvironmentVariable().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): OrganizationEnvironmentVariable {
+    return new OrganizationEnvironmentVariable().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: OrganizationEnvironmentVariable | PlainMessage<OrganizationEnvironmentVariable> | undefined, b: OrganizationEnvironmentVariable | PlainMessage<OrganizationEnvironmentVariable> | undefined): boolean {
+    return proto3.util.equals(OrganizationEnvironmentVariable, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.ListOrganizationEnvironmentVariablesRequest
+ */
+export class ListOrganizationEnvironmentVariablesRequest extends Message<ListOrganizationEnvironmentVariablesRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: gitpod.v1.PaginationRequest pagination = 2;
+   */
+  pagination?: PaginationRequest;
+
+  constructor(data?: PartialMessage<ListOrganizationEnvironmentVariablesRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.ListOrganizationEnvironmentVariablesRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "pagination", kind: "message", T: PaginationRequest },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListOrganizationEnvironmentVariablesRequest {
+    return new ListOrganizationEnvironmentVariablesRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListOrganizationEnvironmentVariablesRequest {
+    return new ListOrganizationEnvironmentVariablesRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListOrganizationEnvironmentVariablesRequest {
+    return new ListOrganizationEnvironmentVariablesRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListOrganizationEnvironmentVariablesRequest | PlainMessage<ListOrganizationEnvironmentVariablesRequest> | undefined, b: ListOrganizationEnvironmentVariablesRequest | PlainMessage<ListOrganizationEnvironmentVariablesRequest> | undefined): boolean {
+    return proto3.util.equals(ListOrganizationEnvironmentVariablesRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.ListOrganizationEnvironmentVariablesResponse
+ */
+export class ListOrganizationEnvironmentVariablesResponse extends Message<ListOrganizationEnvironmentVariablesResponse> {
+  /**
+   * @generated from field: repeated gitpod.v1.OrganizationEnvironmentVariable environment_variables = 1;
+   */
+  environmentVariables: OrganizationEnvironmentVariable[] = [];
+
+  /**
+   * @generated from field: gitpod.v1.PaginationResponse pagination = 2;
+   */
+  pagination?: PaginationResponse;
+
+  constructor(data?: PartialMessage<ListOrganizationEnvironmentVariablesResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.ListOrganizationEnvironmentVariablesResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "environment_variables", kind: "message", T: OrganizationEnvironmentVariable, repeated: true },
+    { no: 2, name: "pagination", kind: "message", T: PaginationResponse },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ListOrganizationEnvironmentVariablesResponse {
+    return new ListOrganizationEnvironmentVariablesResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): ListOrganizationEnvironmentVariablesResponse {
+    return new ListOrganizationEnvironmentVariablesResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): ListOrganizationEnvironmentVariablesResponse {
+    return new ListOrganizationEnvironmentVariablesResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: ListOrganizationEnvironmentVariablesResponse | PlainMessage<ListOrganizationEnvironmentVariablesResponse> | undefined, b: ListOrganizationEnvironmentVariablesResponse | PlainMessage<ListOrganizationEnvironmentVariablesResponse> | undefined): boolean {
+    return proto3.util.equals(ListOrganizationEnvironmentVariablesResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.UpdateOrganizationEnvironmentVariableRequest
+ */
+export class UpdateOrganizationEnvironmentVariableRequest extends Message<UpdateOrganizationEnvironmentVariableRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string environment_variable_id = 2;
+   */
+  environmentVariableId = "";
+
+  /**
+   * @generated from field: optional string name = 3;
+   */
+  name?: string;
+
+  /**
+   * @generated from field: optional string value = 4;
+   */
+  value?: string;
+
+  constructor(data?: PartialMessage<UpdateOrganizationEnvironmentVariableRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.UpdateOrganizationEnvironmentVariableRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "environment_variable_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+    { no: 4, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */, opt: true },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateOrganizationEnvironmentVariableRequest {
+    return new UpdateOrganizationEnvironmentVariableRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UpdateOrganizationEnvironmentVariableRequest {
+    return new UpdateOrganizationEnvironmentVariableRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UpdateOrganizationEnvironmentVariableRequest {
+    return new UpdateOrganizationEnvironmentVariableRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UpdateOrganizationEnvironmentVariableRequest | PlainMessage<UpdateOrganizationEnvironmentVariableRequest> | undefined, b: UpdateOrganizationEnvironmentVariableRequest | PlainMessage<UpdateOrganizationEnvironmentVariableRequest> | undefined): boolean {
+    return proto3.util.equals(UpdateOrganizationEnvironmentVariableRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.UpdateOrganizationEnvironmentVariableResponse
+ */
+export class UpdateOrganizationEnvironmentVariableResponse extends Message<UpdateOrganizationEnvironmentVariableResponse> {
+  /**
+   * @generated from field: gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1;
+   */
+  environmentVariable?: OrganizationEnvironmentVariable;
+
+  constructor(data?: PartialMessage<UpdateOrganizationEnvironmentVariableResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.UpdateOrganizationEnvironmentVariableResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "environment_variable", kind: "message", T: OrganizationEnvironmentVariable },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): UpdateOrganizationEnvironmentVariableResponse {
+    return new UpdateOrganizationEnvironmentVariableResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): UpdateOrganizationEnvironmentVariableResponse {
+    return new UpdateOrganizationEnvironmentVariableResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): UpdateOrganizationEnvironmentVariableResponse {
+    return new UpdateOrganizationEnvironmentVariableResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: UpdateOrganizationEnvironmentVariableResponse | PlainMessage<UpdateOrganizationEnvironmentVariableResponse> | undefined, b: UpdateOrganizationEnvironmentVariableResponse | PlainMessage<UpdateOrganizationEnvironmentVariableResponse> | undefined): boolean {
+    return proto3.util.equals(UpdateOrganizationEnvironmentVariableResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.CreateOrganizationEnvironmentVariableRequest
+ */
+export class CreateOrganizationEnvironmentVariableRequest extends Message<CreateOrganizationEnvironmentVariableRequest> {
+  /**
+   * @generated from field: string organization_id = 1;
+   */
+  organizationId = "";
+
+  /**
+   * @generated from field: string name = 2;
+   */
+  name = "";
+
+  /**
+   * @generated from field: string value = 3;
+   */
+  value = "";
+
+  constructor(data?: PartialMessage<CreateOrganizationEnvironmentVariableRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.CreateOrganizationEnvironmentVariableRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "organization_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "name", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateOrganizationEnvironmentVariableRequest {
+    return new CreateOrganizationEnvironmentVariableRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): CreateOrganizationEnvironmentVariableRequest {
+    return new CreateOrganizationEnvironmentVariableRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): CreateOrganizationEnvironmentVariableRequest {
+    return new CreateOrganizationEnvironmentVariableRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: CreateOrganizationEnvironmentVariableRequest | PlainMessage<CreateOrganizationEnvironmentVariableRequest> | undefined, b: CreateOrganizationEnvironmentVariableRequest | PlainMessage<CreateOrganizationEnvironmentVariableRequest> | undefined): boolean {
+    return proto3.util.equals(CreateOrganizationEnvironmentVariableRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.CreateOrganizationEnvironmentVariableResponse
+ */
+export class CreateOrganizationEnvironmentVariableResponse extends Message<CreateOrganizationEnvironmentVariableResponse> {
+  /**
+   * @generated from field: gitpod.v1.OrganizationEnvironmentVariable environment_variable = 1;
+   */
+  environmentVariable?: OrganizationEnvironmentVariable;
+
+  constructor(data?: PartialMessage<CreateOrganizationEnvironmentVariableResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.CreateOrganizationEnvironmentVariableResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "environment_variable", kind: "message", T: OrganizationEnvironmentVariable },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): CreateOrganizationEnvironmentVariableResponse {
+    return new CreateOrganizationEnvironmentVariableResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): CreateOrganizationEnvironmentVariableResponse {
+    return new CreateOrganizationEnvironmentVariableResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): CreateOrganizationEnvironmentVariableResponse {
+    return new CreateOrganizationEnvironmentVariableResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: CreateOrganizationEnvironmentVariableResponse | PlainMessage<CreateOrganizationEnvironmentVariableResponse> | undefined, b: CreateOrganizationEnvironmentVariableResponse | PlainMessage<CreateOrganizationEnvironmentVariableResponse> | undefined): boolean {
+    return proto3.util.equals(CreateOrganizationEnvironmentVariableResponse, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.DeleteOrganizationEnvironmentVariableRequest
+ */
+export class DeleteOrganizationEnvironmentVariableRequest extends Message<DeleteOrganizationEnvironmentVariableRequest> {
+  /**
+   * @generated from field: string environment_variable_id = 1;
+   */
+  environmentVariableId = "";
+
+  constructor(data?: PartialMessage<DeleteOrganizationEnvironmentVariableRequest>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.DeleteOrganizationEnvironmentVariableRequest";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+    { no: 1, name: "environment_variable_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteOrganizationEnvironmentVariableRequest {
+    return new DeleteOrganizationEnvironmentVariableRequest().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): DeleteOrganizationEnvironmentVariableRequest {
+    return new DeleteOrganizationEnvironmentVariableRequest().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): DeleteOrganizationEnvironmentVariableRequest {
+    return new DeleteOrganizationEnvironmentVariableRequest().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: DeleteOrganizationEnvironmentVariableRequest | PlainMessage<DeleteOrganizationEnvironmentVariableRequest> | undefined, b: DeleteOrganizationEnvironmentVariableRequest | PlainMessage<DeleteOrganizationEnvironmentVariableRequest> | undefined): boolean {
+    return proto3.util.equals(DeleteOrganizationEnvironmentVariableRequest, a, b);
+  }
+}
+
+/**
+ * @generated from message gitpod.v1.DeleteOrganizationEnvironmentVariableResponse
+ */
+export class DeleteOrganizationEnvironmentVariableResponse extends Message<DeleteOrganizationEnvironmentVariableResponse> {
+  constructor(data?: PartialMessage<DeleteOrganizationEnvironmentVariableResponse>) {
+    super();
+    proto3.util.initPartial(data, this);
+  }
+
+  static readonly runtime: typeof proto3 = proto3;
+  static readonly typeName = "gitpod.v1.DeleteOrganizationEnvironmentVariableResponse";
+  static readonly fields: FieldList = proto3.util.newFieldList(() => [
+  ]);
+
+  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeleteOrganizationEnvironmentVariableResponse {
+    return new DeleteOrganizationEnvironmentVariableResponse().fromBinary(bytes, options);
+  }
+
+  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): DeleteOrganizationEnvironmentVariableResponse {
+    return new DeleteOrganizationEnvironmentVariableResponse().fromJson(jsonValue, options);
+  }
+
+  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): DeleteOrganizationEnvironmentVariableResponse {
+    return new DeleteOrganizationEnvironmentVariableResponse().fromJsonString(jsonString, options);
+  }
+
+  static equals(a: DeleteOrganizationEnvironmentVariableResponse | PlainMessage<DeleteOrganizationEnvironmentVariableResponse> | undefined, b: DeleteOrganizationEnvironmentVariableResponse | PlainMessage<DeleteOrganizationEnvironmentVariableResponse> | undefined): boolean {
+    return proto3.util.equals(DeleteOrganizationEnvironmentVariableResponse, a, b);
+  }
+}
+
+/**
  * @generated from message gitpod.v1.ResolveWorkspaceEnvironmentVariablesRequest
  */
 export class ResolveWorkspaceEnvironmentVariablesRequest extends Message<ResolveWorkspaceEnvironmentVariablesRequest> {

--- a/components/server/src/api/envvar-service-api.ts
+++ b/components/server/src/api/envvar-service-api.ts
@@ -24,6 +24,14 @@ import {
     CreateConfigurationEnvironmentVariableResponse,
     DeleteConfigurationEnvironmentVariableRequest,
     DeleteConfigurationEnvironmentVariableResponse,
+    ListOrganizationEnvironmentVariablesRequest,
+    ListOrganizationEnvironmentVariablesResponse,
+    UpdateOrganizationEnvironmentVariableRequest,
+    UpdateOrganizationEnvironmentVariableResponse,
+    CreateOrganizationEnvironmentVariableRequest,
+    CreateOrganizationEnvironmentVariableResponse,
+    DeleteOrganizationEnvironmentVariableRequest,
+    DeleteOrganizationEnvironmentVariableResponse,
     ResolveWorkspaceEnvironmentVariablesResponse,
     ResolveWorkspaceEnvironmentVariablesRequest,
     EnvironmentVariable,
@@ -195,6 +203,75 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         await this.envVarService.deleteProjectEnvVar(ctxUserId(), req.environmentVariableId);
 
         const response = new DeleteConfigurationEnvironmentVariableResponse();
+        return response;
+    }
+
+    async listOrganizationEnvironmentVariables(
+        req: ListOrganizationEnvironmentVariablesRequest,
+        _: HandlerContext,
+    ): Promise<ListOrganizationEnvironmentVariablesResponse> {
+        if (!uuidValidate(req.organizationId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
+        }
+
+        const response = new ListOrganizationEnvironmentVariablesResponse();
+        const orgEnvVars = await this.envVarService.listOrgEnvVars(ctxUserId(), req.organizationId);
+        response.environmentVariables = orgEnvVars.map((i) => this.apiConverter.toOrganizationEnvironmentVariable(i));
+
+        return response;
+    }
+
+    async updateOrganizationEnvironmentVariable(
+        req: UpdateOrganizationEnvironmentVariableRequest,
+        _: HandlerContext,
+    ): Promise<UpdateOrganizationEnvironmentVariableResponse> {
+        if (!uuidValidate(req.organizationId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
+        }
+        if (!uuidValidate(req.environmentVariableId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "environmentVariableId is required");
+        }
+
+        const updatedOrgEnvVar = await this.envVarService.updateOrgEnvVar(ctxUserId(), req.organizationId, {
+            id: req.environmentVariableId,
+            name: req.name,
+            value: req.value,
+        });
+
+        const response = new UpdateOrganizationEnvironmentVariableResponse();
+        response.environmentVariable = this.apiConverter.toOrganizationEnvironmentVariable(updatedOrgEnvVar);
+        return response;
+    }
+
+    async createOrganizationEnvironmentVariable(
+        req: CreateOrganizationEnvironmentVariableRequest,
+        _: HandlerContext,
+    ): Promise<CreateOrganizationEnvironmentVariableResponse> {
+        if (!uuidValidate(req.organizationId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "organizationId is required");
+        }
+
+        const result = await this.envVarService.addOrgEnvVar(ctxUserId(), req.organizationId, {
+            name: req.name,
+            value: req.value,
+        });
+
+        const response = new CreateOrganizationEnvironmentVariableResponse();
+        response.environmentVariable = this.apiConverter.toOrganizationEnvironmentVariable(result);
+        return response;
+    }
+
+    async deleteOrganizationEnvironmentVariable(
+        req: DeleteOrganizationEnvironmentVariableRequest,
+        _: HandlerContext,
+    ): Promise<DeleteOrganizationEnvironmentVariableResponse> {
+        if (!uuidValidate(req.environmentVariableId)) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, "environmentVariableId is required");
+        }
+
+        await this.envVarService.deleteOrgEnvVar(ctxUserId(), req.environmentVariableId);
+
+        const response = new DeleteOrganizationEnvironmentVariableResponse();
         return response;
     }
 

--- a/components/server/src/api/envvar-service-api.ts
+++ b/components/server/src/api/envvar-service-api.ts
@@ -207,6 +207,7 @@ export class EnvironmentVariableServiceAPI implements ServiceImpl<typeof Environ
         const { workspace } = await this.workspaceService.getWorkspace(ctxUserId(), req.workspaceId);
         const envVars = await this.envVarService.resolveEnvVariables(
             workspace.ownerId,
+            workspace.organizationId,
             workspace.projectId,
             workspace.type,
             workspace.context,

--- a/components/server/src/authorization/definitions.ts
+++ b/components/server/src/authorization/definitions.ts
@@ -65,6 +65,8 @@ export type OrganizationPermission =
     | "delete"
     | "read_settings"
     | "write_settings"
+    | "read_env_var"
+    | "write_env_var"
     | "read_audit_logs"
     | "read_members"
     | "invite_members"

--- a/components/server/src/user/env-var-service.ts
+++ b/components/server/src/user/env-var-service.ts
@@ -4,10 +4,12 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-import { ProjectDB, UserDB } from "@gitpod/gitpod-db/lib";
+import { ProjectDB, TeamDB, UserDB } from "@gitpod/gitpod-db/lib";
 import {
     CommitContext,
     EnvVar,
+    OrgEnvVar,
+    OrgEnvVarWithValue,
     ProjectEnvVar,
     ProjectEnvVarWithValue,
     UserEnvVar,
@@ -36,6 +38,7 @@ export class EnvVarService {
         @inject(Config) private readonly config: Config,
         @inject(UserDB) private readonly userDB: UserDB,
         @inject(ProjectDB) private readonly projectDB: ProjectDB,
+        @inject(TeamDB) private readonly orgDB: TeamDB,
         @inject(Authorizer) private readonly auth: Authorizer,
         @inject(IAnalyticsWriter) private readonly analytics: IAnalyticsWriter,
     ) {}
@@ -181,8 +184,8 @@ export class EnvVarService {
         projectId: string,
         envVar: ProjectEnvVarWithValue,
     ): Promise<ProjectEnvVar> {
-        this.validateProjectEnvVar(envVar);
         await this.auth.checkPermissionOnProject(requestorId, "write_env_var", projectId);
+        this.validateProjectOrOrgEnvVar(envVar);
         const existingVar = await this.projectDB.findProjectEnvironmentVariable(projectId, envVar);
         if (existingVar) {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Project env var ${envVar.name} already exists`);
@@ -191,7 +194,7 @@ export class EnvVarService {
         return await this.projectDB.addProjectEnvironmentVariable(projectId, envVar);
     }
 
-    validateProjectEnvVar(envVar: Partial<ProjectEnvVarWithValue>) {
+    validateProjectOrOrgEnvVar(envVar: Partial<ProjectEnvVarWithValue>) {
         if (!envVar.name) {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, "Variable name cannot be empty");
         }
@@ -211,8 +214,8 @@ export class EnvVarService {
         projectId: string,
         envVar: Partial<ProjectEnvVarWithValue>,
     ): Promise<ProjectEnvVar> {
-        this.validateProjectEnvVar(envVar);
         await this.auth.checkPermissionOnProject(requestorId, "write_env_var", projectId);
+        this.validateProjectOrOrgEnvVar(envVar);
         const result = await this.projectDB.updateProjectEnvironmentVariable(projectId, envVar);
         if (!result) {
             throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Project env var ${envVar.name} does not exists`);
@@ -227,16 +230,78 @@ export class EnvVarService {
         return this.projectDB.deleteProjectEnvironmentVariable(variableId);
     }
 
+    async listOrgEnvVars(requestorId: string, orgId: string): Promise<OrgEnvVar[]> {
+        await this.auth.checkPermissionOnOrganization(requestorId, "read_env_var", orgId);
+        return this.orgDB.getOrgEnvironmentVariables(orgId);
+    }
+
+    async getOrgEnvVarById(requestorId: string, id: string): Promise<OrgEnvVar> {
+        const result = await this.orgDB.getOrgEnvironmentVariableById(id);
+        if (!result) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, `Environment Variable ${id} not found.`);
+        }
+        try {
+            await this.auth.checkPermissionOnOrganization(requestorId, "read_env_var", result.orgId);
+        } catch (err) {
+            throw new ApplicationError(ErrorCodes.NOT_FOUND, `Environment Variable ${id} not found.`);
+        }
+        return result;
+    }
+
+    async addOrgEnvVar(requestorId: string, orgId: string, envVar: OrgEnvVarWithValue): Promise<OrgEnvVar> {
+        await this.auth.checkPermissionOnOrganization(requestorId, "write_env_var", orgId);
+        this.validateProjectOrOrgEnvVar(envVar);
+
+        // gpl: We only intent to use org-level env vars for this very specific use case right now.
+        // If we every want to use it more generically, just lift this restriction
+        if (envVar.name !== UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME) {
+            throw new ApplicationError(
+                ErrorCodes.BAD_REQUEST,
+                "Can only update GITPOD_IMAGE_AUTH env var on org level",
+            );
+        }
+
+        const existingVar = await this.orgDB.findOrgEnvironmentVariableByName(orgId, envVar.name);
+        if (existingVar) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Organization env var ${envVar.name} already exists`);
+        }
+
+        return await this.orgDB.addOrgEnvironmentVariable(orgId, envVar);
+    }
+
+    async updateOrgEnvVar(requestorId: string, orgId: string, envVar: Partial<OrgEnvVarWithValue>): Promise<OrgEnvVar> {
+        await this.auth.checkPermissionOnOrganization(requestorId, "write_env_var", orgId);
+        this.validateProjectOrOrgEnvVar(envVar);
+
+        const result = await this.orgDB.updateOrgEnvironmentVariable(orgId, envVar);
+        if (!result) {
+            throw new ApplicationError(ErrorCodes.BAD_REQUEST, `Organization env var ${envVar.name} does not exists`);
+        }
+
+        return result;
+    }
+
+    async deleteOrgEnvVar(requestorId: string, variableId: string): Promise<void> {
+        const variable = await this.getOrgEnvVarById(requestorId, variableId);
+        await this.auth.checkPermissionOnOrganization(requestorId, "write_env_var", variable.orgId);
+        return this.orgDB.deleteOrgEnvironmentVariable(variableId);
+    }
+
     async resolveEnvVariables(
         requestorId: string,
+        organizationId: string,
         projectId: string | undefined,
         wsType: WorkspaceType,
         wsContext: WorkspaceContext,
         wsConfig?: WorkspaceConfig,
     ): Promise<ResolvedEnvVars> {
-        await this.auth.checkPermissionOnUser(requestorId, "read_env_var", requestorId);
+        const isPrebuild = wsType === "prebuild";
+        if (!isPrebuild) {
+            await this.auth.checkPermissionOnUser(requestorId, "read_env_var", requestorId);
+        }
         if (projectId) {
             await this.auth.checkPermissionOnProject(requestorId, "read_env_var", projectId);
+            await this.auth.checkPermissionOnOrganization(requestorId, "read_env_var", organizationId);
         }
 
         const workspaceEnvVars = new Map<String, EnvVar>();
@@ -245,20 +310,6 @@ export class EnvVarService {
                 workspaceEnvVars.set(env.name, env);
             }
         };
-
-        const projectEnvVars = projectId
-            ? (await ApplicationError.notFoundToUndefined(this.listProjectEnvVars(requestorId, projectId))) || []
-            : [];
-
-        if (wsType === "prebuild") {
-            // prebuild does not have access to user env vars and cannot be started via prefix URL
-            const withValues = await this.projectDB.getProjectEnvironmentVariableValues(projectEnvVars);
-            merge(withValues);
-            return {
-                project: projectEnvVars,
-                workspace: [...workspaceEnvVars.values()],
-            };
-        }
 
         // 1. first merge the `env` in the .gitpod.yml
         if (wsConfig?.env) {
@@ -269,25 +320,38 @@ export class EnvVarService {
             merge(configEnvVars);
         }
 
-        // 2. then user envs
-        if (CommitContext.is(wsContext)) {
+        // 2. then org env vars (if applicable)
+        if (projectId) {
+            // !!! Important: Only apply the org env vars if the workspace is part of a project
+            // This is to prevent leaking org env vars to workspaces randomly started in an organization (safety feature)
+            const orgEnvVars =
+                (await ApplicationError.notFoundToUndefined(this.listOrgEnvVars(requestorId, organizationId))) || [];
+            const withValues: OrgEnvVarWithValue[] = await this.orgDB.getOrgEnvironmentVariableValues(orgEnvVars);
+            merge(withValues);
+        }
+
+        // 3. then user envs (if not a prebuild)
+        if (!isPrebuild && CommitContext.is(wsContext)) {
             // this is a commit context, thus we can filter the env vars
             const userEnvVars = await this.userDB.getEnvVars(requestorId);
             merge(UserEnvVar.filter(userEnvVars, wsContext.repository.owner, wsContext.repository.name));
         }
 
-        // 3. then from the project
+        // 4. then from the project
+        const projectEnvVars = projectId
+            ? (await ApplicationError.notFoundToUndefined(this.listProjectEnvVars(requestorId, projectId))) || []
+            : [];
         if (projectEnvVars.length) {
-            // Instead of using an access guard for Project environment variables, we let Project owners decide whether
-            // a variable should be:
-            //   - exposed in all workspaces (even for non-Project members when the repository is public), or
-            //   - censored from all workspaces (even for Project members)
-            const availablePrjEnvVars = projectEnvVars.filter((variable) => !variable.censored);
+            let availablePrjEnvVars = projectEnvVars;
+            if (!isPrebuild) {
+                // If "censored", a variable is only visible in Prebuilds, so we have to filter it out for other workspace types
+                availablePrjEnvVars = availablePrjEnvVars.filter((variable) => !variable.censored);
+            }
             const withValues = await this.projectDB.getProjectEnvironmentVariableValues(availablePrjEnvVars);
             merge(withValues);
         }
 
-        // 4. then parsed from the context URL
+        // 5. then parsed from the context URL
         if (WithEnvvarsContext.is(wsContext)) {
             merge(wsContext.envvars);
         }

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1221,6 +1221,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         await this.guardAccess({ kind: "workspace", subject: workspace }, "get");
         const envVars = await this.envVarService.resolveEnvVariables(
             workspace.ownerId,
+            workspace.organizationId,
             workspace.projectId,
             workspace.type,
             workspace.context,

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -1231,7 +1231,7 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         const result: EnvVarWithValue[] = [];
         for (const value of envVars.workspace) {
             if (
-                "repositoryPattern" in value &&
+                UserEnvVar.is(value) &&
                 !(await this.resourceAccessGuard.canAccess({ kind: "envVar", subject: value }, "get"))
             ) {
                 continue;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -48,6 +48,7 @@ import {
     StartWorkspaceResult,
     TaskConfig,
     User,
+    UserEnvVar,
     WithPrebuild,
     WithReferrerContext,
     Workspace,
@@ -411,6 +412,7 @@ export class WorkspaceStarter {
 
                         const envVars = await this.envVarService.resolveEnvVariables(
                             user.id,
+                            workspace.organizationId,
                             workspace.projectId,
                             workspace.type,
                             workspace.context,
@@ -839,7 +841,7 @@ export class WorkspaceStarter {
 
     private async getAdditionalImageAuth(envVars: ResolvedEnvVars): Promise<Map<string, string>> {
         const res = new Map<string, string>();
-        const imageAuth = envVars.project.find((e) => e.name === "GITPOD_IMAGE_AUTH");
+        const imageAuth = envVars.project.find((e) => e.name === UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME);
         if (!imageAuth) {
             return res;
         }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -32,6 +32,7 @@ import {
     CommitContext,
     Disposable,
     DisposableCollection,
+    EnvVar,
     GitCheckoutInfo,
     GitpodServer,
     GitpodToken,
@@ -48,7 +49,6 @@ import {
     StartWorkspaceResult,
     TaskConfig,
     User,
-    UserEnvVar,
     WithPrebuild,
     WithReferrerContext,
     Workspace,
@@ -841,14 +841,12 @@ export class WorkspaceStarter {
 
     private async getAdditionalImageAuth(envVars: ResolvedEnvVars): Promise<Map<string, string>> {
         const res = new Map<string, string>();
-        const imageAuth = envVars.project.find((e) => e.name === UserEnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME);
+        const imageAuth = envVars.workspace.find((e) => e.name === EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME);
         if (!imageAuth) {
             return res;
         }
 
-        const imageAuthValue = (await this.projectDB.getProjectEnvironmentVariableValues([imageAuth]))[0];
-
-        (imageAuthValue.value || "")
+        (imageAuth.value || "")
             .split(",")
             .map((e) => e.trim().split(":"))
             .filter((e) => e.length == 2)

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -75,6 +75,9 @@ schema: |-
       permission read_settings = member + owner + collaborator + installation->admin
       permission write_settings = owner + installation->admin
 
+      permission read_env_var = member + owner + collaborator + installation->admin
+      permission write_env_var = owner + installation->admin
+
       permission read_audit_logs = owner + installation->admin
 
       // Operations on Organization's Members


### PR DESCRIPTION
## Description
Introduces an org-level setting to set `GITPOD_IMAGE_AUTH`.
![image](https://github.com/user-attachments/assets/bd34c540-9eb3-4aee-b6d1-00594fb00d77)


Turned out to be a bit more work due to old bugs that surfaced now, and suboptimal design around the EnvVar shapes and how they are used. I did not clean it up completely, as I did not want to delay merging this further, but clearly moved in that direction by removing some cruft from the defintions and tests.

ToDo:
 - [x] backend
 - [x] API
 - [x] dashboard

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1091

## How to test

### Unit tests
 - are green :green_circle: 

### Manual
1. signup here: https://gpl-1089-auth.preview.gitpod-dev.com/workspaces
2. start a workspace on https://gpl-1089-auth.preview.gitpod-dev.com/#https://github.com/geropl/gitpod-test-repo/tree/gpl/test-img-auth and see the error message ("insufficient_scope" etc.) :heavy_check_mark: 
3. join my org: https://gpl-1089-auth.preview.gitpod-dev.com/orgs/join?inviteId=7c86eaf0-c9ad-4a24-8e59-a5758c593c38
  - note the repo config is added: https://gpl-1089-auth.preview.gitpod-dev.com/repositories?sortBy=name&sortOrder=asc
  - note the GITPOD_IMAGE_AUTH env var is set at org level: https://gpl-1089-auth.preview.gitpod-dev.com/settings
4. start the workspace again: https://gpl-1089-auth.preview.gitpod-dev.com/#https://github.com/geropl/gitpod-test-repo/tree/gpl/test-img-auth and see how it works now :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
