### PR TITLE
[components] include scheduler-extender:docker in all-docker build

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,10 +62,13 @@
 /components/proxy @gitpod-io/team-experience @gitpod-io/team-enterprise
 /components/public-api @gitpod-io/team-experience @gitpod-io/team-enterprise
 # Any team can make changes to the experimental package
+/components/ipfs/kubo @gitpod-io/team-experience @gitpod-io/team-enterprise
+/components/ipfs/ipfs-cluster @gitpod-io/team-experience @gitpod-io/team-enterprise
 /components/public-api/gitpod/experimental @gitpod-io/team-experience @gitpod-io/team-enterprise
 /components/public-api-server @gitpod-io/team-experience @gitpod-io/team-enterprise
 /components/registry-facade-api @gitpod-io/team-engine @gitpod-io/team-enterprise
 /components/registry-facade @gitpod-io/team-engine @gitpod-io/team-enterprise
+/components/scheduler-extender @gitpod-io/team-engine @gitpod-io/team-enterprise
 /components/server @gitpod-io/team-experience @gitpod-io/team-enterprise
 /components/server/src/ide-service.* @gitpod-io/team-experience @gitpod-io/team-enterprise
 /components/service-waiter @gitpod-io/team-experience @gitpod-io/team-enterprise

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -73,6 +73,7 @@ packages:
       - components/openvsx-proxy:docker
       - components/proxy:docker
       - components/registry-facade:docker
+      - components/scheduler-extender:docker
       - components/server:docker
       - components/service-waiter:docker
       - components/supervisor:docker


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Follow-up on #20624

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1171

## How to test
<!-- Provide steps to test this PR -->
This works after landing on main:
```
docker pull eu.gcr.io/gitpod-core-dev/build/scheduler-extender:c1925d8

```


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
