### PR TITLE
Make JetBrains backend plugin compatible with `2025.1`

### DIFF
--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -90,7 +90,7 @@ jobs:
                       - [x] /werft with-large-vm
                       - [x] /werft with-gce-vm
                       - [x] with-integration-tests=jetbrains
-                      - [x] latest-ide-version=${{ contains(inputs.pluginId, 'latest') }}
+                      - [x] latest-ide-version=${{ contains(inputs.pluginId, 'true') }}
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"
@@ -134,7 +134,7 @@ jobs:
                       - [x] /werft with-large-vm
                       - [x] /werft with-gce-vm
                       - [x] with-integration-tests=jetbrains
-                      - [x] latest-ide-version=${{ contains(inputs.pluginId, 'latest') }}
+                      - [x] latest-ide-version=${{ contains(inputs.pluginId, 'true') }}
 
                       _This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-update-plugin-platform-template.yml) template._
                   commit-message: "Update Platform Version of ${{ inputs.pluginName }} to ${{ steps.latest-version.outputs.result }}"

--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -2,10 +2,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=243.15521
-pluginUntilBuild=243.*
+pluginSinceBuild=251.17181
+pluginUntilBuild=251.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2024.3
-# Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=243.15521.24
+pluginVerifierIdeVersions=2025.1
+# Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/updates/updates.xml or exec `./gradlew printProductsReleases`
+platformVersion=251.17181.16

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
@@ -226,7 +226,7 @@ abstract class AbstractGitpodClientProjectSessionTracker(private val project: Pr
     private fun trackEvent(eventName: String, props: Map<String, Any?>) {
         if (session == null) return
         manager.trackEvent(eventName, mapOf(
-                "sessionId" to session.clientId.value
+                "sessionId" to session?.clientId?.value
         ).plus(props))
     }
 }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/GitpodClientProjectSessionTracker.kt
@@ -9,7 +9,7 @@ import com.intellij.ide.BrowserUtil
 import com.intellij.notification.NotificationAction
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.Disposable
-import com.intellij.openapi.client.ClientSessionsManager
+import com.intellij.openapi.client.ClientProjectSession
 import com.intellij.openapi.components.service
 import com.intellij.openapi.components.serviceOrNull
 import com.intellij.openapi.diagnostic.thisLogger
@@ -35,10 +35,10 @@ import java.util.concurrent.CancellationException
 import java.util.concurrent.CompletableFuture
 
 @Suppress("UnstableApiUsage", "OPT_IN_USAGE")
-class GitpodClientProjectSessionTracker(private val project: Project) : Disposable {
+abstract class AbstractGitpodClientProjectSessionTracker(private val project: Project) : Disposable {
 
     private val manager = service<GitpodManager>()
-    private val session = ClientSessionsManager.getProjectSession(project)
+    abstract val session: ClientProjectSession?
 
     private lateinit var info: Info.WorkspaceInfoResponse
     private val lifetime = Lifetime.Eternal.createNested()

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodClientProjectSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/latest/GitpodClientProjectSessionTracker.kt
@@ -1,0 +1,16 @@
+// Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.latest
+
+import com.intellij.codeWithMe.ClientId
+import com.intellij.openapi.client.ClientProjectSession
+import com.intellij.openapi.client.ClientSessionsManager
+import com.intellij.openapi.project.Project
+import io.gitpod.jetbrains.remote.AbstractGitpodClientProjectSessionTracker
+
+@Suppress("UnstableApiUsage")
+class GitpodClientProjectSessionTracker(val project: Project) : AbstractGitpodClientProjectSessionTracker(project) {
+    override val session: ClientProjectSession? = ClientSessionsManager.getProjectSession(project, ClientId.current)
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodClientProjectSessionTracker.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/stable/GitpodClientProjectSessionTracker.kt
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package io.gitpod.jetbrains.remote.stable
+
+import com.intellij.openapi.client.ClientProjectSession
+import com.intellij.openapi.client.ClientSessionsManager
+import com.intellij.openapi.project.Project
+import io.gitpod.jetbrains.remote.AbstractGitpodClientProjectSessionTracker
+
+@Suppress("UnstableApiUsage")
+class GitpodClientProjectSessionTracker(val project: Project) : AbstractGitpodClientProjectSessionTracker(project) {
+    override val session: ClientProjectSession? = ClientSessionsManager.getProjectSession(project)
+}

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -6,5 +6,7 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.latest.GitpodClientProjectSessionTracker"
+                        client="controller" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -6,5 +6,7 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <projectService serviceImplementation="io.gitpod.jetbrains.remote.stable.GitpodClientProjectSessionTracker"
+                        client="controller" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -38,9 +38,6 @@
 
         <httpRequestHandler implementation="io.gitpod.jetbrains.remote.GitpodCLIService"/>
 
-        <projectService serviceImplementation="io.gitpod.jetbrains.remote.GitpodClientProjectSessionTracker"
-                        client="controller" preload="true"/>
-
         <gateway.customization.name
                 implementation="io.gitpod.jetbrains.remote.GitpodGatewayClientCustomizationProvider"/>
         <gateway.customization.metrics id="gitpodMetricsProvider"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

TODO:
- [ ] we need to run production GHA after this PR is merged

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates CLC-1123

## How to test
<!-- Provide steps to test this PR -->
~~**Integration tests**~~
~~Check integration tests of current PR, maybe some of them will be failed, but most of them should work~~
Integration tests will not work because the latest JB IDEs are not updated to `2025.1` yet, so we need to do smoke tests. (in case preview env is gone, you need to exec [this script](https://github.com/gitpod-io/gitpod/blob/hw/jb-release/components/ide/gha-update-image/BUILD.yaml#L2) to make it use the editor that uploaded by the [GHA](https://github.com/gitpod-io/gitpod/actions/workflows/jetbrains-auto-update.yml) from current branch

**Smoke test**
- Exec `leeway run components/ide/gha-update-image:jb-use-dev-latest` if the editor is not latest 2025.1
- Open workspace with latest JetBrains IDEs

|IntelliJ IDEA|GoLand|WebStorm|
|:-:|:-:|:-:|
|<img width="850" alt="image" src="https://github.com/user-attachments/assets/00e39cf6-7c45-4d1a-a934-c80797bcde47" />|<img width="827" alt="image" src="https://github.com/user-attachments/assets/074ce3fd-4ec9-4586-b53b-abf00a32de15" /> | <img width="824" alt="image" src="https://github.com/user-attachments/assets/d8d5358c-46bd-4418-ba06-5ce738cd1134" /> |

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-release</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-release.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-release.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-release-gha.31140</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-release%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [x] latest-ide-version=true
- [ ] with-monitoring
</details>

/hold
