### PR TITLE
[server] Don't block soft deletion rewinds in `updateDeletionEligibilityTime`

### DIFF
--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -568,13 +568,10 @@ export class WorkspaceService {
                 daysToLive = daysToLive * 2;
             }
             deletionEligibilityTime.setDate(deletionEligibilityTime.getDate() + daysToLive);
-            if (
-                workspace.deletionEligibilityTime &&
-                workspace.deletionEligibilityTime > deletionEligibilityTime.toISOString()
-            ) {
+            if (new Date() > deletionEligibilityTime) {
                 log.warn(
                     { userId, workspaceId, instanceId: instance?.id },
-                    "[updateDeletionEligibilityTime] Prevented moving deletion eligibility time backwards",
+                    "[updateDeletionEligibilityTime] Prevented moving deletion eligibility time to the past",
                     {
                         hasGitChanges,
                         timestamps: new TrustedValue({

--- a/components/server/src/workspace/workspace-service.ts
+++ b/components/server/src/workspace/workspace-service.ts
@@ -568,7 +568,7 @@ export class WorkspaceService {
                 daysToLive = daysToLive * 2;
             }
             deletionEligibilityTime.setDate(deletionEligibilityTime.getDate() + daysToLive);
-            if (new Date() > deletionEligibilityTime) {
+            if (new Date().toISOString() > deletionEligibilityTime.toISOString()) {
                 log.warn(
                     { userId, workspaceId, instanceId: instance?.id },
                     "[updateDeletionEligibilityTime] Prevented moving deletion eligibility time to the past",


### PR DESCRIPTION
## Description

Reverts a behavior we introduced in https://github.com/gitpod-io/gitpod/pull/20271 that prevented shifting the `deletionEligibilityTime` of a workspace backwards. This was problematic because workspaces with git changes are meant to live twice as long, but this change it made it so that "any workspace that ever had git changes" lived twice as long.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fix CLC-1070


/hold
