### PR TITLE
[dashboard] re-order org docker auth config

### DIFF
--- a/components/dashboard/src/dedicated-setup/SetupLayout.tsx
+++ b/components/dashboard/src/dedicated-setup/SetupLayout.tsx
@@ -38,7 +38,7 @@ export const SetupLayout: FC<Props> = ({
         <div className="container">
             <div className="app-container">
                 <div className="flex justify-between items-center">
-                    <div className="flex items-center justify-start items-center py-3 space-x-1">
+                    <div className="flex items-center justify-start py-3 space-x-1">
                         <img src={gitpodIcon} className="w-6 h-6" alt="Gitpod's logo" />
                         {showOrg ? (
                             <div className="pr-1 flex font-semibold whitespace-nowrap max-w-xs overflow-hidden">
@@ -55,7 +55,7 @@ export const SetupLayout: FC<Props> = ({
                         )}
                     </div>
                 </div>
-                <div className={`mt-24 ${noMaxWidth ? "" : "max-w-md"}`}>
+                <div className={`mt-24 ${noMaxWidth ? "" : "max-w-md"} pb-4`}>
                     {/* generate the rounded dots for the progress  */}
                     {progressCurrent !== undefined && progressTotal !== undefined ? (
                         <div className="flex flex-row space-x-2 mb-4">

--- a/components/dashboard/src/teams/TeamSettings.tsx
+++ b/components/dashboard/src/teams/TeamSettings.tsx
@@ -227,6 +227,28 @@ export default function TeamSettingsPage() {
                         />
                     </ConfigurationSettingsField>
 
+                    {org?.id && (
+                        <ConfigurationSettingsField>
+                            <Heading3>Docker Registry authentication</Heading3>
+                            <Subheading>Configure Docker registry permissions for the whole organization.</Subheading>
+
+                            <NamedOrganizationEnvvarItem
+                                disabled={!isOwner}
+                                name={EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}
+                                organizationId={org.id}
+                                variable={gitpodImageAuthEnvVar}
+                            />
+                        </ConfigurationSettingsField>
+                    )}
+
+                    {showImageEditModal && (
+                        <OrgDefaultWorkspaceImageModal
+                            settings={settings}
+                            installationDefaultWorkspaceImage={installationDefaultImage}
+                            onClose={() => setShowImageEditModal(false)}
+                        />
+                    )}
+
                     {isCommitAnnotationEnabled && (
                         <ConfigurationSettingsField>
                             <Heading3>Insights</Heading3>
@@ -252,28 +274,6 @@ export default function TeamSettingsPage() {
                                     label=""
                                 />
                             </InputField>
-                        </ConfigurationSettingsField>
-                    )}
-
-                    {showImageEditModal && (
-                        <OrgDefaultWorkspaceImageModal
-                            settings={settings}
-                            installationDefaultWorkspaceImage={installationDefaultImage}
-                            onClose={() => setShowImageEditModal(false)}
-                        />
-                    )}
-
-                    {org?.id && (
-                        <ConfigurationSettingsField>
-                            <Heading3>Docker Registry authentication</Heading3>
-                            <Subheading>Configure Docker registry permissions for the whole organization.</Subheading>
-
-                            <NamedOrganizationEnvvarItem
-                                disabled={!isOwner}
-                                name={EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME}
-                                organizationId={org.id}
-                                variable={gitpodImageAuthEnvVar}
-                            />
                         </ConfigurationSettingsField>
                     )}
 


### PR DESCRIPTION
## Description

Re-order the settings for `GITPOD_IMAGE_AUTH`, so that it's right next to the related workspace image settings.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://gitpod.slack.com/archives/C071G5TTS49/p1737732283525949

## How to test

Take a look at the preview environment's org settings.

https://ft-reorder0de6b997d6.preview.gitpod-dev.com/settings

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ft-reorder0de6b997d6</li>
	<li><b>🔗 URL</b> - <a href="https://ft-reorder0de6b997d6.preview.gitpod-dev.com/workspaces" target="_blank">ft-reorder0de6b997d6.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ft-reorder-org-docker-settings-gha.31162</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ft-reorder0de6b997d6%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

- [x] /werft with-preview
/hold
