### PR TITLE
Fix image build failed for GAR

### DIFF
--- a/components/image-builder-bob/pkg/proxy/proxy.go
+++ b/components/image-builder-bob/pkg/proxy/proxy.go
@@ -60,7 +60,7 @@ func rewriteDockerAPIURL(u *url.URL, fromRepo, toRepo, host, tag string) {
 		from = "/v2/" + strings.Trim(fromRepo, "/") + "/"
 		to   = "/v2/" + strings.Trim(toRepo, "/") + "/"
 	)
-	u.Path = to + strings.TrimPrefix(u.Path, from)
+	u.Path = to + strings.TrimPrefix(strings.TrimPrefix(u.Path, from), "/")
 
 	// we reset the escaped encoding hint, because EscapedPath will produce a valid encoding.
 	u.RawPath = ""
@@ -95,7 +95,7 @@ func rewriteNonDockerAPIURL(u *url.URL, fromPrefix, toPrefix, host string) {
 	if toPrefix == "" {
 		to = "/"
 	}
-	u.Path = to + strings.TrimPrefix(u.Path, from)
+	u.Path = to + strings.TrimPrefix(strings.TrimPrefix(u.Path, from), "/")
 
 	// we reset the escaped encoding hint, because EscapedPath will produce a valid encoding.
 	u.RawPath = ""

--- a/components/image-builder-bob/pkg/proxy/proxy_test.go
+++ b/components/image-builder-bob/pkg/proxy/proxy_test.go
@@ -70,6 +70,22 @@ func TestRewriteNonDockerAPIURL(t *testing.T) {
 			},
 		},
 		{
+			Name: "fromPrefix and toPrefix are not empty and origin url is not start with fromPrefix",
+			in: input{
+				fromPrefix: "from",
+				toPrefix:   "to",
+				host:       "localhost.com",
+				u: url.URL{
+					Host: "example.com",
+					Path: "/other-string/some/random/path",
+				},
+			},
+			u: url.URL{
+				Host: "localhost.com",
+				Path: "/to/other-string/some/random/path",
+			},
+		},
+		{
 			Name: "fromPrefix and toPrefix are empty",
 			in: input{
 				fromPrefix: "",
@@ -132,6 +148,23 @@ func TestRewriteDockerAPIURL(t *testing.T) {
 			u: url.URL{
 				Host: "localhost.com",
 				Path: "/v2/base/some/random/path",
+			},
+		},
+		{
+			Name: "remote to localhost without repo",
+			in: input{
+				fromRepo: "base-images",
+				toRepo:   "base",
+				host:     "localhost.com",
+				tag:      "",
+				u: url.URL{
+					Host: "prince.azurecr.io",
+					Path: "/v2/other-string/some/random/path",
+				},
+			},
+			u: url.URL{
+				Host: "localhost.com",
+				Path: "/v2/base/v2/other-string/some/random/path",
 			},
 		},
 		{


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Fix image build failed for GAR
## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1099

## How to test
<!-- Provide steps to test this PR -->
1. create a dummy repo, and use image from https://hub.docker.com/r/gitpod/workspace-base/tags (You can choose an image that has never been used before. The key point here is that you need to re-trigger the image build function and upload at least one blob file)
2. try start workspace  from that repo in different preview env, make sure it failed.
3. try start workspace from that repo with this preview env, it will start image build and it should success

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-clc-1099</li>
	<li><b>🔗 URL</b> - <a href="https://pd-clc-1099.preview.gitpod-dev.com/workspaces" target="_blank">pd-clc-1099.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-CLC-1099-gha.31367</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-clc-1099%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
