### PR TITLE
[server] make gRPC clients viable in non-HTTP/2-compatible environments

### DIFF
--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -124,7 +124,6 @@ function createServiceClient<T extends ServiceType>(
                     return grpcClient;
                 }
                 if (preferJsonRpc) {
-                    console.debug("using preferred jsonrpc client for", type.typeName, prop);
                     return jsonRpcOptions.client;
                 }
                 const featureFlags = [`dashboard_public_api_${jsonRpcOptions.featureFlagSuffix}_enabled`];

--- a/components/dashboard/src/service/public-api.ts
+++ b/components/dashboard/src/service/public-api.ts
@@ -10,11 +10,8 @@ import { CallOptions, Code, ConnectError, PromiseClient, createPromiseClient } f
 import { createConnectTransport } from "@connectrpc/connect-web";
 import { Disposable } from "@gitpod/gitpod-protocol";
 import { PublicAPIConverter } from "@gitpod/public-api-common/lib/public-api-converter";
-import { Project as ProtocolProject } from "@gitpod/gitpod-protocol/lib/teams-projects-protocol";
 import { HelloService } from "@gitpod/public-api/lib/gitpod/experimental/v1/dummy_connect";
 import { OIDCService } from "@gitpod/public-api/lib/gitpod/experimental/v1/oidc_connect";
-import { ProjectsService } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_connect";
-import { Project } from "@gitpod/public-api/lib/gitpod/experimental/v1/projects_pb";
 import { TokensService } from "@gitpod/public-api/lib/gitpod/experimental/v1/tokens_connect";
 import { OrganizationService } from "@gitpod/public-api/lib/gitpod/v1/organization_connect";
 import { WorkspaceService } from "@gitpod/public-api/lib/gitpod/v1/workspace_connect";
@@ -52,10 +49,6 @@ export const converter = new PublicAPIConverter();
 
 export const helloService = createServiceClient(HelloService);
 export const personalAccessTokensService = createPromiseClient(TokensService, transport);
-/**
- * @deprecated use configurationClient instead
- */
-export const projectsService = createPromiseClient(ProjectsService, transport);
 
 export const oidcService = createPromiseClient(OIDCService, transport);
 
@@ -68,7 +61,7 @@ export const organizationClient = createServiceClient(OrganizationService, {
     featureFlagSuffix: "organization",
 });
 
-// No jsonrcp client for the configuration service as it's only used in new UI of the dashboard
+// No jsonrpc client for the configuration service as it's only used in new UI of the dashboard
 export const configurationClient = createServiceClient(ConfigurationService);
 export const prebuildClient = createServiceClient(PrebuildService, {
     client: new JsonRpcPrebuildClient(),
@@ -110,56 +103,6 @@ export const installationClient = createServiceClient(InstallationService, {
     featureFlagSuffix: "installation",
 });
 
-export async function listAllProjects(opts: { orgId: string }): Promise<ProtocolProject[]> {
-    let pagination = {
-        page: 1,
-        pageSize: 100,
-    };
-
-    const response = await projectsService.listProjects({
-        teamId: opts.orgId,
-        pagination,
-    });
-    const results = response.projects;
-
-    while (results.length < response.totalResults) {
-        pagination = {
-            pageSize: 100,
-            page: 1 + pagination.page,
-        };
-        const response = await projectsService.listProjects({
-            teamId: opts.orgId,
-            pagination,
-        });
-        results.push(...response.projects);
-    }
-
-    return results.map(projectToProtocol);
-}
-
-export function projectToProtocol(project: Project): ProtocolProject {
-    return {
-        id: project.id,
-        name: project.name,
-        cloneUrl: project.cloneUrl,
-        creationTime: project.creationTime?.toDate().toISOString() || "",
-        teamId: project.teamId,
-        appInstallationId: "undefined",
-        settings: {
-            workspaceClasses: {
-                regular: project.settings?.workspace?.workspaceClass?.regular || "",
-            },
-            prebuilds: {
-                enable: project.settings?.prebuild?.enablePrebuilds,
-                branchStrategy: project.settings?.prebuild?.branchStrategy as any,
-                branchMatchingPattern: project.settings?.prebuild?.branchMatchingPattern,
-                prebuildInterval: project.settings?.prebuild?.prebuildInterval,
-                workspaceClass: project.settings?.prebuild?.workspaceClass,
-            },
-        },
-    };
-}
-
 let user: { id: string; email?: string } | undefined;
 export function updateUserForExperiments(newUser?: { id: string; email?: string }) {
     user = newUser;
@@ -176,9 +119,13 @@ function createServiceClient<T extends ServiceType>(
         get(grpcClient, prop) {
             const experimentsClient = getExperimentsClient();
             // TODO(ak) remove after migration
-            async function resolveClient(): Promise<PromiseClient<T>> {
+            async function resolveClient(preferJsonRpc?: boolean): Promise<PromiseClient<T>> {
                 if (!jsonRpcOptions) {
                     return grpcClient;
+                }
+                if (preferJsonRpc) {
+                    console.debug("using preferred jsonrpc client for", type.typeName, prop);
+                    return jsonRpcOptions.client;
                 }
                 const featureFlags = [`dashboard_public_api_${jsonRpcOptions.featureFlagSuffix}_enabled`];
                 const resolvedFlags = await Promise.all(
@@ -241,7 +188,8 @@ function createServiceClient<T extends ServiceType>(
                 }
                 return (async function* () {
                     try {
-                        const client = await resolveClient();
+                        // for server streaming, we prefer jsonRPC
+                        const client = await resolveClient(true);
                         const generator = Reflect.apply(client[prop as any], client, args) as AsyncGenerator<any>;
                         for await (const item of generator) {
                             yield item;

--- a/components/dashboard/src/service/service.tsx
+++ b/components/dashboard/src/service/service.tsx
@@ -33,7 +33,7 @@ import { sendTrackEvent } from "../Analytics";
 export const gitpodHostUrl = new GitpodHostUrl(window.location.toString());
 
 function createGitpodService<C extends GitpodClient, S extends GitpodServer>() {
-    let host = gitpodHostUrl.asWebsocket().with({ pathname: GitpodServerPath }).withApi();
+    const host = gitpodHostUrl.asWebsocket().with({ pathname: GitpodServerPath }).withApi();
 
     const connectionProvider = new WebSocketConnectionProvider();
     instrumentWebSocketConnection(connectionProvider);

--- a/components/gitpod-db/src/redis/publisher.ts
+++ b/components/gitpod-db/src/redis/publisher.ts
@@ -23,13 +23,13 @@ export class RedisPublisher {
     constructor(@inject(Redis) private readonly redis: Redis) {}
 
     async publishPrebuildUpdate(update: RedisPrebuildUpdate): Promise<void> {
-        log.debug("[redis] Publish prebuild udpate invoked.");
+        log.debug("[redis] Publish prebuild update invoked.");
 
         let err: Error | undefined;
         try {
             const serialized = JSON.stringify(update);
             await this.redis.publish(PrebuildUpdatesChannel, serialized);
-            log.debug("[redis] Succesfully published prebuild update.", update);
+            log.debug("[redis] Successfully published prebuild update.", update);
         } catch (e) {
             err = e;
             log.error("[redis] Failed to publish prebuild update.", e, update);
@@ -43,7 +43,7 @@ export class RedisPublisher {
         try {
             const serialized = JSON.stringify(update);
             await this.redis.publish(WorkspaceInstanceUpdatesChannel, serialized);
-            log.debug("[redis] Succesfully published instance update.", update);
+            log.debug("[redis] Successfully published instance update.", update);
         } catch (e) {
             err = e;
             log.error("[redis] Failed to publish instance update.", e, update);
@@ -53,13 +53,13 @@ export class RedisPublisher {
     }
 
     async publishHeadlessUpdate(update: RedisHeadlessUpdate): Promise<void> {
-        log.debug("[redis] Publish headless udpate invoked.");
+        log.debug("[redis] Publish headless update invoked.");
 
         let err: Error | undefined;
         try {
             const serialized = JSON.stringify(update);
             await this.redis.publish(HeadlessUpdatesChannel, serialized);
-            log.debug("[redis] Succesfully published headless update.", update);
+            log.debug("[redis] Successfully published headless update.", update);
         } catch (e) {
             err = e;
             log.error("[redis] Failed to publish headless update.", e, update);

--- a/components/gitpod-protocol/src/redis.ts
+++ b/components/gitpod-protocol/src/redis.ts
@@ -22,6 +22,7 @@ export type RedisPrebuildUpdate = {
     prebuildID: string;
     workspaceID: string;
     projectID: string;
+    organizationID?: string;
 };
 
 export type RedisHeadlessUpdate = {

--- a/components/server/src/messaging/redis-subscriber.ts
+++ b/components/server/src/messaging/redis-subscriber.ts
@@ -67,7 +67,7 @@ export class RedisSubscriber {
                 let err: Error | undefined;
                 try {
                     await this.onMessage(channel, message);
-                    log.debug("[redis] Succesfully handled update", { channel, message });
+                    log.debug("[redis] Successfully handled update", { channel, message });
                 } catch (e) {
                     err = e;
                     log.error("[redis] Failed to handle message from Pub/Sub", e, { channel, message });
@@ -132,7 +132,10 @@ export class RedisSubscriber {
             return;
         }
 
-        const listeners = this.prebuildUpdateListeners.get(update.projectID) || [];
+        const listeners = this.prebuildUpdateListeners.get(update.projectID) ?? [];
+        if (update.organizationID) {
+            listeners.push(...(this.prebuildUpdateListeners.get(update.organizationID) ?? []));
+        }
         if (listeners.length === 0) {
             return;
         }
@@ -182,8 +185,12 @@ export class RedisSubscriber {
         this.disposables.dispose();
     }
 
-    listenForPrebuildUpdates(projectId: string, listener: PrebuildUpdateListener): Disposable {
+    listenForProjectPrebuildUpdates(projectId: string, listener: PrebuildUpdateListener): Disposable {
         return this.doRegister(projectId, listener, this.prebuildUpdateListeners, "prebuild");
+    }
+
+    listenForOrganizationPrebuildUpdates(organizationId: string, listener: PrebuildUpdateListener): Disposable {
+        return this.doRegister(organizationId, listener, this.prebuildUpdateListeners, "prebuild");
     }
 
     listenForPrebuildUpdatableEvents(listener: HeadlessWorkspaceEventListener): Disposable {

--- a/components/server/src/prebuilds/prebuild-manager.ts
+++ b/components/server/src/prebuilds/prebuild-manager.ts
@@ -100,7 +100,7 @@ export class PrebuildManager {
         await this.auth.checkPermissionOnProject(userId, "read_prebuild", configurationId);
         return generateAsyncGenerator<PrebuildWithStatus>((sink) => {
             try {
-                const toDispose = this.subscriber.listenForPrebuildUpdates(configurationId, (_ctx, prebuild) => {
+                const toDispose = this.subscriber.listenForProjectPrebuildUpdates(configurationId, (_ctx, prebuild) => {
                     sink.push(prebuild);
                 });
                 return () => {

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -242,7 +242,8 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
     }
 
     private async listenForPrebuildUpdates(ctx?: TraceContext) {
-        if (!this.client) {
+        const userId = this.userID;
+        if (!this.client || !userId) {
             return;
         }
 
@@ -258,19 +259,19 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 ctx,
             );
 
-        if (!this.disposables.disposed && this.userID) {
+        if (!this.disposables.disposed) {
             await runWithRequestContext(
                 {
                     requestKind: "gitpod-server-impl-listener",
                     requestMethod: "listenForPrebuildUpdates",
                     signal: new AbortController().signal,
-                    subjectId: SubjectId.fromUserId(this.userID),
+                    subjectId: SubjectId.fromUserId(userId),
                 },
                 async () => {
                     const organizations = await this.getTeams(ctx ?? {});
                     for (const organization of organizations) {
                         const hasPermission = await this.auth.hasPermissionOnOrganization(
-                            this.userID,
+                            userId,
                             "read_prebuild",
                             organization.id,
                         );

--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -236,29 +236,15 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
         log.debug({ userId: this.userID }, "initializeClient");
 
         this.listenForWorkspaceInstanceUpdates();
-        this.listenForPrebuildUpdates().catch((err) => log.error("error registering for prebuild updates", err));
+        this.listenForPrebuildUpdates(connectionCtx).catch((err) =>
+            log.error("error registering for prebuild updates", err),
+        );
     }
 
-    private async listenForPrebuildUpdates() {
+    private async listenForPrebuildUpdates(ctx?: TraceContext) {
         if (!this.client) {
             return;
         }
-
-        // todo(ft) disable registering for all updates from all projects by default and only listen to updates when the client is explicity interested in them
-        const disableWebsocketPrebuildUpdates = await getExperimentsClientForBackend().getValueAsync(
-            "disableWebsocketPrebuildUpdates",
-            false,
-            {
-                gitpodHost: this.config.hostUrl.url.host,
-            },
-        );
-        if (disableWebsocketPrebuildUpdates) {
-            log.info("ws prebuild updates disabled by feature flag");
-            return;
-        }
-
-        // 'registering for prebuild updates for all projects this user has access to
-        const projects = await this.getAccessibleProjects();
 
         const handler = (ctx: TraceContext, update: PrebuildWithStatus) =>
             TraceContext.withSpan(
@@ -272,39 +258,31 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                 ctx,
             );
 
-        if (!this.disposables.disposed) {
-            for (const project of projects) {
-                this.disposables.push(this.subscriber.listenForPrebuildUpdates(project.id, handler));
-            }
+        if (!this.disposables.disposed && this.userID) {
+            await runWithRequestContext(
+                {
+                    requestKind: "gitpod-server-impl-listener",
+                    requestMethod: "listenForPrebuildUpdates",
+                    signal: new AbortController().signal,
+                    subjectId: SubjectId.fromUserId(this.userID),
+                },
+                async () => {
+                    const organizations = await this.getTeams(ctx ?? {});
+                    for (const organization of organizations) {
+                        const hasPermission = await this.auth.hasPermissionOnOrganization(
+                            this.userID,
+                            "read_prebuild",
+                            organization.id,
+                        );
+                        if (hasPermission) {
+                            this.disposables.push(
+                                this.subscriber.listenForOrganizationPrebuildUpdates(organization.id, handler),
+                            );
+                        }
+                    }
+                },
+            );
         }
-
-        // TODO(at) we need to keep the list of accessible project up to date
-    }
-
-    private async getAccessibleProjects() {
-        const userId = this.userID;
-        if (!userId) {
-            return [];
-        }
-
-        // update all project this user has access to
-        // gpl: This call to runWithRequestContext is not nice, but it's only there to please the old impl for a limited time, so it's fine.
-        return runWithRequestContext(
-            {
-                requestKind: "gitpod-server-impl-listener",
-                requestMethod: "getAccessibleProjects",
-                signal: new AbortController().signal,
-                subjectId: SubjectId.fromUserId(userId),
-            },
-            async () => {
-                const allProjects: Project[] = [];
-                const teams = await this.organizationService.listOrganizationsByMember(userId, userId);
-                for (const team of teams) {
-                    allProjects.push(...(await this.projectsService.getProjects(userId, team.id)));
-                }
-                return allProjects;
-            },
-        );
     }
 
     private listenForWorkspaceInstanceUpdates(): void {
@@ -497,9 +475,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
 
     /**
      * Returns the descriptions of auth providers. This also controls the visibility of
-     * auth providers on the dashbard.
+     * auth providers on the dashboard.
      *
-     * If this call is unauthenticated (i.e. for anonumous users,) it returns only information
+     * If this call is unauthenticated (i.e. for anonymous users,) it returns only information
      * necessary for the Login page.
      *
      * If there are built-in auth providers configured, only these are returned.
@@ -1701,7 +1679,9 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                     ctx,
                 );
 
-            this.disposables.pushAll([this.subscriber.listenForPrebuildUpdates(project.id, prebuildUpdateHandler)]);
+            this.disposables.pushAll([
+                this.subscriber.listenForProjectPrebuildUpdates(project.id, prebuildUpdateHandler),
+            ]);
         }
 
         return project;

--- a/components/server/src/workspace/workspace-starter.ts
+++ b/components/server/src/workspace/workspace-starter.ts
@@ -914,6 +914,7 @@ export class WorkspaceStarter {
                         prebuildID: prebuild.id,
                         projectID: prebuild.projectId,
                         workspaceID: workspace.id,
+                        organizationID: workspace.organizationId,
                     });
                 }
             }

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -17,7 +17,7 @@ schema: |-
 
       permission make_admin = installation->admin + organization->installation_admin
 
-      // administrate is for changes such as blocking or verifying, i.e. things that only admins can do on user
+      // administrate is for changes such as blocking or verifiying, i.e. things that only admins can do on user
       permission admin_control = installation->admin + organization->installation_admin
 
       permission read_ssh = self

--- a/components/spicedb/schema/schema.yaml
+++ b/components/spicedb/schema/schema.yaml
@@ -17,7 +17,7 @@ schema: |-
 
       permission make_admin = installation->admin + organization->installation_admin
 
-      // administrate is for changes such as blocking or verifiying, i.e. things that only admins can do on user
+      // administrate is for changes such as blocking or verifying, i.e. things that only admins can do on user
       permission admin_control = installation->admin + organization->installation_admin
 
       permission read_ssh = self

--- a/components/ws-manager-bridge/src/prebuild-updater.ts
+++ b/components/ws-manager-bridge/src/prebuild-updater.ts
@@ -39,7 +39,6 @@ export class PrebuildUpdater {
         const span = TraceContext.startSpan("updatePrebuiltWorkspace", ctx);
         try {
             const prebuild = await this.workspaceDB.trace({ span }).findPrebuildByWorkspaceID(status.metadata!.metaId!);
-            const workspace = await this.workspaceDB.trace({ span }).findById(workspaceId);
             if (!prebuild) {
                 log.warn(logCtx, "Headless workspace without prebuild");
                 TraceContext.setError({ span }, new Error("headless workspace without prebuild"));
@@ -99,7 +98,7 @@ export class PrebuildUpdater {
                         prebuildID: updatedPrebuild.id,
                         status: updatedPrebuild.state,
                         workspaceID: workspaceId,
-                        organizationID: workspace?.organizationId,
+                        organizationID: info.teamId,
                     });
                 }
             }
@@ -115,7 +114,6 @@ export class PrebuildUpdater {
         const span = TraceContext.startSpan("stopPrebuildInstance", ctx);
 
         const prebuild = await this.workspaceDB.trace({}).findPrebuildByWorkspaceID(instance.workspaceId);
-        const workspace = await this.workspaceDB.trace({}).findById(instance.workspaceId);
         if (prebuild) {
             // this is a prebuild - set it to aborted
             prebuild.state = "aborted";
@@ -130,7 +128,7 @@ export class PrebuildUpdater {
                         prebuildID: prebuild.id,
                         status: prebuild.state,
                         workspaceID: instance.workspaceId,
-                        organizationID: workspace?.organizationId,
+                        organizationID: info.teamId,
                     });
                 }
             }

--- a/components/ws-manager-bridge/src/prebuild-updater.ts
+++ b/components/ws-manager-bridge/src/prebuild-updater.ts
@@ -39,6 +39,7 @@ export class PrebuildUpdater {
         const span = TraceContext.startSpan("updatePrebuiltWorkspace", ctx);
         try {
             const prebuild = await this.workspaceDB.trace({ span }).findPrebuildByWorkspaceID(status.metadata!.metaId!);
+            const workspace = await this.workspaceDB.trace({ span }).findById(workspaceId);
             if (!prebuild) {
                 log.warn(logCtx, "Headless workspace without prebuild");
                 TraceContext.setError({ span }, new Error("headless workspace without prebuild"));
@@ -98,6 +99,7 @@ export class PrebuildUpdater {
                         prebuildID: updatedPrebuild.id,
                         status: updatedPrebuild.state,
                         workspaceID: workspaceId,
+                        organizationID: workspace?.organizationId,
                     });
                 }
             }
@@ -113,6 +115,7 @@ export class PrebuildUpdater {
         const span = TraceContext.startSpan("stopPrebuildInstance", ctx);
 
         const prebuild = await this.workspaceDB.trace({}).findPrebuildByWorkspaceID(instance.workspaceId);
+        const workspace = await this.workspaceDB.trace({}).findById(instance.workspaceId);
         if (prebuild) {
             // this is a prebuild - set it to aborted
             prebuild.state = "aborted";
@@ -127,6 +130,7 @@ export class PrebuildUpdater {
                         prebuildID: prebuild.id,
                         status: prebuild.state,
                         workspaceID: instance.workspaceId,
+                        organizationID: workspace?.organizationId,
                     });
                 }
             }


### PR DESCRIPTION
## Description

This PR makes a couple of related changes:
- most notably, whenever determining what client an API request should use, we always prefer the jsonRPC client if it's available and the request is a server-side-streaming request --> this should eliminate our HTTP/2 problems, hopefully
- removes the use of `disableWebsocketPrebuildUpdates`, and instead introduces a by-organization subscription for prebuild updates. This makes the listening much more efficient (requiring way fewer listeners) and scales well even with thousands of projects. Permission-wise, it relies on the organization's `read_prebuild` permission.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1106

## How to test

1. Sign up for https://ft-stream-websockets.preview.gitpod-dev.com/workspaces
2. Try running a prebuild. It should stream updates via a websocket, but you should get other API requests to the prebuild service through gRPC.
