### PR TITLE
[dashboard] Fix user preferences workspace timeouts alert

### DIFF
--- a/components/dashboard/src/data/organizations/default-org-timeout-query.ts
+++ b/components/dashboard/src/data/organizations/default-org-timeout-query.ts
@@ -1,0 +1,20 @@
+/**
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { WORKSPACE_TIMEOUT_DEFAULT_LONG, WORKSPACE_TIMEOUT_DEFAULT_SHORT } from "@gitpod/gitpod-protocol";
+import { useOrgBillingMode } from "../billing-mode/org-billing-mode-query";
+
+/**
+ * Returns the default workspace timeout for an organization based on their billing mode (does not take into account the organization's own settings)
+ */
+export const useDefaultOrgTimeoutQuery = () => {
+    const { data: billingMode } = useOrgBillingMode();
+
+    const isPaidOrDedicated =
+        billingMode?.mode === "none" || (billingMode?.mode === "usage-based" && billingMode?.paid);
+
+    return isPaidOrDedicated ? WORKSPACE_TIMEOUT_DEFAULT_LONG : WORKSPACE_TIMEOUT_DEFAULT_SHORT;
+};

--- a/components/dashboard/src/teams/TeamPolicies.tsx
+++ b/components/dashboard/src/teams/TeamPolicies.tsx
@@ -31,6 +31,7 @@ import { WorkspaceClassesEnterpriseCallout } from "./policies/WorkspaceClassesEn
 import { EditorOptions } from "./policies/EditorOptions";
 import { RolePermissionsRestrictions } from "./policies/RoleRestrictions";
 import { OrgWorkspaceClassesOptions } from "./policies/OrgWorkspaceClassesOptions";
+import { useDefaultOrgTimeoutQuery } from "../data/organizations/default-org-timeout-query";
 
 export default function TeamPoliciesPage() {
     useDocumentTitle("Organization Settings - Policies");
@@ -45,6 +46,8 @@ export default function TeamPoliciesPage() {
     const [workspaceTimeout, setWorkspaceTimeout] = useState<string | undefined>(undefined);
     const [allowTimeoutChangeByMembers, setAllowTimeoutChangeByMembers] = useState<boolean | undefined>(undefined);
     const [workspaceTimeoutSettingError, setWorkspaceTimeoutSettingError] = useState<string | undefined>(undefined);
+
+    const defaultOrgTimeout = useDefaultOrgTimeoutQuery();
 
     const handleUpdateTeamSettings = useCallback(
         async (newSettings: Partial<PlainMessage<OrganizationSettings>>, options?: { throwMutateError?: boolean }) => {
@@ -156,7 +159,9 @@ export default function TeamPoliciesPage() {
                                 hint={
                                     <span>
                                         Use minutes or hours, like <span className="font-semibold">30m</span> or{" "}
-                                        <span className="font-semibold">2h</span>
+                                        <span className="font-semibold">2h</span>. If not set, your organization's
+                                        default of <span className="font-semibold">{defaultOrgTimeout}</span> will be
+                                        used.
                                     </span>
                                 }
                             >

--- a/components/dashboard/src/user-settings/Preferences.tsx
+++ b/components/dashboard/src/user-settings/Preferences.tsx
@@ -25,6 +25,7 @@ import { converter, userClient } from "../service/public-api";
 import { LoadingButton } from "@podkit/buttons/LoadingButton";
 import { useOrgSettingsQuery } from "../data/organizations/org-settings-query";
 import Alert from "../components/Alert";
+import { useDefaultOrgTimeoutQuery } from "../data/organizations/default-org-timeout-query";
 
 export type IDEChangedTrackLocation = "workspace_list" | "workspace_start" | "preferences";
 
@@ -35,7 +36,7 @@ export default function Preferences() {
     const billingMode = useOrgBillingMode();
     const updateDotfileRepo = useUpdateCurrentUserDotfileRepoMutation();
     const { data: settings } = useOrgSettingsQuery();
-
+    const defaultOrgTimeout = useDefaultOrgTimeoutQuery();
     const [dotfileRepo, setDotfileRepo] = useState<string>(user?.dotfileRepo || "");
 
     const [workspaceTimeout, setWorkspaceTimeout] = useState<string>(
@@ -173,7 +174,8 @@ export default function Preferences() {
                         <Alert type="warning" className="mb-4">
                             The currently selected organization does not allow members to set custom workspace timeouts,
                             so for workspaces created in it, its default timeout of{" "}
-                            {converter.toDurationStringOpt(settings?.timeoutSettings?.inactivity) || ""} will be used.
+                            {converter.toDurationStringOpt(settings?.timeoutSettings?.inactivity) ?? defaultOrgTimeout}{" "}
+                            will be used.
                         </Alert>
                     )}
 


### PR DESCRIPTION
Tool: gitpod/catfood.gitpod.cloud

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test

1. Visit the preview env
2. Go to org settings --> Policies
3. Turn off `Allow members to change workspace timeouts`
4. Go to user preferences and observe the warning banner mentioning 30m instead of the previous empty value.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
