### PR TITLE
[server] Add organization image auth context to workspace image validation

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -412,9 +412,9 @@ export const productionContainerModule = new ContainerModule(
         bind<DefaultWorkspaceImageValidator>(DefaultWorkspaceImageValidator)
             .toDynamicValue((ctx) =>
                 // lazy load to avoid circular dependency
-                async (userId: string, imageRef: string) => {
+                async (userId: string, imageRef: string, organizationId?: string) => {
                     const user = await ctx.container.get(UserService).findUserById(userId, userId);
-                    await ctx.container.get(WorkspaceService).validateImageRef({}, user, imageRef);
+                    await ctx.container.get(WorkspaceService).validateImageRef({}, user, imageRef, organizationId);
                 },
             )
             .inSingletonScope();

--- a/components/server/src/orgs/default-workspace-image-validator.ts
+++ b/components/server/src/orgs/default-workspace-image-validator.ts
@@ -4,5 +4,9 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
-export type DefaultWorkspaceImageValidator = (userId: string, imageRef: string) => Promise<void>;
+export type DefaultWorkspaceImageValidator = (
+    userId: string,
+    imageRef: string,
+    organizationId?: string,
+) => Promise<void>;
 export const DefaultWorkspaceImageValidator = Symbol("DefaultWorkspaceImageValidator");

--- a/components/server/src/orgs/organization-service.ts
+++ b/components/server/src/orgs/organization-service.ts
@@ -493,7 +493,7 @@ export class OrganizationService {
         if (typeof settings.defaultWorkspaceImage === "string") {
             const defaultWorkspaceImage = settings.defaultWorkspaceImage.trim();
             if (defaultWorkspaceImage) {
-                await this.validateDefaultWorkspaceImage(userId, defaultWorkspaceImage);
+                await this.validateDefaultWorkspaceImage(userId, defaultWorkspaceImage, orgId);
                 settings = { ...settings, defaultWorkspaceImage };
             } else {
                 settings = { ...settings, defaultWorkspaceImage: null };

--- a/components/server/src/user/env-var-service.ts
+++ b/components/server/src/user/env-var-service.ts
@@ -234,6 +234,13 @@ export class EnvVarService {
         return this.orgDB.getOrgEnvironmentVariables(orgId);
     }
 
+    async listOrgEnvVarsWithValues(requestorId: string, orgId: string): Promise<OrgEnvVarWithValue[]> {
+        const envVars = (await ApplicationError.notFoundToUndefined(this.listOrgEnvVars(requestorId, orgId))) ?? [];
+        const envVarValues = await this.orgDB.getOrgEnvironmentVariableValues(envVars);
+
+        return envVarValues;
+    }
+
     async getOrgEnvVarById(requestorId: string, id: string): Promise<OrgEnvVar> {
         const result = await this.orgDB.getOrgEnvironmentVariableById(id);
         if (!result) {

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -1407,9 +1407,17 @@ export class WorkspaceService {
         });
     }
 
-    public async validateImageRef(ctx: TraceContext, user: User, imageRef: string) {
+    public async validateImageRef(ctx: TraceContext, user: User, imageRef: string, organizationId?: string) {
         try {
-            return await this.workspaceStarter.resolveBaseImage(ctx, user, imageRef);
+            return await this.workspaceStarter.resolveBaseImage(
+                ctx,
+                user,
+                imageRef,
+                undefined,
+                undefined,
+                undefined,
+                organizationId,
+            );
         } catch (e) {
             // see https://github.com/gitpod-io/gitpod/blob/f3e41f8d86234e4101edff2199c54f50f8cbb656/components/image-builder-mk3/pkg/orchestrator/orchestrator.go#L561
             // TODO(ak) ideally we won't check a message (subject to change)
@@ -1423,8 +1431,8 @@ export class WorkspaceService {
             ) {
                 let message = details;
                 // strip confusing prefix
-                if (details.startsWith("cannt resolve base image ref: ")) {
-                    message = details.substring("cannt resolve base image ref: ".length);
+                if (details.startsWith("can't resolve base image ref: ")) {
+                    message = details.substring("can't resolve base image ref: ".length);
                 }
                 throw new ApplicationError(ErrorCodes.BAD_REQUEST, message);
             }

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -42,7 +42,6 @@ import {
     ImageBuildLogInfo,
     ImageConfigFile,
     NamedWorkspaceFeatureFlag,
-    OrgEnvVarWithValue,
     Permission,
     Project,
     RefType,
@@ -129,7 +128,7 @@ import { TokenProvider } from "../user/token-provider";
 import { UserAuthentication } from "../user/user-authentication";
 import { ImageSourceProvider } from "./image-source-provider";
 import { WorkspaceClassesConfig } from "./workspace-classes";
-import { SYSTEM_USER, SYSTEM_USER_ID, Authorizer } from "../authorization/authorizer";
+import { SYSTEM_USER, SYSTEM_USER_ID } from "../authorization/authorizer";
 import { EnvVarService, ResolvedEnvVars } from "../user/env-var-service";
 import { RedlockAbortSignal } from "redlock";
 import { ConfigProvider } from "./config-provider";
@@ -240,7 +239,6 @@ export class WorkspaceStarter {
         @inject(EnvVarService) private readonly envVarService: EnvVarService,
         @inject(OrganizationService) private readonly orgService: OrganizationService,
         @inject(ProjectsService) private readonly projectService: ProjectsService,
-        @inject(Authorizer) private readonly auth: Authorizer,
     ) {}
 
     public async startWorkspace(
@@ -2047,11 +2045,9 @@ export class WorkspaceStarter {
 
         // if the image resolution is for an organization, we also include the organization's set up env vars
         if (organizationId) {
-            await this.auth.checkPermissionOnOrganization(user.id, "read_env_var", organizationId);
-            const orgEnvVars = await this.orgDB.getOrgEnvironmentVariables(organizationId);
-            const orgEnvVarValues: OrgEnvVarWithValue[] = await this.orgDB.getOrgEnvironmentVariableValues(orgEnvVars);
+            const envVars = await this.envVarService.listOrgEnvVarsWithValues(user.id, organizationId);
 
-            const additionalAuth = await this.getAdditionalImageAuth({ workspace: orgEnvVarValues });
+            const additionalAuth = await this.getAdditionalImageAuth({ workspace: envVars });
             additionalAuth.forEach((val, key) => auth.getAdditionalMap().set(key, val));
         }
 


### PR DESCRIPTION
## Description

As a follow-up to https://github.com/gitpod-io/gitpod/pull/20538, this PR adds org-level `GITPOD_IMAGE_AUTH` authentication for base image validation.

This is relevant for validating workspace images when tweaking the organization settings and setting a new custom default workspace image.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1104

## How to test

1. Sign up for https://ft-fix-add83ebcff3ec.preview.gitpod-dev.com/settings
2. After you've signed up, try setting `geropl/workspace-base:latest` as the default workspace image. It should not let you and result with an error
3. [Join my org](https://ft-fix-add83ebcff3ec.preview.gitpod-dev.com/orgs/join?inviteId=dfba92d4-b841-45d6-8638-7c312af8bfae) and try the same again, now it should let you proceed
4. Try setting the Docker Registry authentication on the same Organization settings page and after saving that, try setting the default workspace image again with the same value as above - this time, it should work.

/hold
