### PR TITLE
[server] add feature flags for spicedb client options

### DIFF
--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -105,11 +105,14 @@ export class SpiceDBClientProvider {
                         clientOptions: new TrustedValue(clientOptions),
                     });
 
+                    // close client after 10s to make sure most pending requests on the previous client are finished.
                     setTimeout(() => {
                         this.closeClient(oldClient);
                     }, 10 * 1000);
                 }
                 this.clientOptions = clientOptions;
+                // `createClient` will use the `DefaultClientOptions` to create client if the value on Feature Flag is not able to create a client
+                // but we will still write `previousClientOptionsString` here to avoid retry with that incorrect value again
                 this.previousClientOptionsString = customClientOptions;
             } catch (e) {
                 log.error("[spicedb] Failed to parse custom client options", e);

--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -100,10 +100,10 @@ export class SpiceDBClientProvider {
                     clientOptions: new TrustedValue(clientOptions),
                 });
 
-                // close client after 10s to make sure most pending requests on the previous client are finished.
+                // close client after 2 minutes to make sure most pending requests on the previous client are finished.
                 setTimeout(() => {
                     this.closeClient(oldClient);
-                }, 10 * 1000);
+                }, 2 * 60 * 1000);
             }
             this.clientOptions = clientOptions;
             // `createClient` will use the `DefaultClientOptions` to create client if the value on Feature Flag is not able to create a client

--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -7,6 +7,8 @@
 import { v1 } from "@authzed/authzed-node";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
 import * as grpc from "@grpc/grpc-js";
+import { getExperimentsClientForBackend } from "@gitpod/gitpod-protocol/lib/experiments/configcat-server";
+import { TrustedValue } from "@gitpod/gitpod-protocol/lib/util/scrubbing";
 
 export interface SpiceDBClientConfig {
     address: string;
@@ -15,6 +17,34 @@ export interface SpiceDBClientConfig {
 
 export type SpiceDBClient = v1.ZedPromiseClientInterface;
 type Client = v1.ZedClientInterface & grpc.Client;
+const DEFAULT_FEATURE_FLAG_VALUE = "undefined";
+const DefaultClientOptions: grpc.ClientOptions = {
+    // we ping frequently to check if the connection is still alive
+    "grpc.keepalive_time_ms": 1000,
+    "grpc.keepalive_timeout_ms": 1000,
+
+    "grpc.max_reconnect_backoff_ms": 5000,
+    "grpc.initial_reconnect_backoff_ms": 500,
+    "grpc.service_config": JSON.stringify({
+        methodConfig: [
+            {
+                name: [{}],
+                retryPolicy: {
+                    maxAttempts: 10,
+                    initialBackoff: "0.1s",
+                    maxBackoff: "5s",
+                    backoffMultiplier: 2.0,
+                    retryableStatusCodes: ["UNAVAILABLE", "DEADLINE_EXCEEDED"],
+                },
+            },
+        ],
+    }),
+    "grpc.enable_retries": 1, //TODO enabled by default
+
+    // Governs how log DNS resolution results are cached (at minimum!)
+    // default is 30s, which is too long for us during rollouts (where service DNS entries are updated)
+    "grpc.dns_min_time_between_resolutions_ms": 2000,
+};
 
 export function spiceDBConfigFromEnv(): SpiceDBClientConfig | undefined {
     const token = process.env["SPICEDB_PRESHARED_KEY"];
@@ -36,48 +66,102 @@ export function spiceDBConfigFromEnv(): SpiceDBClientConfig | undefined {
 
 export class SpiceDBClientProvider {
     private client: Client | undefined;
+    private previousClientOptionsString: string = DEFAULT_FEATURE_FLAG_VALUE;
+    private clientOptions: grpc.ClientOptions;
 
     constructor(
         private readonly clientConfig: SpiceDBClientConfig,
         private readonly interceptors: grpc.Interceptor[] = [],
-    ) {}
+    ) {
+        this.clientOptions = DefaultClientOptions;
+        this.reconcileClientOptions()
+            .then(() => {})
+            .catch((e) => {
+                log.error("[spicedb] Failed to reconcile client options", e);
+            });
+    }
 
-    getClient(): SpiceDBClient {
-        if (!this.client) {
-            this.client = v1.NewClient(
+    private async reconcileClientOptions() {
+        const doReconcileClientOptions = async () => {
+            try {
+                const customClientOptions = await getExperimentsClientForBackend().getValueAsync(
+                    "spicedb_client_options",
+                    DEFAULT_FEATURE_FLAG_VALUE,
+                    {},
+                );
+                if (customClientOptions === this.previousClientOptionsString) {
+                    return;
+                }
+                let clientOptions = DefaultClientOptions;
+                if (customClientOptions && customClientOptions != DEFAULT_FEATURE_FLAG_VALUE) {
+                    clientOptions = JSON.parse(customClientOptions);
+                }
+                if (this.client != null) {
+                    const newClient = this.createClient(clientOptions);
+                    const oldClient = this.client;
+                    this.client = newClient;
+
+                    log.info("[spicedb] Client options changes", {
+                        clientOptions: new TrustedValue(clientOptions),
+                    });
+
+                    setTimeout(() => {
+                        this.closeClient(oldClient);
+                    }, 10 * 1000);
+                }
+                this.clientOptions = clientOptions;
+                this.previousClientOptionsString = customClientOptions;
+            } catch (e) {
+                log.error("[spicedb] Failed to parse custom client options", e);
+            }
+        };
+        while (true) {
+            await doReconcileClientOptions();
+            await new Promise((resolve) => setTimeout(resolve, 60 * 1000));
+        }
+    }
+
+    private closeClient(client: Client) {
+        try {
+            client.close();
+        } catch (error) {
+            log.error("[spicedb] Error closing client", error);
+        }
+    }
+
+    private createClient(clientOptions: grpc.ClientOptions): Client {
+        log.debug("[spicedb] Creating client", {
+            clientOptions: new TrustedValue(clientOptions),
+        });
+        try {
+            return v1.NewClient(
                 this.clientConfig.token,
                 this.clientConfig.address,
                 v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS,
-                undefined, //
+                undefined,
                 {
-                    // we ping frequently to check if the connection is still alive
-                    "grpc.keepalive_time_ms": 1000,
-                    "grpc.keepalive_timeout_ms": 1000,
-
-                    "grpc.max_reconnect_backoff_ms": 5000,
-                    "grpc.initial_reconnect_backoff_ms": 500,
-                    "grpc.service_config": JSON.stringify({
-                        methodConfig: [
-                            {
-                                name: [{}],
-                                retryPolicy: {
-                                    maxAttempts: 10,
-                                    initialBackoff: "0.1s",
-                                    maxBackoff: "5s",
-                                    backoffMultiplier: 2.0,
-                                    retryableStatusCodes: ["UNAVAILABLE", "DEADLINE_EXCEEDED"],
-                                },
-                            },
-                        ],
-                    }),
-                    "grpc.enable_retries": 1, //TODO enabled by default
-
-                    // Governs how log DNS resolution results are cached (at minimum!)
-                    // default is 30s, which is too long for us during rollouts (where service DNS entries are updated)
-                    "grpc.dns_min_time_between_resolutions_ms": 2000,
+                    ...clientOptions,
                     interceptors: this.interceptors,
                 },
             ) as Client;
+        } catch (error) {
+            log.error("[spicedb] Error create client, fallback to default options", error);
+            return v1.NewClient(
+                this.clientConfig.token,
+                this.clientConfig.address,
+                v1.ClientSecurity.INSECURE_PLAINTEXT_CREDENTIALS,
+                undefined,
+                {
+                    ...DefaultClientOptions,
+                    interceptors: this.interceptors,
+                },
+            ) as Client;
+        }
+    }
+
+    getClient(): SpiceDBClient {
+        if (!this.client) {
+            this.client = this.createClient(this.clientOptions);
         }
         return this.client.promises;
     }

--- a/components/server/src/authorization/spicedb.ts
+++ b/components/server/src/authorization/spicedb.ts
@@ -112,7 +112,7 @@ export class SpiceDBClientProvider {
                 }
                 this.clientOptions = clientOptions;
                 // `createClient` will use the `DefaultClientOptions` to create client if the value on Feature Flag is not able to create a client
-                // but we will still write `previousClientOptionsString` here to avoid retry with that incorrect value again
+                // but we will still write `previousClientOptionsString` here to prevent retry loops.
                 this.previousClientOptionsString = customClientOptions;
             } catch (e) {
                 log.error("[spicedb] Failed to parse custom client options", e);


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[server] add feature flags for spicedb client options

The default value of the feature flag is `undefined`. If the feature flag is set to this value, we will use the default spicedb grpc client options, otherwise the value should be a valid json.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Relates CLC-370 ([internal chat](https://gitpod.slack.com/archives/C071G5TTS49/p1739870590350829?thread_ts=1739869326.120209&cid=C071G5TTS49))

## How to test
<!-- Provide steps to test this PR -->

- Update value of [FF](https://app.configcat.com/08da1258-64fb-4a8e-8a1e-51de773884f6/08da1258-6541-4fc7-8b61-c8b47f82f3a0/08da1258-6512-4ec0-80a3-3f6aa301f853?settingId=699989) , the value should be `JSON.stringify` grpc client options
   - with correct grpc client options - use new option
   - incorrect options - use default option
   - invalid value - use default option
- Check logs of server and see if spicedb grpc options / client changed

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-clc-370</li>
	<li><b>🔗 URL</b> - <a href="https://hw-clc-370.preview.gitpod-dev.com/workspaces" target="_blank">hw-clc-370.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-CLC-370-gha.31461</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-clc-370%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
