### PR TITLE
[JetBrains] display workspace name on the navbar

### DIFF
--- a/components/dashboard/src/workspaces/RenameWorkspaceModal.tsx
+++ b/components/dashboard/src/workspaces/RenameWorkspaceModal.tsx
@@ -10,21 +10,14 @@ import { Button } from "@podkit/buttons/Button";
 import { Workspace } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { useUpdateWorkspaceMutation } from "../data/workspaces/update-workspace-mutation";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
+import { Workspace as WorkspaceProtocol } from "@gitpod/gitpod-protocol";
 
-export const NAME_PREFIX = "named:";
 export function toWorkspaceName(name: string): string {
-    // unsetting the name
-    if (name.trim().length === 0) {
-        return "no-name";
-    }
-    return `${NAME_PREFIX}${name}`;
+    return WorkspaceProtocol.toWorkspaceName(name);
 }
 
 export function fromWorkspaceName(workspace?: Workspace): string | undefined {
-    if (workspace?.metadata?.name?.startsWith(NAME_PREFIX)) {
-        return workspace.metadata.name.slice(NAME_PREFIX.length);
-    }
-    return undefined;
+    return WorkspaceProtocol.fromWorkspaceName(workspace?.metadata?.name);
 }
 
 type Props = {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -766,6 +766,20 @@ export namespace Workspace {
         }
         return undefined;
     }
+
+    const NAME_PREFIX = "named:";
+    export function fromWorkspaceName(name?: Workspace["description"]): string | undefined {
+        if (name?.startsWith(NAME_PREFIX)) {
+            return name.slice(NAME_PREFIX.length);
+        }
+        return undefined;
+    }
+    export function toWorkspaceName(name?: Workspace["description"]): string {
+        if (!name || name?.trim().length === 0) {
+            return "no-name";
+        }
+        return `${NAME_PREFIX}${name}`;
+    }
 }
 
 export interface GuessGitTokenScopesParams {

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodGatewayClientCustomizationProvider.kt
@@ -17,7 +17,7 @@ class GitpodGatewayClientCustomizationProvider : GatewayClientCustomizationProvi
 
     override val controlCenter: GatewayControlCenterProvider = object : GatewayControlCenterProvider {
         override fun getHostnameDisplayKind() = GatewayHostnameDisplayKind.ShowHostnameOnNavbar
-        override fun getHostnameShort() = title
+        override fun getHostnameShort() = System.getenv("GITPOD_WORKSPACE_NAME") ?: title
         override fun getHostnameLong() = title
     }
 }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1587,6 +1587,12 @@ export class WorkspaceStarter {
         sysEnvvars.push(isSetJavaXmx);
         sysEnvvars.push(isSetJavaProcessorCount);
         sysEnvvars.push(disableJetBrainsLocalPortForwarding);
+        if (workspace.context.title) {
+            const workspaceNameEnv = new EnvironmentVariable();
+            workspaceNameEnv.setName("GITPOD_WORKSPACE_NAME");
+            workspaceNameEnv.setValue(workspace.context.title);
+            sysEnvvars.push(workspaceNameEnv);
+        }
         const spec = new StartWorkspaceSpec();
         await createGitpodTokenPromise;
         spec.setEnvvarsList(envvars);

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -1587,10 +1587,12 @@ export class WorkspaceStarter {
         sysEnvvars.push(isSetJavaXmx);
         sysEnvvars.push(isSetJavaProcessorCount);
         sysEnvvars.push(disableJetBrainsLocalPortForwarding);
-        if (workspace.context.title) {
+
+        const workspaceName = Workspace.fromWorkspaceName(workspace.description);
+        if (workspaceName && workspaceName.length > 0) {
             const workspaceNameEnv = new EnvironmentVariable();
             workspaceNameEnv.setName("GITPOD_WORKSPACE_NAME");
-            workspaceNameEnv.setValue(workspace.context.title);
+            workspaceNameEnv.setValue(workspaceName);
             sysEnvvars.push(workspaceNameEnv);
         }
         const spec = new StartWorkspaceSpec();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1079

## How to test
<!-- Provide steps to test this PR -->

> [!NOTE]
> There's a limitation: `getHostnameShort` is only called one time by JetBrains on the editor start, so we can't update the NavBar when user updates workspace name. Only after they restart the workspace, the title on NavBar could change

- Open a workspace on preview env with IntelliJ
- Rename the workspace and restart workspace
- It should show the name on the NavBar

<img width="1362" alt="image" src="https://github.com/user-attachments/assets/7718aaff-e7a8-45ff-8ee5-69e287d2815f" />


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-clc-1079</li>
	<li><b>🔗 URL</b> - <a href="https://hw-clc-1079.preview.gitpod-dev.com/workspaces" target="_blank">hw-clc-1079.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-CLC-1079-gha.31099</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-clc-1079%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [x] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
