### PR TITLE
Fix main build

### DIFF
--- a/components/public-api/typescript-common/fixtures/fromPartialConfiguration_2.golden
+++ b/components/public-api/typescript-common/fixtures/fromPartialConfiguration_2.golden
@@ -2,15 +2,15 @@
     "result": {
         "id": "123",
         "settings": {
+            "workspaceClasses": {
+                "regular": "huge"
+            },
             "prebuilds": {
                 "enable": true,
                 "prebuildInterval": 5,
                 "cloneSettings": {
                     "fullClone": false
                 }
-            },
-            "workspaceClasses": {
-                "regular": "huge"
             }
         }
     },

--- a/components/public-api/typescript-common/fixtures/fromPartialConfiguration_3.golden
+++ b/components/public-api/typescript-common/fixtures/fromPartialConfiguration_3.golden
@@ -2,20 +2,20 @@
     "result": {
         "id": "123",
         "settings": {
-            "prebuilds": {
-                "enable": true,
-                "prebuildInterval": 5,
-                "cloneSettings": {
-                    "fullClone": false
-                }
-            },
             "workspaceClasses": {
                 "regular": "huge"
             },
             "restrictedWorkspaceClasses": [
                 "huge",
                 "large"
-            ]
+            ],
+            "prebuilds": {
+                "enable": true,
+                "prebuildInterval": 5,
+                "cloneSettings": {
+                    "fullClone": false
+                }
+            }
         }
     },
     "err": ""

--- a/components/public-api/typescript-common/fixtures/toConfiguration_1.golden
+++ b/components/public-api/typescript-common/fixtures/toConfiguration_1.golden
@@ -19,7 +19,8 @@
         "workspaceSettings": {
             "workspaceClass": "dev",
             "restrictedWorkspaceClasses": [],
-            "restrictedEditorNames": []
+            "restrictedEditorNames": [],
+            "enableDockerdAuthentication": false
         }
     },
     "err": ""

--- a/components/public-api/typescript-common/fixtures/toConfiguration_2.golden
+++ b/components/public-api/typescript-common/fixtures/toConfiguration_2.golden
@@ -22,7 +22,8 @@
                 "cls-1",
                 "cls-2"
             ],
-            "restrictedEditorNames": []
+            "restrictedEditorNames": [],
+            "enableDockerdAuthentication": false
         }
     },
     "err": ""

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_1.golden
@@ -2,7 +2,8 @@
     "result": {
         "workspaceClass": "dev",
         "restrictedWorkspaceClasses": [],
-        "restrictedEditorNames": []
+        "restrictedEditorNames": [],
+        "enableDockerdAuthentication": false
     },
     "err": ""
 }

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_2.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_2.golden
@@ -2,7 +2,8 @@
     "result": {
         "workspaceClass": "",
         "restrictedWorkspaceClasses": [],
-        "restrictedEditorNames": []
+        "restrictedEditorNames": [],
+        "enableDockerdAuthentication": false
     },
     "err": ""
 }

--- a/components/public-api/typescript-common/fixtures/toWorkspaceSettings_3.golden
+++ b/components/public-api/typescript-common/fixtures/toWorkspaceSettings_3.golden
@@ -5,7 +5,8 @@
             "g1",
             "g2"
         ],
-        "restrictedEditorNames": []
+        "restrictedEditorNames": [],
+        "enableDockerdAuthentication": false
     },
     "err": ""
 }


### PR DESCRIPTION
Content is generated by `yarn test:forceUpdate`, changes looks good

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://github.com/gitpod-io/gitpod/actions/runs/13306529851/job/37158749104

## How to test
<!-- Provide steps to test this PR -->
PR build should be passed

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
