### PR TITLE
[JetBrains] wait for the file to be closed before returning

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -5,7 +5,8 @@
     <file type="web" url="file://$PROJECT_DIR$/components/gitpod-protocol/java" />
     <file type="web" url="file://$PROJECT_DIR$/components/ide/jetbrains/backend-plugin" />
     <file type="web" url="file://$PROJECT_DIR$/components/ide/jetbrains/gateway-plugin" />
+    <file type="web" url="file://$PROJECT_DIR$/components/public-api/java" />
     <file type="web" url="file://$PROJECT_DIR$/components/supervisor-api/java" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="zulu-21" project-jdk-type="JavaSDK" />
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_18" project-jdk-name="zulu-17" project-jdk-type="JavaSDK" />
 </project>

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
@@ -12,9 +12,6 @@ import io.gitpod.jetbrains.remote.icons.GitpodIcons
 import javax.swing.Icon
 
 class GitpodGatewayClientCustomizationProvider : GatewayClientCustomizationProvider {
-    // 1. call frequertly
-    // 2. can access gitpod instance?
-    // 3. instance change -> event ?
     override val icon: Icon = GitpodIcons.Logo
     override val title: String = System.getenv("JETBRAINS_GITPOD_WORKSPACE_HOST") ?: DefaultGatewayControlCenterProvider().getHostnameShort()
 

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
@@ -12,6 +12,9 @@ import io.gitpod.jetbrains.remote.icons.GitpodIcons
 import javax.swing.Icon
 
 class GitpodGatewayClientCustomizationProvider : GatewayClientCustomizationProvider {
+    // 1. call frequertly
+    // 2. can access gitpod instance?
+    // 3. instance change -> event ?
     override val icon: Icon = GitpodIcons.Logo
     override val title: String = System.getenv("JETBRAINS_GITPOD_WORKSPACE_HOST") ?: DefaultGatewayControlCenterProvider().getHostnameShort()
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-891

## How to test
<!-- Provide steps to test this PR -->
- Open a workspace with JetBrains IDE like IntelliJ on preview environment
- Exec commands like `gp open <file> -w` and `git rebase -i HEAD~2` should wait until user close the editor
- Relevant code paths such as `gp preview` will not be affected, it should work as before

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-fix-jb-cli</li>
	<li><b>🔗 URL</b> - <a href="https://hw-fix-jb-cli.preview.gitpod-dev.com/workspaces" target="_blank">hw-fix-jb-cli.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-fix-jb-cli-gha.31051</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-fix-jb-cli%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
