### PR TITLE
[docker-up] Auto-login if GITPOD_IMAGE_AUTH is set

### DIFF
--- a/components/supervisor/pkg/supervisor/config.go
+++ b/components/supervisor/pkg/supervisor/config.go
@@ -347,6 +347,9 @@ type WorkspaceConfig struct {
 	ConfigcatEnabled bool `env:"GITPOD_CONFIGCAT_ENABLED"`
 
 	SSHGatewayCAPublicKey string `env:"GITPOD_SSH_CA_PUBLIC_KEY"`
+
+	// Comma-separated list of host:<base64ed user:password> pairs to authenticate against docker registries
+	GitpodImageAuth string `env:"GITPOD_IMAGE_AUTH"`
 }
 
 // WorkspaceGitpodToken is a list of tokens that should be added to supervisor's token service.

--- a/components/supervisor/pkg/supervisor/docker.go
+++ b/components/supervisor/pkg/supervisor/docker.go
@@ -191,7 +191,13 @@ func listenToDockerSocket(parentCtx context.Context, term *terminal.Mux, cfg *Co
 			}
 
 			cmd := exec.CommandContext(ctx, "/usr/bin/docker-up")
-			cmd.Env = append(os.Environ(), "LISTEN_FDS=1")
+			// TODO(gpl): Why are we using os.Environ() in the first place, and not childProcEnvvars?
+			// Might be an oversight from times when we still passed all dockerupEnv vars as Pod dockerupEnv vars... otherwise I don't see why not use [] instead.
+			// But I'm not sure, so sticking with the slightly more verbose version here.
+			dockerupEnv := os.Environ()
+			dockerupEnv = append(dockerupEnv, fmt.Sprintf("GITPOD_IMAGE_AUTH=%s", cfg.GitpodImageAuth))
+			dockerupEnv = append(dockerupEnv, "LISTEN_FDS=1")
+			cmd.Env = dockerupEnv
 			cmd.ExtraFiles = []*os.File{socketFD}
 			cmd.Stdout = stdout
 			cmd.Stderr = stderr

--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -593,7 +593,8 @@ func createWorkspaceEnvironment(sctx *startWorkspaceContext) ([]corev1.EnvVar, e
 			"GITPOD_EXTERNAL_EXTENSIONS",
 			"GITPOD_WORKSPACE_CLASS_INFO",
 			"GITPOD_IDE_ALIAS",
-			"GITPOD_RLIMIT_CORE":
+			"GITPOD_RLIMIT_CORE",
+			"GITPOD_IMAGE_AUTH":
 			// these variables are allowed - don't skip them
 		default:
 			if strings.HasPrefix(e.Name, "GITPOD_") {


### PR DESCRIPTION
## Description

So far GITPOD_IMAGE_AUTH had two issues:
 - it was not present in the default env in terminals, although it was present in `gp env`
 - it was used for pulling docker images in image builder, but not used in workspaces to authenticated the docker daemon
This PR fixes both issues.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1098

## How to test
 - [join this org](https://gpl-1098-dockerup.preview.gitpod-dev.com/orgs/join?inviteId=443bbb18-d8e6-4f42-b2ad-9c747e1f7543)
 - [start a workspace](https://gpl-1098-dockerup.preview.gitpod-dev.com/new#https://github.com/geropl/gitpod), and note:
   - `env | grep GITPOD_IMAGE_AUTH` is not empty
   - test `gp validate`:
     - change first line in `.gitpod.yml` to `image: geropl/workspace-base:latest`
     - hit `gp validate` and note how it successfully pulls the base image

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - gpl-1098-dockerup</li>
	<li><b>🔗 URL</b> - <a href="https://gpl-1098-dockerup.preview.gitpod-dev.com/workspaces" target="_blank">gpl-1098-dockerup.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - gpl-1098-dockerup-gha.31103</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-gpl-1098-dockerup%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
