### PR TITLE
[memory bank] Initialize cline memory bank

### DIFF
--- a/memory-bank/.clinerules
+++ b/memory-bank/.clinerules
@@ -73,10 +73,30 @@ This file captures important patterns, preferences, and project intelligence tha
 - **README.md**: Each component should have a README explaining its purpose
 - **API Documentation**: Generated from Protocol Buffer definitions
 - **Architecture Documentation**: System-level documentation in various formats
+- **Memory Bank Documentation**:
+  - Component-specific documentation is stored in `memory-bank/components/` directory
+  - Each component gets its own markdown file with detailed information about its purpose, architecture, and implementation
+  - API components (with "*-api" suffix) should NOT be documented separately as they are typically just interface definitions
+  - Component documentation should focus on the main service components that implement business logic
+  - Documentation follows a consistent structure with sections for Overview, Purpose, Architecture, Key Features, etc.
 
 ## Evolution of Project Decisions
 
 This section will be updated as I learn about how and why certain architectural and design decisions were made.
+
+### Memory Bank Organization
+
+- **Component Documentation**: The decision to create separate documentation files for each component in the `memory-bank/components/` directory was made to:
+  1. Provide a clear, organized structure for component documentation
+  2. Allow for detailed documentation of each component's purpose, architecture, and implementation
+  3. Make it easier to find information about specific components
+  4. Enable incremental updates to component documentation without affecting other files
+
+- **API Component Exclusion**: The decision to exclude "*-api" components from separate documentation was made because:
+  1. API components primarily contain interface definitions, not implementation logic
+  2. The interfaces are typically documented within the main service component that implements them
+  3. Documenting API components separately would create redundancy
+  4. The focus should be on documenting the service components that implement business logic
 
 ## User Preferences
 

--- a/memory-bank/.clinerules
+++ b/memory-bank/.clinerules
@@ -1,0 +1,87 @@
+# Gitpod Project Intelligence
+
+This file captures important patterns, preferences, and project intelligence that help me work more effectively with the Gitpod codebase. It serves as a learning journal that will be updated as I discover new insights.
+
+## Project Structure Patterns
+
+- **Component Organization**: The project is organized into components, each with its own directory in the `components/` folder
+- **API Definitions**: API definitions are typically in separate packages with `-api` suffix (e.g., `content-service-api`)
+- **Protocol Buffers**: gRPC service definitions use Protocol Buffers (`.proto` files)
+- **Build Configuration**: Each component has a `BUILD.yaml` file defining its build configuration
+- **Docker Configuration**: Components that run as containers have a `leeway.Dockerfile`
+
+## Code Style Preferences
+
+- **Go Code**:
+  - Follow standard Go conventions (gofmt)
+  - Error handling with explicit checks
+  - Context propagation for cancellation
+  - Structured logging
+
+- **TypeScript Code**:
+  - Use TypeScript for type safety
+  - React for UI components
+  - Functional components with hooks
+  - ESLint and Prettier for formatting
+
+## Development Workflow
+
+- **Build System**: Use Leeway for building components
+  - `leeway build` to build specific components
+  - `leeway exec` to run commands across components
+
+- **Testing**:
+  - Unit tests alongside code
+  - Integration tests in separate directories
+  - End-to-end tests in the `test/` directory
+
+- **Local Development**:
+  - Use Gitpod workspaces for development (dogfooding)
+  - Components can be run individually for testing
+  - Preview environments for testing changes
+
+## Critical Implementation Paths
+
+- **Workspace Lifecycle**: The critical path for workspace operations involves:
+  - Workspace Manager
+  - Image Builder
+  - Kubernetes
+  - Workspace Daemon
+  - Supervisor
+
+- **User Authentication**: The critical path for user authentication involves:
+  - Auth Service
+  - Dashboard
+  - Proxy
+
+## Known Challenges
+
+- **Build System Complexity**: The Leeway build system has a learning curve
+- **Component Dependencies**: Understanding dependencies between components can be challenging
+- **Testing Environment**: Setting up proper testing environments for all components
+
+## Tool Usage Patterns
+
+- **VS Code**: Primary IDE for TypeScript development
+- **GoLand/IntelliJ**: Often used for Go development
+- **Docker**: Used for containerized development and testing
+- **kubectl**: Used for interacting with Kubernetes clusters
+- **Werft**: CI/CD system for automated builds and tests
+
+## Documentation Patterns
+
+- **README.md**: Each component should have a README explaining its purpose
+- **API Documentation**: Generated from Protocol Buffer definitions
+- **Architecture Documentation**: System-level documentation in various formats
+
+## Evolution of Project Decisions
+
+This section will be updated as I learn about how and why certain architectural and design decisions were made.
+
+## User Preferences
+
+This section will be updated as I learn about specific user preferences for working with the codebase.
+
+---
+
+Note: This file will be continuously updated as I work with the Gitpod codebase and discover new patterns, preferences, and insights.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -25,6 +25,9 @@ Key areas of focus include:
   - ide-service: Manages IDE configurations and resolves workspace IDE requirements
   - registry-facade: Modifies container images by adding layers for workspaces
   - image-builder-mk3: Builds custom workspace images from user-defined Dockerfiles
+  - server: Main backend service handling API requests and user management
+  - proxy: Main entry point for all HTTP and WebSocket traffic
+  - ws-proxy: Handles routing and proxying of traffic to workspaces
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -46,6 +46,9 @@ Key areas of focus include:
   - docker-up: Sets up and manages Docker within workspace containers
   - image-builder-bob: Builds and pushes workspace images during workspace startup
   - node-labeler: Manages node labels and annotations for workspace scheduling
+  - openvsx-proxy: Caching proxy service for the OpenVSX registry
+  - scheduler-extender: Extends Kubernetes scheduling capabilities for workspaces
+  - ipfs: Provides distributed content-addressable storage for container images
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -28,6 +28,8 @@ Key areas of focus include:
   - server: Main backend service handling API requests and user management
   - proxy: Main entry point for all HTTP and WebSocket traffic
   - ws-proxy: Handles routing and proxying of traffic to workspaces
+  - gitpod-cli: Command-line interface for interacting with Gitpod workspaces
+  - gitpod-db: Database layer for the Gitpod platform
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -1,0 +1,79 @@
+# Active Context: Gitpod
+
+## Current Work Focus
+
+As of the memory bank initialization, we are focusing on understanding the Gitpod codebase and architecture. The primary goal is to build a comprehensive knowledge base that will allow for effective development, troubleshooting, and enhancement of the Gitpod platform.
+
+Key areas of focus include:
+
+1. **System Architecture Understanding**: Mapping out the relationships between components and services
+2. **Development Workflow**: Understanding how to effectively develop and test changes
+3. **Documentation**: Creating a comprehensive memory bank for future reference
+
+## Recent Changes
+
+The memory bank has just been initialized, so there are no recent changes to track yet. As work progresses, this section will be updated to reflect:
+
+- Code changes implemented
+- Bug fixes
+- Feature additions
+- Refactoring efforts
+- Documentation improvements
+
+## Next Steps
+
+The immediate next steps are:
+
+1. **Explore Component Structure**: Dive deeper into specific components to understand their implementation details
+2. **Set Up Development Environment**: Configure a local development environment for effective testing
+3. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
+4. **Establish Testing Approach**: Define how changes will be tested and validated
+5. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
+
+## Active Decisions and Considerations
+
+### Architecture Decisions
+
+- **Component Boundaries**: Understanding and respecting the boundaries between different microservices
+- **API Contracts**: Maintaining compatibility with existing API contracts
+- **Performance Considerations**: Ensuring changes maintain or improve performance characteristics
+
+### Development Approach
+
+- **Testing Strategy**: Determining appropriate testing approaches for different types of changes
+- **Documentation Standards**: Establishing standards for code documentation and memory bank updates
+- **Collaboration Model**: Defining how to effectively collaborate with the team
+
+### Technical Considerations
+
+- **Backward Compatibility**: Ensuring changes maintain compatibility with existing clients and integrations
+- **Security Implications**: Evaluating security implications of any changes
+- **Scalability**: Considering how changes impact system scalability
+
+## Current Questions and Uncertainties
+
+As we begin working with the Gitpod codebase, several questions and uncertainties exist:
+
+1. **Component Interactions**: How do the various components interact in specific scenarios?
+2. **Performance Bottlenecks**: What are the current performance bottlenecks in the system?
+3. **Testing Approach**: What is the most effective way to test changes to different components?
+4. **Deployment Process**: What is the process for deploying changes to production?
+5. **Feature Priorities**: What features or improvements are currently prioritized?
+
+These questions will be addressed as we continue to explore the codebase and work with the system.
+
+## Active Experiments
+
+No active experiments are currently in progress. This section will be updated as experiments are designed and conducted to test hypotheses about the system or potential improvements.
+
+## Recent Learnings
+
+As we begin working with the Gitpod codebase, we'll document key learnings here. This will include:
+
+- Insights about system behavior
+- Unexpected interactions between components
+- Performance characteristics
+- Common patterns and anti-patterns
+- Effective debugging techniques
+
+This section will be continuously updated as new insights are gained through working with the system.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -2,33 +2,47 @@
 
 ## Current Work Focus
 
-As of the memory bank initialization, we are focusing on understanding the Gitpod codebase and architecture. The primary goal is to build a comprehensive knowledge base that will allow for effective development, troubleshooting, and enhancement of the Gitpod platform.
+We are focusing on understanding the Gitpod codebase and architecture. The primary goal is to build a comprehensive knowledge base that will allow for effective development, troubleshooting, and enhancement of the Gitpod platform.
 
 Key areas of focus include:
 
 1. **System Architecture Understanding**: Mapping out the relationships between components and services
-2. **Development Workflow**: Understanding how to effectively develop and test changes
-3. **Documentation**: Creating a comprehensive memory bank for future reference
+2. **Component Documentation**: Creating detailed documentation for each component
+3. **Development Workflow**: Understanding how to effectively develop and test changes
+4. **Documentation**: Maintaining a comprehensive memory bank for future reference
 
 ## Recent Changes
 
-The memory bank has just been initialized, so there are no recent changes to track yet. As work progresses, this section will be updated to reflect:
+- Created the initial memory bank structure with core files
+- Added a components subdirectory to the memory bank
+- Created detailed documentation for key components:
+  - blobserve: Service that provides static assets from OCI images
+  - content-service: Manages various types of content within the platform
+  - dashboard: Web-based user interface for Gitpod
+  - ws-manager-mk2: Kubernetes controller for managing workspace lifecycle
 
+As work progresses, this section will continue to be updated to reflect:
+- Additional component documentation
 - Code changes implemented
 - Bug fixes
 - Feature additions
 - Refactoring efforts
-- Documentation improvements
 
 ## Next Steps
 
 The immediate next steps are:
 
-1. **Explore Component Structure**: Dive deeper into specific components to understand their implementation details
-2. **Set Up Development Environment**: Configure a local development environment for effective testing
-3. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
-4. **Establish Testing Approach**: Define how changes will be tested and validated
-5. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
+1. **Continue Component Documentation**: Document additional key components such as:
+   - supervisor
+   - ws-daemon
+   - ide-service
+   - registry-facade
+   - image-builder
+2. **Explore Component Interactions**: Understand how components interact with each other
+3. **Set Up Development Environment**: Configure a local development environment for effective testing
+4. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
+5. **Establish Testing Approach**: Define how changes will be tested and validated
+6. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
 
 ## Active Decisions and Considerations
 
@@ -68,12 +82,15 @@ No active experiments are currently in progress. This section will be updated as
 
 ## Recent Learnings
 
-As we begin working with the Gitpod codebase, we'll document key learnings here. This will include:
+Initial exploration of the Gitpod codebase has revealed:
 
-- Insights about system behavior
-- Unexpected interactions between components
-- Performance characteristics
-- Common patterns and anti-patterns
-- Effective debugging techniques
+- **Microservices Architecture**: Gitpod is built as a collection of loosely coupled services, each with specific responsibilities
+- **Go and TypeScript**: Backend services are primarily written in Go, while frontend components use TypeScript/React
+- **Kubernetes Native**: Many components are designed as Kubernetes controllers or operators
+- **gRPC Communication**: Services communicate using gRPC for efficient, typed communication
+- **Component Patterns**: Components follow consistent patterns:
+  - Go services typically have a cmd/ directory with command implementations
+  - TypeScript services use React and modern frontend practices
+  - Most components have a clear separation between API definitions and implementations
 
 This section will be continuously updated as new insights are gained through working with the system.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -40,6 +40,9 @@ Key areas of focus include:
   - usage: Tracks, calculates, and manages workspace usage and billing
   - common-go: Foundational Go library providing shared utilities across services
   - workspacekit: Manages container setup and namespace isolation for workspaces
+  - spicedb: Provides authorization and permission management
+  - scrubber: Removes or masks sensitive information from data
+  - service-waiter: Waits for services to become available
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -31,6 +31,9 @@ Key areas of focus include:
   - gitpod-cli: Command-line interface for interacting with Gitpod workspaces
   - gitpod-db: Database layer for the Gitpod platform
   - gitpod-protocol: Core type definitions and shared protocol library
+  - ide: Packages and manages IDEs available in Gitpod workspaces
+  - ide-proxy: Serves static IDE-related assets and proxies requests
+  - ws-manager-bridge: Bridges between workspace managers and the rest of the platform
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -38,6 +38,8 @@ Key areas of focus include:
   - local-app: Provides tools for interacting with Gitpod workspaces from local machine
   - public-api-server: Provides a stable, versioned API for programmatic access to Gitpod
   - usage: Tracks, calculates, and manages workspace usage and billing
+  - common-go: Foundational Go library providing shared utilities across services
+  - workspacekit: Manages container setup and namespace isolation for workspaces
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -30,6 +30,7 @@ Key areas of focus include:
   - ws-proxy: Handles routing and proxying of traffic to workspaces
   - gitpod-cli: Command-line interface for interacting with Gitpod workspaces
   - gitpod-db: Database layer for the Gitpod platform
+  - gitpod-protocol: Core type definitions and shared protocol library
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -22,6 +22,9 @@ Key areas of focus include:
   - ws-manager-mk2: Kubernetes controller for managing workspace lifecycle
   - supervisor: Init process that runs inside each workspace container
   - ws-daemon: Node-level daemon for workspace operations
+  - ide-service: Manages IDE configurations and resolves workspace IDE requirements
+  - registry-facade: Modifies container images by adding layers for workspaces
+  - image-builder-mk3: Builds custom workspace images from user-defined Dockerfiles
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation
@@ -34,15 +37,11 @@ As work progresses, this section will continue to be updated to reflect:
 
 The immediate next steps are:
 
-1. **Continue Component Documentation**: Document additional key components such as:
-   - ide-service
-   - registry-facade
-   - image-builder
-2. **Explore Component Interactions**: Understand how components interact with each other
-3. **Set Up Development Environment**: Configure a local development environment for effective testing
-4. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
-5. **Establish Testing Approach**: Define how changes will be tested and validated
-6. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
+1. **Explore Component Interactions**: Understand how components interact with each other
+2. **Set Up Development Environment**: Configure a local development environment for effective testing
+3. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
+4. **Establish Testing Approach**: Define how changes will be tested and validated
+5. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
 
 ## Active Decisions and Considerations
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -36,6 +36,8 @@ Key areas of focus include:
   - ws-manager-bridge: Bridges between workspace managers and the rest of the platform
   - ide-metrics: Collects and processes metrics and error reports from IDE components
   - local-app: Provides tools for interacting with Gitpod workspaces from local machine
+  - public-api-server: Provides a stable, versioned API for programmatic access to Gitpod
+  - usage: Tracks, calculates, and manages workspace usage and billing
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -43,6 +43,9 @@ Key areas of focus include:
   - spicedb: Provides authorization and permission management
   - scrubber: Removes or masks sensitive information from data
   - service-waiter: Waits for services to become available
+  - docker-up: Sets up and manages Docker within workspace containers
+  - image-builder-bob: Builds and pushes workspace images during workspace startup
+  - node-labeler: Manages node labels and annotations for workspace scheduling
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -20,6 +20,8 @@ Key areas of focus include:
   - content-service: Manages various types of content within the platform
   - dashboard: Web-based user interface for Gitpod
   - ws-manager-mk2: Kubernetes controller for managing workspace lifecycle
+  - supervisor: Init process that runs inside each workspace container
+  - ws-daemon: Node-level daemon for workspace operations
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation
@@ -33,8 +35,6 @@ As work progresses, this section will continue to be updated to reflect:
 The immediate next steps are:
 
 1. **Continue Component Documentation**: Document additional key components such as:
-   - supervisor
-   - ws-daemon
    - ide-service
    - registry-facade
    - image-builder

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -34,6 +34,8 @@ Key areas of focus include:
   - ide: Packages and manages IDEs available in Gitpod workspaces
   - ide-proxy: Serves static IDE-related assets and proxies requests
   - ws-manager-bridge: Bridges between workspace managers and the rest of the platform
+  - ide-metrics: Collects and processes metrics and error reports from IDE components
+  - local-app: Provides tools for interacting with Gitpod workspaces from local machine
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation

--- a/memory-bank/components/blobserve.md
+++ b/memory-bank/components/blobserve.md
@@ -1,0 +1,88 @@
+# Blobserve Component
+
+## Overview
+
+Blobserve is a service that provides static assets from OCI (Open Container Initiative) images. It serves as a specialized content delivery mechanism for container images, allowing efficient access to static content within those images.
+
+## Purpose
+
+The primary purpose of Blobserve is to:
+- Extract and serve static content from container images
+- Provide efficient access to image layers
+- Handle authentication with container registries
+- Serve HTTP requests for blob content
+
+## Architecture
+
+Blobserve operates as an HTTP server that:
+1. Connects to container registries
+2. Retrieves image content
+3. Extracts and caches static assets
+4. Serves these assets via HTTP
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/run.go`: Implements the main server functionality
+- `pkg/blobserve`: Contains the core implementation of the blob serving functionality
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities used across Gitpod
+- `components/registry-facade-api/go:lib`: API definitions for registry facade
+- `components/registry-facade:lib`: Library for interacting with container registries
+
+### External Dependencies
+- `containerd/containerd`: For container image handling
+- `docker/cli`: For Docker configuration handling
+- `prometheus`: For metrics and monitoring
+- `spf13/cobra`: For command-line interface
+
+## Configuration
+
+Blobserve is configured via a JSON configuration file that includes:
+- Authentication configuration for container registries
+- HTTP server settings
+- Repository mappings
+- Caching parameters
+- Monitoring endpoints
+
+## Integration Points
+
+Blobserve integrates with:
+1. **Container Registries**: Connects to registries like Docker Hub, ECR, GCR
+2. **Prometheus**: Exposes metrics for monitoring
+3. **Health Checking**: Provides readiness probes for Kubernetes
+
+## Security Considerations
+
+- Requires proper IAM permissions when using cloud-based container registries (e.g., AWS ECR)
+- Handles authentication credentials for private registries
+- Monitors file changes for authentication configuration updates
+
+## Common Usage Patterns
+
+Blobserve is typically used to:
+1. Serve static content from workspace images
+2. Provide efficient access to container image layers
+3. Cache frequently accessed content for performance
+
+## Metrics and Monitoring
+
+Blobserve exposes several Prometheus metrics:
+- `http_client_requests_total`: Counter of outgoing HTTP requests
+- `http_client_requests_duration_seconds`: Histogram of outgoing HTTP request durations
+- `http_server_requests_total`: Counter of incoming HTTP requests
+- `http_server_requests_duration_seconds`: Histogram of incoming HTTP request durations
+
+## Known Limitations
+
+- Requires specific IAM permissions when using cloud-based container registries
+- Authentication configuration must be properly set up for private registries
+
+## Related Components
+
+- **Registry Facade**: Works closely with Blobserve to provide access to container images
+- **Workspace Manager**: May use Blobserve to access workspace image content

--- a/memory-bank/components/common-go.md
+++ b/memory-bank/components/common-go.md
@@ -1,0 +1,170 @@
+# Common-Go Component
+
+## Overview
+
+The Common-Go component is a foundational Go library that provides shared utilities, abstractions, and functionality used across multiple Gitpod services. It serves as a central repository for common code patterns, helping to maintain consistency, reduce duplication, and simplify development across the Gitpod platform's Go-based microservices.
+
+## Purpose
+
+The primary purposes of the Common-Go component are:
+- Provide shared utilities and abstractions for Gitpod's Go-based services
+- Ensure consistent implementation of cross-cutting concerns
+- Reduce code duplication across services
+- Simplify service development with ready-to-use components
+- Standardize logging, metrics, tracing, and server configuration
+- Offer common patterns for Kubernetes integration
+- Provide utilities for gRPC communication
+- Support consistent error handling and debugging
+
+## Architecture
+
+The Common-Go component is structured as a collection of Go packages, each focusing on a specific area of functionality:
+
+1. **Baseserver**: Core server implementation with standardized configuration
+2. **Log**: Structured logging utilities
+3. **Tracing**: Distributed tracing functionality
+4. **gRPC**: Utilities for gRPC communication
+5. **Kubernetes**: Kubernetes client and utilities
+6. **Analytics**: Analytics tracking and reporting
+7. **Experiments**: Feature flag and experimentation support
+8. **Metrics**: Prometheus metrics collection
+9. **Utilities**: Various helper functions and utilities
+
+The component is designed to be imported and used by other Go-based services in the Gitpod platform, providing a consistent foundation for service development.
+
+## Key Packages and Functionality
+
+### Baseserver
+- Standard server implementation with HTTP and gRPC support
+- Consistent configuration and option handling
+- Health check endpoints
+- Graceful shutdown
+- Metrics integration
+
+### Log
+- Structured logging based on logrus
+- Context-aware logging
+- Log level management
+- Field-based logging
+- Metrics integration for log counts
+
+### Tracing
+- Distributed tracing with OpenTelemetry
+- Span creation and management
+- Context propagation
+- Prometheus integration for tracing metrics
+
+### gRPC
+- Standard gRPC server and client configuration
+- Authentication and authorization middleware
+- Rate limiting
+- Error handling
+- Metrics collection
+
+### Kubernetes
+- Kubernetes client configuration
+- Custom resource definitions
+- Controller patterns
+- Informer and lister utilities
+
+### Analytics
+- Event tracking
+- User and session identification
+- Batch processing of analytics events
+- Privacy-aware data collection
+
+### Experiments
+- Feature flag management
+- A/B testing support
+- Gradual rollout capabilities
+- User segmentation
+
+### Metrics
+- Prometheus metrics collection
+- Standard metric types (counters, gauges, histograms)
+- Metric registration and exposure
+- Label standardization
+
+### Utilities
+- String manipulation
+- Time handling
+- Error wrapping
+- JSON utilities
+- Network helpers
+
+## Dependencies
+
+### Internal Dependencies
+- `components/scrubber`: For data scrubbing and sanitization
+
+### External Dependencies
+- Kubernetes client libraries
+- gRPC and related libraries
+- Prometheus client
+- OpenTelemetry
+- Logrus for logging
+- Various utility libraries
+
+## Integration Points
+
+The Common-Go component integrates with:
+1. **All Go-based Gitpod Services**: Provides foundational functionality
+2. **Kubernetes**: For cluster interaction and management
+3. **Prometheus**: For metrics collection
+4. **Tracing Systems**: For distributed tracing
+5. **Logging Systems**: For centralized logging
+
+## Usage Patterns
+
+### Server Initialization
+```go
+srv, err := baseserver.New("service-name",
+    baseserver.WithVersion(version),
+    baseserver.WithConfig(cfg.Server),
+)
+if err != nil {
+    log.WithError(err).Fatal("failed to initialize server")
+}
+```
+
+### Logging
+```go
+log.WithFields(log.Fields{
+    "user": userID,
+    "workspace": workspaceID,
+}).Info("workspace started")
+```
+
+### Tracing
+```go
+span, ctx := tracing.FromContext(ctx, "operation-name")
+defer span.Finish()
+span.SetTag("key", "value")
+```
+
+### Metrics
+```go
+counter := prometheus.NewCounter(prometheus.CounterOpts{
+    Name: "operation_total",
+    Help: "Total number of operations performed",
+})
+metrics.Registry.MustRegister(counter)
+counter.Inc()
+```
+
+## Common Usage Patterns
+
+The Common-Go component is typically used to:
+1. Initialize and configure services
+2. Set up logging, metrics, and tracing
+3. Interact with Kubernetes
+4. Implement gRPC servers and clients
+5. Handle cross-cutting concerns like authentication and rate limiting
+6. Manage feature flags and experiments
+7. Track analytics events
+
+## Related Components
+
+- **All Go-based Services**: Use the Common-Go component for foundational functionality
+- **Kubernetes Components**: Interact with Kubernetes using utilities from Common-Go
+- **Monitoring Components**: Use metrics and tracing from Common-Go

--- a/memory-bank/components/content-service.md
+++ b/memory-bank/components/content-service.md
@@ -1,0 +1,103 @@
+# Content Service Component
+
+## Overview
+
+The Content Service is a core component of Gitpod that manages various types of content within the platform, including workspace content, blobs, logs, and IDE plugins. It provides a set of gRPC services that handle storage, retrieval, and management of different content types.
+
+## Purpose
+
+The primary purposes of the Content Service are:
+- Manage workspace content (snapshots, downloads, deletions)
+- Handle blob storage and retrieval
+- Store and retrieve headless logs
+- Manage IDE plugin content
+- Provide a unified interface for content operations
+
+## Architecture
+
+The Content Service operates as a gRPC server that exposes several services:
+
+1. **ContentService**: Handles general content operations like user content deletion
+2. **BlobService**: Manages blob storage, providing upload/download URLs and deletion capabilities
+3. **WorkspaceService**: Manages workspace content, including snapshots and downloads
+4. **HeadlessLogService**: Handles logs for headless operations
+5. **IDEPluginService**: Manages IDE plugin-related content
+
+Each service is implemented as a separate module but shares common storage configuration and infrastructure.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/run.go`: Implements the main server functionality, setting up all services
+- `cmd/test.go`: Contains test functionality
+- `pkg/service/`: Contains implementations of the various services
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities used across Gitpod
+- `components/content-service-api/go:lib`: API definitions for the content service
+
+### External Dependencies
+- gRPC: For service communication
+- Protocol Buffers: For API definitions
+- Various storage backends (likely S3, filesystem, etc.)
+
+## API Services
+
+### ContentService
+- `DeleteUserContent`: Deletes all content associated with a user
+
+### BlobService
+- `UploadUrl`: Provides a URL for uploading content via HTTP PUT
+- `DownloadUrl`: Provides a URL for downloading content via HTTP GET
+- `Delete`: Deletes uploaded content
+
+### WorkspaceService
+- `WorkspaceDownloadURL`: Provides a URL for downloading workspace content
+- `DeleteWorkspace`: Deletes the content of a single workspace
+- `WorkspaceSnapshotExists`: Checks whether a workspace snapshot exists
+
+### HeadlessLogService
+(API details not examined, but likely handles log storage and retrieval)
+
+### IDEPluginService
+(API details not examined, but likely handles IDE plugin content)
+
+## Configuration
+
+The Content Service is configured via a JSON configuration file that includes:
+- Storage configuration (backends, credentials, etc.)
+- Service settings (ports, TLS, etc.)
+- Logging configuration
+
+## Integration Points
+
+The Content Service integrates with:
+1. **Storage Systems**: For persisting content (likely S3, filesystem, etc.)
+2. **Workspace Components**: For managing workspace content
+3. **IDE Components**: For managing IDE plugin content
+4. **Other Gitpod Services**: That need to store or retrieve content
+
+## Security Considerations
+
+- Handles user content, requiring proper access controls
+- Generates secure URLs for content upload/download
+- Must ensure proper isolation between different users' content
+- Likely implements content expiration policies
+
+## Common Usage Patterns
+
+The Content Service is typically used to:
+1. Store and retrieve workspace snapshots
+2. Provide download URLs for workspace content
+3. Manage blob storage for various components
+4. Store logs from headless operations
+5. Manage IDE plugin content
+
+## Related Components
+
+- **Workspace Manager**: Uses Content Service for workspace snapshots and content
+- **IDE Service**: Uses Content Service for IDE plugin management
+- **Supervisor**: Likely interacts with Content Service for workspace operations

--- a/memory-bank/components/dashboard.md
+++ b/memory-bank/components/dashboard.md
@@ -1,0 +1,130 @@
+# Dashboard Component
+
+## Overview
+
+The Dashboard is the web-based user interface for Gitpod, providing users with access to workspaces, settings, account management, and other platform features. It's a single-page application (SPA) built with modern web technologies.
+
+## Purpose
+
+The primary purposes of the Dashboard are:
+- Provide a user interface for managing workspaces
+- Allow users to configure their account settings
+- Enable management of environment variables, Git integrations, and other preferences
+- Display subscription and billing information
+- Offer a consistent and intuitive user experience for the Gitpod platform
+
+## Architecture
+
+The Dashboard is a React-based single-page application with the following architectural characteristics:
+- Uses React Router for navigation between different pages
+- Implements lazy loading for components to optimize performance
+- Uses React Context for global state management
+- Communicates with backend services via API calls
+- Implements responsive design with TailwindCSS
+
+## Key Files and Structure
+
+- `App.tsx`: Entry point for the SPA, sets up routing
+- `src/account/`: Components for account-related pages (Profile, Notifications, Subscriptions)
+- `src/settings/`: Components for settings-related pages (DefaultIDE, EnvVars, GitIntegration, FeaturePreview)
+- `src/workspaces/`: Components for workspace management
+- `public/`: Static assets
+
+## Dependencies
+
+### Internal Dependencies
+- `components/gitpod-protocol:lib`: Protocol definitions for communicating with Gitpod services
+- `components/public-api/typescript:lib`: TypeScript client for the Gitpod public API
+- `components/public-api/typescript-common:lib`: Common TypeScript utilities for the public API
+
+### External Dependencies
+- **React**: Core UI library
+- **React Router**: For navigation and routing
+- **TailwindCSS**: For styling
+- **Radix UI**: For accessible UI components
+- **React Query**: For data fetching and caching
+- **Stripe JS**: For payment processing
+- **XTerm**: For terminal emulation
+- Various utility libraries (dayjs, lodash, etc.)
+
+## Features
+
+The Dashboard provides interfaces for:
+1. **Workspace Management**:
+   - Listing, creating, and managing workspaces
+   - Workspace configuration and settings
+
+2. **Account Management**:
+   - Profile settings
+   - Notification preferences
+   - Subscription management
+
+3. **Platform Configuration**:
+   - Environment variables
+   - Git integrations
+   - IDE preferences
+   - Feature preview settings
+
+## Development Workflow
+
+The Dashboard supports several development workflows:
+
+1. **Local Development**:
+   - Run `yarn start-local` to start the development server
+   - Access the dashboard at the provided URL
+
+2. **Development Against Live Gitpod**:
+   - For users with developer role, can use X-Frontend-Dev-URL header
+   - Allows testing against live data while developing locally
+
+3. **Testing**:
+   - Unit tests with Jest and React Testing Library
+   - Run tests with `yarn test:unit` or in watch mode with `yarn test:unit:watch`
+
+## Build Process
+
+The Dashboard is built using:
+- **Yarn**: Package management
+- **Craco**: Configuration layer for Create React App
+- **TypeScript**: For type safety
+- **ESLint**: For code quality
+- **Leeway**: For integration with the Gitpod build system
+
+The build process includes:
+1. Compiling TypeScript to JavaScript
+2. Bundling assets with webpack (via Create React App)
+3. Optimizing for production
+4. Packaging as a Docker container for deployment
+
+## Integration Points
+
+The Dashboard integrates with:
+1. **Gitpod Backend Services**: For workspace and user management
+2. **Public API**: For programmatic access to Gitpod features
+3. **Authentication System**: For user login and session management
+4. **Stripe**: For subscription and payment processing
+5. **Git Providers**: For repository integration
+
+## Security Considerations
+
+- Implements proper authentication and authorization
+- Handles sensitive user data securely
+- Uses HTTPS for all communications
+- Implements CSRF protection
+- Follows security best practices for web applications
+
+## Common Usage Patterns
+
+The Dashboard is typically used to:
+1. Create and manage workspaces
+2. Configure user settings and preferences
+3. Manage subscriptions and billing
+4. Set up integrations with Git providers
+5. Configure environment variables and other workspace settings
+
+## Related Components
+
+- **IDE Service**: Integrates with the Dashboard for IDE preferences
+- **Content Service**: Used for content management
+- **Workspace Manager**: Manages workspaces that are created through the Dashboard
+- **Authentication Service**: Handles user authentication for the Dashboard

--- a/memory-bank/components/docker-up.md
+++ b/memory-bank/components/docker-up.md
@@ -1,0 +1,159 @@
+# Docker-Up Component
+
+## Overview
+
+The Docker-Up component in Gitpod is responsible for setting up and managing Docker within workspace containers. It provides a way to run Docker in a rootless mode inside Gitpod workspaces, enabling users to build and run containers without requiring privileged access. The component handles the installation, configuration, and startup of Docker daemon and related tools, ensuring they work correctly within the constraints of a workspace environment.
+
+## Purpose
+
+The primary purposes of the Docker-Up component are:
+- Enable Docker functionality within Gitpod workspaces
+- Provide rootless Docker execution for security
+- Automatically install Docker and its dependencies when needed
+- Configure Docker daemon with appropriate settings for workspace environments
+- Handle network namespace and user namespace setup
+- Provide Docker Compose functionality
+- Ensure proper permissions for Docker socket access
+- Manage container runtime (runc) with appropriate configuration
+- Support custom Docker daemon arguments
+- Facilitate container port binding through capability management
+
+## Architecture
+
+The Docker-Up component consists of several key parts:
+
+1. **Docker-Up**: The main executable that sets up and starts the Docker daemon
+2. **Runc-Facade**: A wrapper around runc (the OCI container runtime) that handles rootless container execution
+3. **Dockerd**: Configuration and argument parsing for the Docker daemon
+4. **Embedded Binaries**: Docker, Docker Compose, and runc binaries embedded in the component
+
+The component is designed to run as a service within a Gitpod workspace, automatically starting when Docker functionality is requested and configuring the environment appropriately.
+
+## Key Features
+
+### Docker Daemon Management
+
+- Starts and configures the Docker daemon with appropriate settings
+- Sets up the Docker socket with proper permissions
+- Configures data storage location within the workspace
+- Handles MTU configuration based on the container network interface
+- Supports custom Docker daemon arguments through environment variables
+- Manages Docker daemon lifecycle
+
+### Automatic Installation
+
+- Detects missing prerequisites (Docker, Docker Compose, iptables, etc.)
+- Automatically installs required components when needed
+- Embeds Docker and Docker Compose binaries for reliable installation
+- Ensures correct versions of dependencies are installed
+- Handles different Linux distribution package managers
+
+### Rootless Container Execution
+
+- Configures Docker to run in rootless mode for security
+- Uses runc-facade to handle rootless container execution
+- Manages user namespace mappings
+- Configures capabilities for container processes
+- Handles OOM score adjustment for container stability
+
+### Network Configuration
+
+- Configures Docker network with appropriate MTU settings
+- Handles network namespace setup
+- Enables binding to privileged ports (below 1024) without root
+- Configures iptables for container networking
+
+## Configuration
+
+The Docker-Up component can be configured through command-line flags and environment variables:
+
+### Command-line Flags
+- `--verbose`, `-v`: Enables verbose logging
+- `--runc-facade`: Enables the runc-facade to handle rootless idiosyncrasies
+- `--bin-dir`: Directory where runc-facade is found
+- `--auto-install`: Auto-install prerequisites (Docker)
+- `--user-accessible-socket`: Make the Docker socket user accessible
+- `--dont-wrap-netns`: Control network namespace wrapping
+- `--auto-login`: Use content of GITPOD_IMAGE_AUTH to automatically login with the Docker daemon
+
+### Environment Variables
+- `DOCKERD_ARGS`: JSON-formatted custom arguments for the Docker daemon
+- `LISTEN_FDS`: Used for socket activation
+- `WORKSPACEKIT_WRAP_NETNS`: Controls network namespace wrapping
+- `GITPOD_IMAGE_AUTH`: Docker registry authentication information
+
+## Integration Points
+
+The Docker-Up component integrates with:
+1. **Workspace Container**: Runs within the workspace container
+2. **Supervisor**: Started by the supervisor when Docker functionality is requested
+3. **Workspacekit**: Interacts with workspacekit for namespace management
+4. **Container Registry**: For pulling and pushing container images
+5. **User Code**: Provides Docker CLI and API for user code
+
+## Usage Patterns
+
+### Starting Docker Daemon
+```bash
+docker-up
+```
+
+### Using Custom Docker Daemon Arguments
+```bash
+DOCKERD_ARGS='{"remap-user":"1000"}' docker-up
+```
+
+### Using Docker Compose
+```bash
+docker-compose up -d
+```
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+
+### External Dependencies
+- Docker daemon
+- Docker CLI
+- Docker Compose
+- runc (OCI container runtime)
+- iptables
+- uidmap (for user namespace mapping)
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **Rootless Execution**: Runs Docker without root privileges
+2. **User Namespace Mapping**: Isolates container user IDs from host
+3. **Capability Management**: Provides minimal required capabilities
+4. **Socket Permissions**: Controls access to the Docker socket
+5. **OOM Score Adjustment**: Prevents container processes from being killed under memory pressure
+6. **Network Isolation**: Configures network namespaces for isolation
+
+## Implementation Details
+
+### Runc-Facade
+
+The runc-facade is a wrapper around the standard runc container runtime that:
+- Modifies container configurations for rootless execution
+- Adds the CAP_NET_BIND_SERVICE capability to allow binding to privileged ports
+- Sets OOM score adjustment to prevent container processes from being killed
+- Removes problematic sysctl settings that don't work in rootless mode
+- Implements retry logic for container creation to handle timing issues
+
+### Docker Daemon Arguments
+
+The component supports custom Docker daemon arguments through the `DOCKERD_ARGS` environment variable, which accepts a JSON object with configuration options:
+- `remap-user`: Configure user namespace remapping
+- `proxies`: HTTP/HTTPS proxy settings
+- `http-proxy`: HTTP proxy configuration
+- `https-proxy`: HTTPS proxy configuration
+
+## Related Components
+
+- **Supervisor**: Manages the lifecycle of Docker-Up
+- **Workspacekit**: Provides namespace management
+- **Registry-Facade**: Interacts with Docker for image management
+- **Image-Builder**: Uses Docker for building workspace images

--- a/memory-bank/components/gitpod-cli.md
+++ b/memory-bank/components/gitpod-cli.md
@@ -1,0 +1,143 @@
+# Gitpod CLI Component
+
+## Overview
+
+The Gitpod CLI (Command Line Interface) is a utility that comes pre-installed within Gitpod workspaces, providing users with a convenient way to interact with the Gitpod platform and control various aspects of their workspace environment from the terminal.
+
+## Purpose
+
+The primary purposes of the Gitpod CLI are:
+- Provide a command-line interface for interacting with Gitpod workspaces
+- Enable users to control workspace features and settings
+- Facilitate IDE integration from the terminal
+- Manage workspace ports and port forwarding
+- Control environment variables
+- Manage workspace lifecycle
+- Coordinate task execution
+- Provide authentication and credential management
+- Enable workspace snapshots
+- Support workspace configuration
+
+## Architecture
+
+The Gitpod CLI is implemented as a Go application with a command-based structure using the Cobra command framework. It consists of several key components:
+
+1. **Command Processor**: Handles command parsing and execution
+2. **Supervisor Client**: Communicates with the workspace supervisor
+3. **Analytics Tracker**: Tracks command usage for analytics
+4. **Error Reporter**: Reports errors to the supervisor
+5. **Credential Helper**: Manages Git credentials
+
+The CLI is designed to be lightweight and efficient, providing a simple interface to the more complex functionality provided by the workspace supervisor.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic CLI configuration
+- `cmd/*.go`: Individual command implementations
+- `pkg/gitpod/`: Gitpod-specific functionality
+- `pkg/utils/`: Utility functions
+
+## Commands
+
+The Gitpod CLI provides a wide range of commands:
+
+### Workspace Management
+- `gp stop`: Stop the current workspace
+- `gp snapshot`: Take a snapshot of the current workspace
+- `gp init`: Create a Gitpod configuration for the current project
+- `gp url`: Print the URL of the current workspace
+
+### IDE Integration
+- `gp open`: Open a file in the IDE
+- `gp preview`: Open a URL in the IDE's preview
+
+### Port Management
+- `gp ports`: List all exposed ports
+- `gp ports expose`: Make a port available on 0.0.0.0
+- `gp ports await`: Wait for a process to listen on a port
+- `gp ports visibility`: Set the visibility of a port
+- `gp ports protocol`: Set the protocol of a port
+
+### Task Management
+- `gp tasks`: List all tasks
+- `gp tasks attach`: Attach to a running task
+- `gp tasks stop`: Stop a running task
+
+### Environment Variables
+- `gp env`: Manage user-defined environment variables
+
+### Synchronization
+- `gp sync-await`: Wait for an event to happen
+- `gp sync-done`: Signal that an event has happened
+
+### Authentication
+- `gp credential-helper`: Git credential helper
+- `gp idp`: Identity provider integration
+
+### Timeout Management
+- `gp timeout`: Manage workspace timeout
+- `gp timeout set`: Set workspace timeout
+- `gp timeout show`: Show workspace timeout
+- `gp timeout extend`: Extend workspace timeout
+
+### Information
+- `gp info`: Show information about the workspace
+- `gp user-info`: Show information about the user
+
+## Dependencies
+
+### Internal Dependencies
+- `components/supervisor-api/go:lib`: Supervisor API definitions
+- `components/gitpod-protocol/go:lib`: Gitpod protocol definitions
+- `components/common-go:lib`: Common Go utilities
+- `components/ide-metrics-api/go:lib`: IDE metrics API definitions
+- `components/public-api/go:lib`: Public API definitions
+
+### External Dependencies
+- Cobra for command-line interface
+- Logrus for logging
+- Various Go standard libraries
+
+## Integration Points
+
+The Gitpod CLI integrates with:
+1. **Supervisor**: Communicates with the workspace supervisor for most operations
+2. **Git**: Provides credential helper for Git authentication
+3. **IDE**: Opens files and previews in the IDE
+4. **Workspace**: Manages workspace lifecycle and configuration
+5. **Identity Providers**: Integrates with various identity providers for authentication
+
+## Error Handling
+
+The CLI implements sophisticated error handling:
+- User-friendly error messages
+- Error reporting to the supervisor
+- Error logging for debugging
+- Different exit codes for different error types
+
+## Analytics
+
+The CLI includes analytics tracking to help improve the user experience:
+- Tracks command usage
+- Records command outcomes
+- Measures command duration
+- Reports errors (with user consent)
+
+## Common Usage Patterns
+
+The Gitpod CLI is typically used to:
+1. Open files in the IDE: `gp open file.txt`
+2. Preview URLs: `gp preview https://example.com`
+3. Expose ports: `gp ports expose 8080`
+4. Manage environment variables: `gp env NAME=VALUE`
+5. Coordinate task execution: `gp sync-await event && command`
+6. Take workspace snapshots: `gp snapshot`
+7. Stop the workspace: `gp stop`
+
+## Related Components
+
+- **Supervisor**: Provides the API that the CLI uses to interact with the workspace
+- **IDE**: Receives commands from the CLI to open files and previews
+- **Server**: Manages workspace lifecycle and configuration
+- **Workspace**: The environment in which the CLI operates

--- a/memory-bank/components/gitpod-db.md
+++ b/memory-bank/components/gitpod-db.md
@@ -1,0 +1,150 @@
+# Gitpod DB Component
+
+## Overview
+
+The Gitpod DB component is the database layer for the Gitpod platform, providing a structured and type-safe interface for interacting with the underlying database. It implements the data access layer using TypeORM, a popular Object-Relational Mapping (ORM) library for TypeScript and JavaScript.
+
+## Purpose
+
+The primary purposes of the Gitpod DB component are:
+- Provide a structured interface for database operations
+- Define database entities and their relationships
+- Manage database migrations
+- Handle data encryption and security
+- Implement data access patterns
+- Support transaction management
+- Provide caching mechanisms
+- Enable database monitoring and metrics
+- Facilitate testing with database fixtures
+
+## Architecture
+
+The Gitpod DB component is built on TypeORM and follows a repository pattern with dependency injection. It consists of several key components:
+
+1. **Entity Definitions**: TypeScript classes that map to database tables
+2. **Repository Implementations**: Classes that implement data access operations
+3. **Migration System**: Manages database schema changes
+4. **Connection Management**: Handles database connections and pooling
+5. **Encryption Layer**: Secures sensitive data
+6. **Tracing Integration**: Provides observability for database operations
+7. **Caching Layer**: Improves performance for frequently accessed data
+
+The component uses Inversify for dependency injection, allowing for flexible configuration and testing.
+
+## Key Files and Structure
+
+- `src/typeorm/entity/`: Database entity definitions
+- `src/typeorm/migration/`: Database migrations
+- `src/*-db.ts`: Database interface definitions
+- `src/typeorm/*-db-impl.ts`: Database implementation classes
+- `src/container-module.ts`: Dependency injection configuration
+- `src/config.ts`: Database configuration
+- `src/typeorm/typeorm.ts`: TypeORM configuration and connection management
+- `src/redis/`: Redis-based caching implementation
+
+## Database Entities
+
+The Gitpod DB component defines numerous entities that map to database tables, including:
+
+- **User**: User accounts and profiles
+- **Workspace**: Workspace metadata and configuration
+- **WorkspaceInstance**: Running workspace instances
+- **Team**: Team organization and membership
+- **Project**: Project configuration and settings
+- **Identity**: User identity and authentication
+- **Token**: Authentication tokens and credentials
+- **AppInstallation**: Integration with external applications
+- **PrebuiltWorkspace**: Prebuild information and status
+- **PersonalAccessToken**: API access tokens
+- **WebhookEvent**: Webhook event processing
+- **AuditLog**: Security and audit logging
+
+## Database Operations
+
+The component provides implementations for various database operations:
+
+### User Operations
+- User creation, retrieval, and updates
+- Identity management
+- Authentication and authorization
+
+### Workspace Operations
+- Workspace creation and configuration
+- Workspace instance management
+- Workspace snapshots and prebuilds
+
+### Team and Project Operations
+- Team management and membership
+- Project configuration and settings
+- Environment variables management
+
+### Security Operations
+- Token management
+- Audit logging
+- Access control
+
+## Dependencies
+
+### Internal Dependencies
+- `@gitpod/gitpod-protocol`: Shared protocol definitions
+- Encryption services for securing sensitive data
+- Tracing infrastructure for observability
+
+### External Dependencies
+- TypeORM for object-relational mapping
+- MySQL as the primary database
+- Redis for caching (optional)
+- Prometheus for metrics
+
+## Configuration
+
+The Gitpod DB component is configured through environment variables and configuration files:
+
+- Database connection settings (host, port, credentials)
+- Connection pool configuration
+- Encryption keys for sensitive data
+- Migration settings
+- Caching configuration
+- Monitoring and metrics settings
+
+## Migration System
+
+The component includes a robust migration system for managing database schema changes:
+
+- Versioned migrations with up/down methods
+- Migration generation and execution tools
+- Testing infrastructure for migrations
+- Baseline schema definition
+
+## Integration Points
+
+The Gitpod DB component integrates with:
+1. **Server Component**: Provides data access for API endpoints
+2. **Workspace Manager**: Stores workspace configuration and state
+3. **Authentication System**: Manages user identities and tokens
+4. **Monitoring System**: Exposes database metrics and health
+
+## Security Considerations
+
+- Implements encryption for sensitive data
+- Provides audit logging for security events
+- Manages access control through repository patterns
+- Handles secure credential storage
+- Implements proper error handling and logging
+
+## Common Usage Patterns
+
+The Gitpod DB component is typically used to:
+1. Define database entities and their relationships
+2. Implement repository interfaces for data access
+3. Manage database migrations for schema changes
+4. Configure database connections and pooling
+5. Implement caching strategies for performance
+6. Provide transaction management for data consistency
+
+## Related Components
+
+- **Server**: Uses the DB component for data access
+- **Gitpod Protocol**: Defines shared interfaces and types
+- **Workspace Manager**: Stores workspace state in the database
+- **Authentication System**: Manages user identities and tokens

--- a/memory-bank/components/gitpod-protocol.md
+++ b/memory-bank/components/gitpod-protocol.md
@@ -1,0 +1,163 @@
+# Gitpod Protocol Component
+
+## Overview
+
+The Gitpod Protocol component serves as the core type definition and shared protocol library for the Gitpod platform. It defines the data structures, interfaces, and utility functions that are used across various components of the system, providing a consistent and type-safe way to communicate between services.
+
+## Purpose
+
+The primary purposes of the Gitpod Protocol component are:
+- Define shared data structures and interfaces
+- Provide type definitions for core Gitpod entities
+- Implement utility functions for common operations
+- Enable type-safe communication between services
+- Define service interfaces and contracts
+- Support cross-language protocol definitions
+- Provide encryption and security utilities
+- Implement messaging infrastructure
+
+## Architecture
+
+The Gitpod Protocol component is primarily a TypeScript library with additional language bindings for Go and Java. It consists of several key modules:
+
+1. **Core Protocol**: Defines the fundamental data structures and interfaces
+2. **Service Interfaces**: Defines the contracts for various services
+3. **Messaging**: Provides infrastructure for real-time communication
+4. **Encryption**: Implements secure data handling
+5. **Utilities**: Offers common helper functions and tools
+6. **Experiments**: Supports feature flagging and experimentation
+
+The component is designed to be imported by other components that need to interact with Gitpod's data model or services.
+
+## Key Files and Structure
+
+- `src/protocol.ts`: Core data structures and interfaces
+- `src/gitpod-service.ts`: Main service interface definitions
+- `src/workspace-instance.ts`: Workspace instance related types
+- `src/teams-projects-protocol.ts`: Team and project related types
+- `src/messaging/`: WebSocket and messaging infrastructure
+- `src/encryption/`: Encryption and security utilities
+- `src/util/`: Common utility functions
+- `src/experiments/`: Feature flag and experimentation support
+- `go/`: Go language bindings
+- `java/`: Java language bindings
+
+## Core Data Structures
+
+The Gitpod Protocol defines numerous core data structures, including:
+
+### User and Authentication
+- `User`: User account information
+- `Identity`: Authentication provider identity
+- `Token`: Authentication tokens
+- `GitpodToken`: API tokens
+- `AuthProviderInfo`: Authentication provider metadata
+- `AuthProviderEntry`: Authentication provider configuration
+
+### Workspace
+- `Workspace`: Workspace metadata and configuration
+- `WorkspaceInstance`: Running workspace instance
+- `WorkspaceContext`: Context for workspace creation
+- `WorkspaceConfig`: Configuration for workspaces
+- `WorkspaceImageSource`: Source for workspace images
+- `PrebuiltWorkspace`: Prebuild information
+
+### Repository
+- `Repository`: Source code repository information
+- `Commit`: Git commit information
+- `CommitContext`: Context for a specific commit
+- `PullRequestContext`: Context for a pull request
+- `IssueContext`: Context for an issue
+
+### Environment
+- `EnvVar`: Environment variable
+- `UserEnvVar`: User-specific environment variable
+- `ProjectEnvVar`: Project-specific environment variable
+- `OrgEnvVar`: Organization-specific environment variable
+
+### Configuration
+- `PortConfig`: Port forwarding configuration
+- `TaskConfig`: Task definition
+- `ImageConfig`: Workspace image configuration
+- `VSCodeConfig`: VS Code specific configuration
+- `JetBrainsConfig`: JetBrains IDE specific configuration
+
+## Service Interfaces
+
+The protocol defines interfaces for various Gitpod services:
+
+- `GitpodClient`: Client-side interface for Gitpod service
+- `GitpodServer`: Server-side interface for Gitpod service
+- `HeadlessLogService`: Service for headless workspace logs
+- `WorkspaceInstancePort`: Service for workspace ports
+- `IDEFrontendService`: Service for IDE frontend integration
+
+## Messaging Infrastructure
+
+The protocol includes infrastructure for real-time messaging:
+
+- `JsonRpcProxy`: JSON-RPC based proxy for service communication
+- `WebSocketConnection`: WebSocket connection management
+- `EventEmitter`: Event-based communication
+- `Disposable`: Resource management
+
+## Encryption
+
+The protocol provides encryption utilities:
+
+- `EncryptionService`: Service for encrypting and decrypting data
+- `KeyProvider`: Provider for encryption keys
+- `CryptoKeyStore`: Storage for cryptographic keys
+
+## Dependencies
+
+### Internal Dependencies
+- None (this is a foundational component)
+
+### External Dependencies
+- TypeScript for type definitions
+- JSON-RPC for service communication
+- WebSocket for real-time messaging
+- Crypto libraries for encryption
+
+## Language Bindings
+
+The Gitpod Protocol provides bindings for multiple languages:
+
+### TypeScript/JavaScript
+- Primary implementation
+- Used by frontend and Node.js backend services
+
+### Go
+- Used by Go-based backend services
+- Provides equivalent type definitions
+
+### Java
+- Used by Java-based services
+- Provides equivalent type definitions
+
+## Integration Points
+
+The Gitpod Protocol integrates with:
+1. **Server**: Uses protocol definitions for API endpoints
+2. **Dashboard**: Uses protocol for client-server communication
+3. **Workspace**: Uses protocol for workspace configuration
+4. **IDE Integration**: Uses protocol for IDE-specific settings
+5. **Authentication**: Uses protocol for auth provider configuration
+
+## Common Usage Patterns
+
+The Gitpod Protocol is typically used to:
+1. Define data structures for database entities
+2. Specify API contracts between services
+3. Implement type-safe communication
+4. Share utility functions across components
+5. Ensure consistent handling of core concepts
+
+## Related Components
+
+- **Server**: Implements the server-side of the protocol
+- **Dashboard**: Implements the client-side of the protocol
+- **Gitpod DB**: Persists entities defined in the protocol
+- **Workspace Manager**: Uses workspace-related protocol definitions
+- **IDE Service**: Uses IDE-related protocol definitions

--- a/memory-bank/components/ide-metrics.md
+++ b/memory-bank/components/ide-metrics.md
@@ -1,0 +1,152 @@
+# IDE Metrics Component
+
+## Overview
+
+The IDE Metrics component is a service in Gitpod that collects, processes, and exposes metrics and error reports from various IDE components. It provides a centralized way to gather performance data, usage statistics, and error information from IDE-related components such as the supervisor, VS Code extensions, and web workbenches.
+
+## Purpose
+
+The primary purposes of the IDE Metrics component are:
+- Collect metrics from IDE components
+- Process and validate metric data
+- Expose metrics in Prometheus format
+- Handle error reporting from IDE components
+- Provide a gRPC and REST API for metrics submission
+- Support aggregated histogram metrics for efficient data collection
+- Implement security measures through label allowlists
+- Enable monitoring of IDE performance and usage
+
+## Architecture
+
+The IDE Metrics component is built as a Go service with several key components:
+
+1. **Metrics Server**: Core server that handles gRPC and HTTP requests
+2. **Metrics Registry**: Manages Prometheus metrics
+3. **Error Reporter**: Processes and forwards error reports
+4. **Label Validator**: Validates metric labels against allowlists
+5. **Aggregated Histograms**: Efficiently handles histogram data
+
+The component exposes both gRPC and HTTP endpoints for metrics submission and provides a Prometheus-compatible endpoint for metrics scraping.
+
+## Key Files and Structure
+
+- `main.go`: Entry point for the application
+- `cmd/root.go`: Command-line interface setup
+- `cmd/run.go`: Main server run command
+- `pkg/server/server.go`: Core server implementation
+- `pkg/metrics/`: Metrics handling utilities
+- `pkg/errorreporter/`: Error reporting functionality
+- `config-example.json`: Example configuration
+
+## Metrics Types
+
+The IDE Metrics component supports several types of metrics:
+
+### Counter Metrics
+Simple counters that can be incremented or added to, used for tracking occurrences of events.
+
+### Histogram Metrics
+Record observations in buckets, used for measuring durations or sizes.
+
+### Aggregated Histogram Metrics
+Efficiently handle pre-aggregated histogram data, reducing the number of individual metric submissions.
+
+## Error Reporting
+
+The component includes an error reporting system that:
+- Validates error reports against an allowlist of components
+- Structures error data with contextual information
+- Forwards errors to an error reporting service
+- Includes workspace and user context with errors
+
+## Security Measures
+
+The IDE Metrics component implements several security measures:
+
+### Label Allowlists
+- Validates metric labels against configured allowlists
+- Replaces invalid labels with default or "unknown" values
+- Logs unexpected label names or values
+- Prevents metric explosion from arbitrary labels
+
+### Component Allowlists
+- Validates error reporting components against an allowlist
+- Prevents unauthorized components from submitting errors
+- Logs attempts from unexpected components
+
+## Configuration
+
+The IDE Metrics component is configured through a JSON configuration file:
+
+```json
+{
+  "server": {
+    "port": 9500,
+    "counterMetrics": [
+      {
+        "name": "example_counter",
+        "help": "Example counter metric",
+        "labels": [
+          {
+            "name": "label1",
+            "allowValues": ["value1", "value2"],
+            "defaultValue": "unknown"
+          }
+        ]
+      }
+    ],
+    "histogramMetrics": [...],
+    "aggregatedHistogramMetrics": [...],
+    "errorReporting": {
+      "allowComponents": ["supervisor", "vscode-web"]
+    }
+  },
+  "prometheus": {
+    "addr": "localhost:9500"
+  }
+}
+```
+
+## API Endpoints
+
+The IDE Metrics component exposes several API endpoints:
+
+- `/metrics-api/`: Base path for all API requests
+- `/metrics`: Prometheus metrics endpoint
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+- `components/ide-metrics-api`: API definitions
+
+### External Dependencies
+- Prometheus client for metrics
+- gRPC for API communication
+- gRPC-web for browser compatibility
+- cmux for multiplexing connections
+
+## Integration Points
+
+The IDE Metrics component integrates with:
+1. **Supervisor**: Submits metrics and error reports
+2. **VS Code Extensions**: Submit metrics and error reports
+3. **Web Workbench**: Submits metrics and error reports
+4. **Prometheus**: Scrapes exposed metrics
+5. **Error Reporting Service**: Receives error reports
+
+## Common Usage Patterns
+
+The IDE Metrics component is typically used to:
+1. Track IDE performance metrics
+2. Monitor feature usage
+3. Collect error reports from IDE components
+4. Generate dashboards for IDE health and usage
+5. Identify performance bottlenecks
+
+## Related Components
+
+- **IDE Service**: Configures and manages IDEs
+- **IDE Proxy**: Proxies requests to IDE Metrics
+- **Supervisor**: Submits metrics and error reports
+- **Dashboard**: May display metrics data

--- a/memory-bank/components/ide-proxy.md
+++ b/memory-bank/components/ide-proxy.md
@@ -1,0 +1,129 @@
+# IDE Proxy Component
+
+## Overview
+
+The IDE Proxy is a lightweight component in Gitpod that serves static assets related to IDEs, including IDE logos, binaries, and configuration files. It acts as a centralized service for delivering IDE-related static content to other components of the Gitpod platform, particularly the dashboard and workspaces.
+
+## Purpose
+
+The primary purposes of the IDE Proxy component are:
+- Serve static IDE-related assets (logos, icons, etc.)
+- Provide a centralized location for IDE binaries and downloads
+- Serve the Gitpod Local Companion application binaries
+- Proxy requests to the blobserve component for IDE-related content
+- Provide metrics endpoints for IDE usage
+- Implement proper caching and security headers for static content
+- Serve VS Code marketplace extension information
+
+## Architecture
+
+The IDE Proxy is built on Caddy, a modern web server with automatic HTTPS capabilities. It consists of several key components:
+
+1. **Static File Server**: Serves static files like IDE logos and binaries
+2. **Proxy Rules**: Routes specific requests to other services like blobserve
+3. **Security Headers**: Implements security policies for served content
+4. **Caching Configuration**: Optimizes content delivery with appropriate caching
+5. **Health Checks**: Provides endpoints for monitoring system health
+
+## Key Files and Structure
+
+- `Dockerfile`: Builds the IDE Proxy container image
+- `conf/Caddyfile`: Main configuration file for the Caddy server
+- `static/image/ide-logo/`: Contains SVG logos for various IDEs
+- `static/bin/`: Contains binaries for Gitpod Local Companion (added during build)
+- `static/code/`: Contains VS Code marketplace information (added during build)
+
+## Static Assets
+
+### IDE Logos
+The component serves SVG logos for various IDEs:
+- VS Code (standard and Insiders)
+- JetBrains IDEs:
+  - IntelliJ IDEA
+  - GoLand
+  - PyCharm
+  - PhpStorm
+  - RubyMine
+  - WebStorm
+  - Rider
+  - CLion
+  - RustRover
+- Terminal
+
+### Binaries
+The component serves binaries for:
+- Gitpod Local Companion for various platforms:
+  - Linux (x86_64)
+  - macOS (x86_64)
+  - Windows (x86_64)
+
+## Routing Rules
+
+The IDE Proxy implements several routing rules:
+
+1. **Static Content**: Serves files from the `/www` directory with appropriate headers
+2. **Blobserve Proxy**: Routes `/blobserve/*` requests to the blobserve service
+3. **Binary Assets**: Serves binary files with appropriate content-type and disposition headers
+4. **Metrics**: Routes metrics-related requests to the ide-metrics service
+5. **Health Checks**: Provides `/live` and `/ready` endpoints for health monitoring
+
+## Configuration
+
+The IDE Proxy is configured through the Caddyfile, which includes:
+
+### Security Headers
+- HTTP Strict Transport Security (HSTS)
+- Content-Type Options
+- Content Security Policy
+- Referrer Policy
+- XSS Protection
+
+### Caching Configuration
+- Long-term caching for static assets (1 year)
+- Short-term caching for binary assets (10 minutes)
+
+### Compression
+- Supports gzip and zstd compression for efficient content delivery
+
+## Dependencies
+
+### Internal Dependencies
+- `blobserve`: For serving IDE-related blob content
+- `ide-metrics`: For metrics collection
+- `local-app`: For Gitpod Local Companion binaries
+
+### External Dependencies
+- Caddy web server
+- OpenVSX marketplace data
+
+## Integration Points
+
+The IDE Proxy integrates with:
+1. **Dashboard**: Provides IDE logos and information for the UI
+2. **Blobserve**: Proxies requests to blobserve for IDE content
+3. **IDE Metrics**: Routes metrics requests to the metrics service
+4. **Local App**: Serves the Gitpod Local Companion binaries
+
+## Security Considerations
+
+- Implements comprehensive security headers
+- Ensures proper content-type for binary downloads
+- Configures appropriate CORS headers for cross-origin requests
+- Removes server identification headers
+
+## Common Usage Patterns
+
+The IDE Proxy is typically used to:
+1. Serve IDE logos for the dashboard UI
+2. Provide downloadable binaries for Gitpod Local Companion
+3. Proxy requests to blobserve for IDE-related content
+4. Serve VS Code marketplace extension information
+5. Collect and expose IDE usage metrics
+
+## Related Components
+
+- **IDE**: Provides the IDE binaries and assets
+- **IDE Service**: Resolves IDE requirements
+- **Blobserve**: Serves blob content that may be proxied through IDE Proxy
+- **Dashboard**: Consumes IDE logos and information
+- **IDE Metrics**: Collects and processes IDE usage metrics

--- a/memory-bank/components/ide-service.md
+++ b/memory-bank/components/ide-service.md
@@ -1,0 +1,117 @@
+# IDE Service Component
+
+## Overview
+
+The IDE Service is a critical component in Gitpod that manages IDE configurations, resolves workspace IDE requirements, and provides information about available IDEs to other components in the system. It serves as the central authority for IDE-related information and decision-making.
+
+## Purpose
+
+The primary purposes of the IDE Service are:
+- Manage and serve IDE configuration information
+- Resolve which IDE images should be used for workspaces
+- Provide IDE configuration to clients and other services
+- Handle IDE version management and pinning
+- Support multiple IDE types (browser-based and desktop)
+- Integrate with various IDE clients (VS Code, JetBrains, etc.)
+
+## Architecture
+
+The IDE Service operates as a gRPC server with several key components:
+
+1. **Config Manager**: Manages and serves IDE configuration information
+2. **Workspace Config Resolver**: Determines the appropriate IDE configuration for workspaces
+3. **Docker Registry Integration**: Interacts with container registries for IDE images
+4. **Experiments Integration**: Supports feature flags and experiments for IDE features
+
+The service is designed to be lightweight and stateless, primarily serving configuration information and making decisions based on user preferences, workspace requirements, and system configuration.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/run.go`: Implements the main service functionality
+- `pkg/server/server.go`: Core server implementation
+- `pkg/server/ideconfig.go`: IDE configuration handling
+- `example-ide-config.json`: Example IDE configuration file
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities
+- `components/gitpod-protocol/go:lib`: Gitpod protocol definitions
+- `components/ide-service-api/go:lib`: IDE service API definitions
+
+### External Dependencies
+- Docker registry client libraries
+- gRPC for service communication
+- JSON schema validation
+- Prometheus for metrics
+
+## Configuration
+
+The IDE Service is configured via two primary JSON configuration files:
+
+### Service Configuration
+- Server address and port
+- Docker registry authentication
+- IDE configuration file path
+
+### IDE Configuration
+- Available IDEs and their properties
+- IDE image references
+- IDE version information
+- Client configuration (VS Code, JetBrains Gateway, etc.)
+- Default IDE settings
+
+## API Services
+
+The IDE Service exposes a gRPC API that provides:
+
+1. **GetConfig**: Retrieves the current IDE configuration
+2. **ResolveWorkspaceConfig**: Determines the appropriate IDE configuration for a workspace based on:
+   - User preferences
+   - Workspace requirements
+   - IDE availability
+   - Client type (browser, desktop application)
+
+## Integration Points
+
+The IDE Service integrates with:
+1. **Workspace Manager**: Provides IDE configuration for workspace creation
+2. **Supervisor**: Supplies IDE configuration for workspace initialization
+3. **Dashboard**: Provides available IDE options for user selection
+4. **Docker Registry**: Retrieves IDE image information
+5. **Experiments Service**: For feature flags and A/B testing
+
+## IDE Management
+
+The IDE Service manages several types of IDEs:
+1. **Browser-based IDEs**:
+   - VS Code (browser version)
+   - Other web-based editors
+
+2. **Desktop IDEs**:
+   - VS Code Desktop
+   - JetBrains IDEs (IntelliJ, GoLand, PyCharm, PhpStorm)
+
+For each IDE, it manages:
+- Container images
+- Version information
+- Client integration details
+- Configuration options
+
+## Common Usage Patterns
+
+The IDE Service is typically used to:
+1. Provide IDE configuration to the dashboard for user selection
+2. Resolve which IDE images should be used for a workspace
+3. Handle IDE version pinning and updates
+4. Support different IDE clients (browser, desktop applications)
+5. Manage IDE-specific configuration options
+
+## Related Components
+
+- **Supervisor**: Uses IDE configuration to start the appropriate IDE
+- **Workspace Manager**: Incorporates IDE requirements into workspace creation
+- **Dashboard**: Displays IDE options to users
+- **Content Service**: May interact for IDE plugin management

--- a/memory-bank/components/ide.md
+++ b/memory-bank/components/ide.md
@@ -1,0 +1,138 @@
+# IDE Component
+
+## Overview
+
+The IDE component in Gitpod is responsible for packaging and managing the various Integrated Development Environments (IDEs) that are available to users within Gitpod workspaces. It includes support for VS Code (both web and desktop versions) and JetBrains IDEs, providing the necessary files, configurations, and integration points for these IDEs to work seamlessly within the Gitpod environment.
+
+## Purpose
+
+The primary purposes of the IDE component are:
+- Package and distribute IDE binaries for use in Gitpod workspaces
+- Configure IDEs to work within the Gitpod environment
+- Provide integration between IDEs and the Gitpod platform
+- Support multiple IDE types (VS Code, JetBrains)
+- Enable both web-based and desktop IDE experiences
+- Manage IDE versions and updates
+- Provide IDE-specific extensions and plugins
+
+## Architecture
+
+The IDE component is organized into several sub-components, each responsible for a specific IDE or IDE family:
+
+1. **Code**: Packages VS Code (OpenVSCode Server) for web-based usage
+2. **Code-Desktop**: Packages VS Code for desktop usage
+3. **JetBrains**: Packages various JetBrains IDEs (IntelliJ, GoLand, PyCharm, etc.)
+4. **Xterm**: Provides terminal functionality
+
+Each IDE sub-component typically includes:
+- Dockerfiles for building IDE images
+- Configuration files for IDE integration
+- Scripts for downloading and setting up IDE binaries
+- Plugins or extensions for Gitpod integration
+
+## Key Files and Structure
+
+### VS Code (Code)
+- `code/BUILD.yaml`: Build configuration for VS Code
+- `code/leeway.Dockerfile`: Dockerfile for building VS Code image
+- `code/codehelper/`: Helper utilities for VS Code
+- `code/gitpod-web-extension/`: Gitpod-specific VS Code extension
+
+### JetBrains
+- `jetbrains/image/`: JetBrains IDE image building
+- `jetbrains/image/BUILD.js`: Build script for JetBrains IDE images
+- `jetbrains/image/leeway.Dockerfile`: Dockerfile for JetBrains IDE images
+- `jetbrains/image/supervisor-ide-config_*.json`: IDE-specific configuration files
+- `jetbrains/backend-plugin/`: Backend plugin for JetBrains IDEs
+- `jetbrains/gateway-plugin/`: Gateway plugin for JetBrains remote development
+- `jetbrains/launcher/`: Launcher for JetBrains IDEs
+- `jetbrains/cli/`: Command-line interface for JetBrains IDEs
+
+## Supported IDEs
+
+### VS Code
+- Web-based VS Code (OpenVSCode Server)
+- Desktop VS Code
+
+### JetBrains
+- IntelliJ IDEA
+- GoLand
+- PyCharm
+- PhpStorm
+- RubyMine
+- WebStorm
+- Rider
+- CLion
+- RustRover
+
+Each JetBrains IDE is available in two versions:
+- Stable: Regular release version
+- Latest: Latest EAP (Early Access Program) or RC (Release Candidate) version
+
+## Build Process
+
+### VS Code
+1. Clones the OpenVSCode Server repository
+2. Builds the web and desktop versions
+3. Packages the built binaries into a Docker image
+4. Configures the image for use with Gitpod
+
+### JetBrains
+1. Downloads the specified JetBrains IDE binary
+2. Creates a Docker image with the IDE binary
+3. Configures the IDE for use with Gitpod
+4. Sets up the necessary plugins and extensions
+
+## Integration Points
+
+The IDE component integrates with:
+1. **Supervisor**: For launching and managing IDEs within workspaces
+2. **Workspace**: For accessing workspace content
+3. **IDE Service**: For resolving IDE requirements
+4. **Blobserve**: For serving static IDE assets
+5. **Registry Facade**: For providing IDE images
+
+## Configuration
+
+Each IDE has specific configuration requirements:
+
+### VS Code
+- Extensions to be pre-installed
+- Web configuration for browser-based usage
+- Desktop configuration for desktop usage
+
+### JetBrains
+- IDE-specific configuration files
+- Backend plugin configuration
+- Gateway plugin configuration
+- CLI configuration
+
+## Dependencies
+
+### Internal Dependencies
+- `supervisor`: For IDE lifecycle management
+- `ide-service`: For IDE resolution
+- `blobserve`: For serving static assets
+- `registry-facade`: For image management
+
+### External Dependencies
+- VS Code (OpenVSCode Server) source code
+- JetBrains IDE binaries
+- Various build tools (Node.js, npm, etc.)
+
+## Common Usage Patterns
+
+The IDE component is typically used to:
+1. Build and package IDE images for use in Gitpod workspaces
+2. Configure IDEs for optimal use within Gitpod
+3. Provide integration between IDEs and the Gitpod platform
+4. Support both web-based and desktop IDE experiences
+5. Manage IDE versions and updates
+
+## Related Components
+
+- **IDE Service**: Resolves IDE requirements and manages IDE configurations
+- **IDE Proxy**: Proxies requests to IDEs
+- **Supervisor**: Manages IDE lifecycle within workspaces
+- **Blobserve**: Serves static IDE assets
+- **Registry Facade**: Provides IDE images

--- a/memory-bank/components/image-builder-bob.md
+++ b/memory-bank/components/image-builder-bob.md
@@ -1,0 +1,153 @@
+# Image-Builder-Bob Component
+
+## Overview
+
+The Image-Builder-Bob component in Gitpod is a CLI tool responsible for building and pushing workspace images during workspace startup. It operates within a headless workspace created by the image-builder-mk3 component and handles the building of custom Docker images based on user-defined Dockerfiles in `.gitpod.yml`. The component consists of two main parts: a build process that creates the images and a proxy that handles authentication for pushing the images to registries.
+
+## Purpose
+
+The primary purposes of the Image-Builder-Bob component are:
+- Build custom workspace images from user-defined Dockerfiles
+- Create base layers for workspace images
+- Push built images to container registries
+- Handle authentication for private container registries
+- Provide a secure way to build images without exposing registry credentials
+- Support the workspace prebuild process
+- Enable customization of development environments
+- Optimize image building with caching
+- Facilitate the use of custom Docker configurations in workspaces
+
+## Architecture
+
+The Image-Builder-Bob component consists of several key parts:
+
+1. **Bob Build**: A command that builds the base layer and workspace image
+2. **Bob Proxy**: A proxy that authenticates image pushes to registries
+3. **Builder Package**: Core functionality for building images
+4. **Proxy Package**: Handles registry authentication and proxying
+5. **Runc-Facade**: A wrapper for the runc container runtime
+
+The component operates in a headless workspace where:
+- `bob proxy` runs in ring1 (started by workspacekit) and receives credentials for pushing images
+- `bob build` runs as a workspace task and builds the images, pushing them to `bob proxy`
+
+## Key Features
+
+### Image Building
+
+- **Base Layer Building**: Creates a base image from a custom Dockerfile specified in `.gitpod.yml`
+- **Workspace Image Building**: Uses the base layer to create a workspace image
+- **Caching**: Reuses previously built base images when available
+- **Buildkit Integration**: Uses Buildkit for efficient image building
+- **Context Management**: Handles the build context for Docker images
+- **Error Handling**: Provides detailed error messages for build failures
+- **Logging**: Writes build logs to `/workspace/.gitpod/bob.log`
+
+### Registry Authentication
+
+- **Secure Credential Handling**: Manages registry credentials securely
+- **Authentication Proxy**: Proxies and authenticates image pushes
+- **Encryption**: Supports encrypted authentication tokens
+- **Multiple Registry Support**: Can authenticate with different registries
+- **Cloud Provider Integration**: Supports authentication with cloud provider registries (AWS ECR, etc.)
+
+## Configuration
+
+The Image-Builder-Bob component is configured through environment variables:
+
+### Build Configuration
+- `BOB_TARGET_REF`: Reference for the target image
+- `BOB_BASE_REF`: Reference for the base image
+- `BOB_BUILD_BASE`: Whether to build the base image
+- `BOB_DOCKERFILE_PATH`: Path to the Dockerfile
+- `BOB_CONTEXT_DIR`: Directory to use as build context
+- `BOB_EXTERNAL_BUILDKITD`: External Buildkit daemon to use
+- `BOB_LOCAL_CACHE_IMPORT`: Local cache import configuration
+- `THEIA_WORKSPACE_ROOT`: Workspace root directory
+
+### Authentication Configuration
+- `BOB_BASELAYER_AUTH`: Authentication for the base layer registry
+- `BOB_WSLAYER_AUTH`: Authentication for the workspace layer registry
+- `BOB_AUTH_KEY`: Key for decrypting authentication tokens
+
+### Proxy Configuration
+- `WORKSPACEKIT_BOBPROXY_BASEREF`: Base image reference for the proxy
+- `WORKSPACEKIT_BOBPROXY_TARGETREF`: Target image reference for the proxy
+- `WORKSPACEKIT_BOBPROXY_AUTH`: Authentication for the proxy
+- `WORKSPACEKIT_BOBPROXY_ADDITIONALAUTH`: Additional authentication for the proxy
+
+## Usage Patterns
+
+### Building an Image
+```bash
+BOB_BASE_REF=localhost:5000/source:latest BOB_TARGET_REF=localhost:5000/target:83 bob build
+```
+
+### Running the Proxy
+```bash
+bob proxy --base-ref=localhost:5000/source:latest --target-ref=localhost:5000/target:83 --auth='{"username":"user","password":"pass"}'
+```
+
+### Typical Workflow
+1. `image-builder-mk3` creates a headless workspace
+2. `bob proxy` starts in ring1 with registry credentials
+3. `bob build` runs as a workspace task
+4. Base layer is built if needed (custom Dockerfile)
+5. Workspace image is built using the base layer
+6. Images are pushed through `bob proxy` to the registry
+7. Workspace starts using the built image
+
+## Integration Points
+
+The Image-Builder-Bob component integrates with:
+1. **Image-Builder-MK3**: Creates the headless workspace where Bob runs
+2. **Workspacekit**: Starts `bob proxy` in ring1
+3. **Registry-Facade**: The built images are later modified by registry-facade
+4. **Container Registries**: For pushing and pulling images
+5. **Buildkit**: For efficient image building
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+
+### External Dependencies
+- Buildkit: For building container images
+- Docker Registry: For storing built images
+- Containerd: For container operations
+- OCI Tools: For working with OCI images
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **Credential Isolation**: Registry credentials are only available to `bob proxy`, not to user code
+2. **Encryption**: Authentication tokens can be encrypted
+3. **Proxy Authentication**: All image pushes are authenticated through the proxy
+4. **Rootless Building**: Images are built without requiring root privileges
+5. **Isolated Workspaces**: Building happens in isolated headless workspaces
+
+## Implementation Details
+
+### Build Process
+
+The build process consists of two main steps:
+1. **Base Layer Building**: If a custom Dockerfile is specified, a base image is built
+2. **Workspace Image Building**: Using crane to copy the image from the base layer
+
+The base layer can be either a previously built custom Dockerfile or a public image. The built images do not include components like `supervisor` or the IDE, as these layers are added by `registry-facade` during image pull.
+
+### Proxy Implementation
+
+The proxy acts as an intermediary between `bob build` and the actual container registry:
+1. Receives image pushes from `bob build` on localhost
+2. Authenticates with the target registry using provided credentials
+3. Forwards the image to the target registry
+4. Handles authentication for both base and target images
+
+## Related Components
+
+- **Image-Builder-MK3**: Orchestrates the image building process
+- **Registry-Facade**: Adds additional layers to the built images
+- **Supervisor**: Manages the workspace environment
+- **Workspacekit**: Starts `bob proxy` in ring1

--- a/memory-bank/components/image-builder-mk3.md
+++ b/memory-bank/components/image-builder-mk3.md
@@ -1,0 +1,123 @@
+# Image Builder MK3 Component
+
+## Overview
+
+The Image Builder MK3 is a service that runs in Gitpod clusters and is responsible for building custom workspace images based on user-defined configurations. It provides APIs to create and list workspace image builds, resolve workspace Docker image references, and listen to build updates and logs.
+
+## Purpose
+
+The primary purposes of the Image Builder MK3 are:
+- Build custom workspace images based on user-defined Dockerfiles
+- Manage the lifecycle of image builds
+- Provide APIs for creating and monitoring image builds
+- Resolve workspace Docker image references
+- Cache frequently used base images
+- Stream build logs to clients
+
+## Architecture
+
+The Image Builder MK3 operates as a gRPC service with several key components:
+
+1. **Orchestrator**: Manages the image build process
+2. **Reference Resolver**: Resolves Docker image references
+3. **Build Manager**: Handles build creation and status tracking
+4. **Log Streamer**: Streams build logs to clients
+5. **Cache Manager**: Manages caching of frequently used images
+
+The service interacts with the Workspace Manager to coordinate image builds and with container registries to store and retrieve images.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/run.go`: Implements the main service functionality
+- `pkg/orchestrator/`: Core orchestration logic for image builds
+- `pkg/resolve/`: Image reference resolution
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities
+- `components/content-service-api/go:lib`: Content service API definitions
+- `components/content-service:lib`: Content service client
+- `components/image-builder-api/go:lib`: Image builder API definitions
+- `components/supervisor-api/go:lib`: Supervisor API definitions
+- `components/ws-manager-api/go:lib`: Workspace manager API definitions
+- `components/registry-facade-api/go:lib`: Registry facade API definitions
+
+### External Dependencies
+- Docker registry client libraries
+- Kubernetes client libraries
+- gRPC for service communication
+- Prometheus for metrics
+
+## Configuration
+
+The Image Builder MK3 is configured via a JSON configuration file that includes:
+
+### Orchestrator Configuration
+- Workspace Manager connection details
+- Pull secret for accessing private registries
+- Base image repository
+- Workspace image repository
+- Builder image reference
+
+### Reference Cache Configuration
+- Cache interval
+- References to cache
+
+### Server Configuration
+- gRPC server address and port
+- TLS settings
+
+## API Services
+
+The Image Builder MK3 exposes a gRPC API that provides:
+
+1. **BuildImage**: Initiates a new image build
+2. **ListBuilds**: Lists existing image builds
+3. **BuildStatus**: Retrieves the status of a specific build
+4. **BuildLogs**: Streams logs from a build
+5. **ResolveWorkspaceImage**: Resolves a workspace image reference
+
+## Build Process
+
+The image build process follows these steps:
+
+1. Client requests an image build via the API
+2. Image Builder creates a build record and initiates the build
+3. Builder container is created to execute the build
+4. Build logs are streamed back to the client
+5. Built image is pushed to the configured registry
+6. Build status is updated and made available to clients
+
+## Integration Points
+
+The Image Builder MK3 integrates with:
+1. **Workspace Manager**: For workspace coordination
+2. **Container Registries**: For storing and retrieving images
+3. **Kubernetes**: For running builder containers
+4. **Content Service**: For accessing workspace content
+
+## Security Considerations
+
+- Handles authentication with private registries
+- Requires proper IAM permissions when using cloud-based registries
+- Manages sensitive build context and credentials
+- Implements proper isolation for build processes
+
+## Common Usage Patterns
+
+The Image Builder MK3 is typically used to:
+1. Build custom workspace images from user-defined Dockerfiles
+2. Resolve workspace image references for workspace creation
+3. Monitor the progress of image builds
+4. Stream build logs to users
+5. Cache frequently used base images
+
+## Related Components
+
+- **Workspace Manager**: Coordinates with Image Builder for workspace creation
+- **Registry Facade**: Serves images built by Image Builder
+- **Content Service**: Provides content for image builds
+- **Supervisor**: Uses images built by Image Builder

--- a/memory-bank/components/ipfs.md
+++ b/memory-bank/components/ipfs.md
@@ -1,0 +1,193 @@
+# IPFS Component
+
+## Overview
+
+The IPFS (InterPlanetary File System) component in Gitpod consists of two main parts: Kubo and IPFS Cluster. Kubo is the core IPFS implementation in Go, while IPFS Cluster provides pinset orchestration for IPFS. This component is primarily used by the registry-facade component to cache container image layers, improving performance and reliability of workspace image distribution.
+
+## Purpose
+
+The primary purposes of the IPFS component are:
+- Cache container image layers for faster workspace startup
+- Provide a distributed content-addressable storage system
+- Reduce bandwidth usage by deduplicating container image layers
+- Improve reliability of image distribution
+- Enable efficient sharing of container images across nodes
+- Support the registry-facade component with blob storage
+- Provide content-based addressing for immutable data
+- Enhance performance of workspace image pulls
+- Reduce load on external container registries
+
+## Architecture
+
+The IPFS component consists of two main parts:
+
+1. **Kubo**: The core IPFS implementation in Go
+   - Provides the IPFS node functionality
+   - Handles content-addressable storage
+   - Manages the IPFS peer-to-peer network
+   - Exposes an HTTP API for interacting with IPFS
+
+2. **IPFS Cluster**: A pinset orchestration layer for IPFS
+   - Coordinates multiple IPFS nodes
+   - Manages pinning of content across nodes
+   - Ensures data replication and availability
+   - Provides an API for cluster management
+
+Both components are packaged as Docker images that wrap the official IPFS images with additional tools like `jq` and, in the case of IPFS Cluster, `kubectl` for Kubernetes integration.
+
+## Key Features
+
+### Kubo (IPFS Node)
+
+- **Content-Addressable Storage**: Stores data based on its content hash
+- **Deduplication**: Automatically deduplicates identical content
+- **P2P Network**: Participates in the IPFS peer-to-peer network
+- **HTTP API**: Provides an API for interacting with the IPFS node
+- **Content Retrieval**: Enables retrieval of content by its CID (Content Identifier)
+- **Content Storage**: Allows adding content to the IPFS network
+
+### IPFS Cluster
+
+- **Pinset Management**: Coordinates pinning of content across IPFS nodes
+- **Replication**: Ensures content is replicated across multiple nodes
+- **Health Monitoring**: Monitors the health of IPFS nodes
+- **Kubernetes Integration**: Includes kubectl for Kubernetes integration
+- **Cluster API**: Provides an API for managing the IPFS cluster
+
+## Integration Points
+
+The IPFS component integrates with:
+1. **Registry-Facade**: Uses IPFS for caching container image layers
+2. **Redis**: Used alongside IPFS for mapping digests to CIDs
+3. **Container Registries**: Caches content from external registries
+4. **Kubernetes**: IPFS Cluster includes kubectl for Kubernetes integration
+
+## Usage Patterns
+
+### Container Image Caching
+
+The primary use of IPFS in Gitpod is for caching container image layers:
+
+1. When a container image is pulled, registry-facade checks if the layers are already in IPFS
+2. If a layer is not in IPFS, it is fetched from the original source and stored in IPFS
+3. The digest of the layer is mapped to its IPFS CID in Redis
+4. For subsequent pulls, layers are retrieved from IPFS instead of the original source
+5. This improves performance and reduces bandwidth usage
+
+### IPFS API Usage
+
+The registry-facade component interacts with IPFS through its HTTP API:
+
+```go
+// Store a blob in IPFS
+func (store *IPFSBlobCache) Store(ctx context.Context, dgst digest.Digest, r io.ReadCloser, mediaType string) error {
+    // Create a file from the reader
+    file := files.NewReaderFile(r)
+
+    // Add the file to IPFS
+    path, err := store.IPFS.Unixfs().Add(ctx, file)
+    if err != nil {
+        return err
+    }
+
+    // Store the mapping from digest to CID in Redis
+    err = store.Redis.Set(ctx, dgst.String(), path.Cid().String(), 0).Err()
+    if err != nil {
+        return err
+    }
+
+    return nil
+}
+
+// Get a blob from IPFS
+func (store *IPFSBlobCache) Get(ctx context.Context, dgst digest.Digest) (ipfsURL string, err error) {
+    // Get the CID from Redis
+    ipfsCID, err := store.Redis.Get(ctx, dgst.String()).Result()
+    if err != nil {
+        return "", err
+    }
+
+    return "ipfs://" + ipfsCID, nil
+}
+```
+
+## Configuration
+
+The IPFS component is configured through environment variables and configuration files:
+
+### Kubo Configuration
+- Version is specified by the `ipfsKuboVersion` variable
+- Additional configuration is typically provided through IPFS config files
+
+### IPFS Cluster Configuration
+- Version is specified by the `ipfsClusterVersion` variable
+- Cluster configuration is typically provided through IPFS Cluster config files
+
+### Registry-Facade Integration
+The registry-facade component is configured to use IPFS through its configuration:
+
+```json
+{
+  "ipfs": {
+    "enabled": true,
+    "ipfsAddr": "/ip4/127.0.0.1/tcp/5001"
+  }
+}
+```
+
+## Dependencies
+
+### Internal Dependencies
+None explicitly specified in the available code.
+
+### External Dependencies
+- `docker.io/ipfs/kubo`: The official Kubo Docker image
+- `docker.io/ipfs/ipfs-cluster`: The official IPFS Cluster Docker image
+- `github.com/ipfs/boxo`: IPFS libraries
+- `github.com/ipfs/kubo`: Kubo IPFS implementation
+- `github.com/ipfs/go-cid`: Content identifier library
+- `github.com/multiformats/go-multiaddr`: Multiaddress library
+
+## Security Considerations
+
+When using IPFS, several security considerations should be kept in mind:
+
+1. **Content Verification**: Verify content integrity using cryptographic hashes
+2. **Network Exposure**: Limit network exposure of IPFS nodes
+3. **Resource Limits**: Set appropriate resource limits to prevent DoS
+4. **Access Control**: Implement access controls for the IPFS API
+5. **Data Privacy**: Be aware that content on IPFS is public by default
+
+## Implementation Details
+
+### Kubo Docker Image
+
+The Kubo Docker image is built from the official IPFS Kubo image with the addition of the `jq` tool:
+
+```dockerfile
+FROM docker.io/ipfs/kubo:${VERSION}
+
+COPY --from=dependencies /jq /usr/bin/jq
+```
+
+### IPFS Cluster Docker Image
+
+The IPFS Cluster Docker image is built from the official IPFS Cluster image with the addition of `jq` and `kubectl`:
+
+```dockerfile
+FROM docker.io/ipfs/ipfs-cluster:${VERSION}
+
+COPY --from=dependencies /jq /usr/bin/jq
+COPY --from=dependencies /kubectl /usr/bin/kubectl
+```
+
+### Registry-Facade Integration
+
+The registry-facade component integrates with IPFS through the `IPFSBlobCache` struct, which provides methods for storing and retrieving blobs from IPFS. It uses Redis to map content digests to IPFS CIDs.
+
+## Related Components
+
+- **Registry-Facade**: Uses IPFS for caching container image layers
+- **Redis**: Used alongside IPFS for mapping digests to CIDs
+- **Content-Service**: May interact with IPFS for content storage
+- **Workspace**: Benefits from faster image pulls due to IPFS caching

--- a/memory-bank/components/local-app.md
+++ b/memory-bank/components/local-app.md
@@ -1,0 +1,144 @@
+# Local App Component
+
+## Overview
+
+The Local App component in Gitpod provides tools for interacting with Gitpod workspaces from a user's local machine. It consists of two main applications: the Gitpod CLI (`gitpod-cli`) and the Local Companion App (`gitpod-local-companion`). These tools enable users to connect to their remote Gitpod workspaces, access ports, establish SSH connections, and manage workspaces from their local environment.
+
+## Purpose
+
+The primary purposes of the Local App component are:
+- Provide a command-line interface for interacting with Gitpod
+- Enable SSH access to Gitpod workspaces
+- Establish secure tunnels to workspace ports
+- Manage authentication and tokens for Gitpod access
+- Support local development workflows with remote workspaces
+- Enable port forwarding from workspaces to local machine
+- Provide auto-updating capabilities for client tools
+- Generate and manage SSH configurations
+
+## Architecture
+
+The Local App component consists of several key parts:
+
+1. **Gitpod CLI**: A command-line tool for interacting with Gitpod
+2. **Local Companion App**: A background service that maintains connections to workspaces
+3. **Bastion**: Core functionality for establishing and managing tunnels
+4. **Authentication**: Handles secure login and token management
+5. **Self-update**: Manages automatic updates of the client tools
+
+The component is designed to work across multiple platforms (Linux, macOS, Windows) and architectures (amd64, arm64).
+
+## Key Files and Structure
+
+- `main/gitpod-cli/main.go`: Entry point for the CLI application
+- `main/gitpod-local-companion/main.go`: Entry point for the Local Companion App
+- `pkg/bastion/bastion.go`: Core tunneling and connection management
+- `pkg/auth/`: Authentication and token management
+- `pkg/selfupdate/`: Self-update functionality
+- `pkg/config/`: Configuration management
+- `pkg/helper/`: Helper utilities
+- `pkg/telemetry/`: Telemetry collection
+
+## CLI Commands
+
+The Gitpod CLI provides various commands for interacting with Gitpod:
+
+- `gitpod login`: Authenticate with Gitpod
+- `gitpod workspace`: Manage workspaces
+- `gitpod ssh`: SSH into a workspace
+- `gitpod port`: Forward ports from a workspace
+- `gitpod context`: Manage Gitpod contexts (different Gitpod installations)
+- `gitpod completion`: Generate shell completion scripts
+
+## Local Companion App
+
+The Local Companion App runs in the background and provides:
+
+1. **Workspace Monitoring**: Tracks running workspaces
+2. **Port Tunneling**: Automatically establishes tunnels to exposed ports
+3. **SSH Access**: Sets up SSH access to workspaces
+4. **API Endpoint**: Exposes a gRPC API for other tools to interact with
+
+## Tunneling System
+
+The tunneling system is a core feature that:
+
+1. **Establishes SSH Connections**: Creates secure SSH connections to workspaces
+2. **Forwards Ports**: Maps remote workspace ports to local ports
+3. **Manages Visibility**: Handles port visibility settings (public, private)
+4. **Monitors Port Status**: Tracks port status changes in workspaces
+5. **Generates SSH Config**: Creates SSH configuration for easy access
+
+## Authentication
+
+The authentication system:
+
+1. **Manages Tokens**: Securely stores and retrieves authentication tokens
+2. **Handles Login Flow**: Implements the OAuth login flow
+3. **Uses System Keyring**: Stores tokens in the system's secure keyring
+4. **Validates Tokens**: Ensures tokens are valid before use
+
+## Self-Update Mechanism
+
+The component includes a self-update mechanism that:
+
+1. **Checks for Updates**: Periodically checks for new versions
+2. **Downloads Updates**: Retrieves new versions when available
+3. **Installs Updates**: Replaces the current binary with the new version
+4. **Maintains Versioning**: Uses semantic versioning for updates
+
+## Dependencies
+
+### Internal Dependencies
+- `components/supervisor-api`: For communicating with workspace supervisor
+- `components/gitpod-protocol`: For Gitpod API communication
+- `components/local-app-api`: API definitions for the Local App
+- `components/public-api`: Public API definitions
+
+### External Dependencies
+- SSH libraries for secure connections
+- gRPC for API communication
+- WebSockets for real-time communication
+- System keyring for secure token storage
+
+## Integration Points
+
+The Local App component integrates with:
+1. **Gitpod Server**: For authentication and workspace information
+2. **Workspace Supervisor**: For port information and terminal access
+3. **IDE Proxy**: For downloading client binaries
+4. **Local System**: For SSH configuration and port forwarding
+
+## Configuration
+
+The Local App is configured through:
+
+1. **Command-line Flags**: For immediate configuration
+2. **Environment Variables**: For persistent configuration
+3. **Configuration File**: Located at `~/.gitpod/config.yaml`
+4. **SSH Configuration**: Generated at a configurable location
+
+## Security Considerations
+
+The Local App implements several security measures:
+
+1. **Secure Token Storage**: Uses system keyring for token storage
+2. **SSH Key Management**: Generates and manages SSH keys securely
+3. **Owner Token Validation**: Ensures only workspace owners can connect
+4. **Port Visibility Enforcement**: Respects port visibility settings
+
+## Common Usage Patterns
+
+The Local App component is typically used to:
+1. Connect to running workspaces via SSH
+2. Forward workspace ports to the local machine
+3. Manage workspaces from the command line
+4. Integrate Gitpod with local development tools
+5. Access workspace services from local applications
+
+## Related Components
+
+- **Supervisor**: Provides workspace information and port status
+- **IDE Proxy**: Serves client binaries and updates
+- **Server**: Handles authentication and workspace management
+- **Dashboard**: Provides web UI for workspace management

--- a/memory-bank/components/node-labeler.md
+++ b/memory-bank/components/node-labeler.md
@@ -1,0 +1,137 @@
+# Node-Labeler Component
+
+## Overview
+
+The Node-Labeler component in Gitpod is a Kubernetes controller responsible for managing node labels and annotations that are required for workspaces to run properly. It monitors the status of critical services like registry-facade and ws-daemon on each node, and adds or removes labels accordingly. Additionally, it manages cluster-autoscaler annotations to prevent nodes with active workspaces from being scaled down.
+
+## Purpose
+
+The primary purposes of the Node-Labeler component are:
+- Ensure workspaces are scheduled only on nodes with required services
+- Add and remove node labels based on service availability
+- Prevent cluster-autoscaler from removing nodes with active workspaces
+- Enable efficient node utilization in Kubernetes clusters
+- Facilitate proper workspace scheduling
+- Monitor the health of critical workspace services
+- Support the Gitpod workspace infrastructure
+- Optimize cluster resource usage
+- Provide metrics for service readiness
+
+## Architecture
+
+The Node-Labeler component consists of several key parts:
+
+1. **Pod Reconciler**: Watches pods of critical services and updates node labels
+2. **Node Scaledown Annotation Controller**: Manages cluster-autoscaler annotations based on workspace presence
+3. **Health Checks**: Verifies service availability before adding labels
+4. **Metrics Collection**: Tracks service readiness times and counts
+
+The component operates as a Kubernetes controller with leader election, ensuring only one instance is active at a time. It uses the controller-runtime library to watch for changes to pods and workspaces, and reconciles the state of node labels and annotations accordingly.
+
+## Key Features
+
+### Node Labeling
+
+- **Service Readiness Labels**: Adds labels to nodes when critical services are ready
+- **Label Removal**: Removes labels when services are no longer available
+- **Health Verification**: Checks TCP connectivity and service health before adding labels
+- **Registry-Facade Verification**: Performs specific checks for registry-facade readiness
+- **Automatic Reconciliation**: Periodically reconciles node labels to ensure correctness
+
+### Cluster-Autoscaler Integration
+
+- **Scale-down Prevention**: Adds annotations to prevent cluster-autoscaler from removing nodes with active workspaces
+- **Workspace Tracking**: Monitors workspace presence on nodes
+- **Annotation Management**: Adds or removes `cluster-autoscaler.kubernetes.io/scale-down-disabled` annotation
+- **Periodic Reconciliation**: Regularly checks all nodes to ensure annotations are correct
+- **Event-based Updates**: Responds to workspace creation, deletion, and node changes
+
+### Monitoring and Metrics
+
+- **Service Readiness Metrics**: Tracks how long it takes for services to become ready
+- **Service Count Metrics**: Counts the number of service instances
+- **Health Endpoints**: Provides health and readiness endpoints
+- **Logging**: Detailed logging of label and annotation changes
+
+## Configuration
+
+The Node-Labeler component can be configured through command-line flags:
+
+### General Configuration
+- `--json-log`, `-j`: Produce JSON log output (default: true)
+- `--verbose`, `-v`: Enable verbose logging
+- `--namespace`: Namespace where Gitpod components are running (default: default)
+
+### Service Configuration
+- `--registry-facade-port`: Port for registry-facade node port (default: 31750)
+- `--ws-daemon-port`: Port for ws-daemon service (default: 8080)
+
+## Integration Points
+
+The Node-Labeler component integrates with:
+1. **Kubernetes API**: For managing node labels and annotations
+2. **Registry-Facade**: Checks readiness of registry-facade service
+3. **WS-Daemon**: Checks readiness of ws-daemon service
+4. **Cluster-Autoscaler**: Prevents scale-down of nodes with active workspaces
+5. **Workspace Controller**: Monitors workspace placement on nodes
+
+## Usage Patterns
+
+### Node Label Management
+The component adds the following labels to nodes:
+- `gitpod.io/registry-facade_ready_ns_<namespace>`: Indicates registry-facade is ready
+- `gitpod.io/ws-daemon_ready_ns_<namespace>`: Indicates ws-daemon is ready
+
+These labels are used by the workspace scheduler to ensure workspaces are only scheduled on nodes with the required services.
+
+### Cluster-Autoscaler Annotation Management
+The component adds or removes the following annotation:
+- `cluster-autoscaler.kubernetes.io/scale-down-disabled`: Prevents cluster-autoscaler from removing nodes with active workspaces
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+- `components/ws-manager-api/go`: Workspace manager API
+- `components/ws-manager-mk2`: Workspace manager CRDs
+
+### External Dependencies
+- Kubernetes controller-runtime: For building Kubernetes controllers
+- Kubernetes client-go: For interacting with the Kubernetes API
+- Prometheus metrics: For exposing metrics
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **Least Privilege**: Requires only the necessary permissions to manage node labels and annotations
+2. **Leader Election**: Ensures only one instance is active at a time
+3. **Namespace Isolation**: Can be configured to watch only specific namespaces
+4. **TLS Verification**: Supports TLS for secure communication with services
+5. **Error Handling**: Proper handling of errors to prevent security issues
+
+## Implementation Details
+
+### Pod Reconciler
+
+The Pod Reconciler watches for changes to pods with the component label matching "ws-daemon" or "registry-facade". When a pod becomes ready, it:
+1. Checks if the pod is running on a node
+2. Verifies TCP connectivity to the service
+3. For registry-facade, performs additional HTTP health checks
+4. Adds the appropriate label to the node if all checks pass
+5. Removes the label when the pod is deleted or becomes not ready
+
+### Node Scaledown Annotation Controller
+
+The Node Scaledown Annotation Controller watches for changes to workspaces. When a workspace is created, deleted, or moved to a different node, it:
+1. Counts the number of workspaces on the affected node
+2. Adds the `cluster-autoscaler.kubernetes.io/scale-down-disabled` annotation if there are workspaces on the node
+3. Removes the annotation if there are no workspaces on the node
+4. Periodically reconciles all nodes to ensure annotations are correct
+
+## Related Components
+
+- **WS-Manager-MK2**: Uses the node labels for workspace scheduling
+- **Registry-Facade**: Provides container images for workspaces
+- **WS-Daemon**: Provides workspace services on nodes
+- **Cluster-Autoscaler**: Uses annotations to determine which nodes can be scaled down

--- a/memory-bank/components/openvsx-proxy.md
+++ b/memory-bank/components/openvsx-proxy.md
@@ -1,0 +1,167 @@
+# OpenVSX-Proxy Component
+
+## Overview
+
+The OpenVSX-Proxy component in Gitpod is a caching proxy service for the OpenVSX registry, which is a repository for VS Code extensions. It stores frequently used requests to the OpenVSX registry and serves these cached responses when needed, particularly when the upstream registry is unavailable. This ensures that VS Code extensions remain accessible to Gitpod workspaces even during OpenVSX outages, improving the reliability and resilience of the IDE experience.
+
+## Purpose
+
+The primary purposes of the OpenVSX-Proxy component are:
+- Cache responses from the OpenVSX registry to improve performance
+- Provide fallback access to VS Code extensions when the upstream registry is down
+- Reduce load on the upstream OpenVSX registry
+- Improve reliability of VS Code extension availability in workspaces
+- Minimize latency for frequently requested extensions
+- Support the IDE experience by ensuring extension availability
+- Provide metrics and monitoring for extension usage
+- Handle cross-origin requests appropriately
+- Support both in-memory and Redis-based caching strategies
+
+## Architecture
+
+The OpenVSX-Proxy component consists of several key parts:
+
+1. **Reverse Proxy**: Forwards requests to the upstream OpenVSX registry
+2. **Caching Layer**: Stores responses from the registry for future use
+3. **Cache Management**: Handles cache expiration and validation
+4. **Metrics Collection**: Tracks cache hits, misses, and request durations
+5. **Error Handling**: Manages failures and provides fallback responses
+6. **Configuration**: Configures caching behavior and upstream registry
+
+The component operates as an HTTP server that intercepts requests for VS Code extensions, checks its cache for a valid response, and either serves the cached response or forwards the request to the upstream registry.
+
+## Key Features
+
+### Caching
+
+- **Two-Tier Caching**: Implements regular (short-lived) and backup (long-lived) caching
+- **Redis Support**: Optional Redis-based caching for distributed deployments
+- **In-Memory Fallback**: Uses BigCache for in-memory caching when Redis is not available
+- **Cache Validation**: Validates cached responses based on age and headers
+- **Selective Caching**: Configurable domain allowlist for caching
+- **Cache Expiration**: Configurable expiration times for different cache tiers
+
+### Proxy Functionality
+
+- **Transparent Proxying**: Acts as a reverse proxy to the upstream OpenVSX registry
+- **Header Management**: Preserves and modifies headers as needed
+- **CORS Support**: Handles cross-origin requests appropriately
+- **Error Handling**: Provides fallback responses when upstream is unavailable
+- **Connection Pooling**: Configurable connection pooling for upstream requests
+- **Experiment Support**: Integration with Gitpod's experiment framework for A/B testing
+
+### Monitoring and Metrics
+
+- **Prometheus Integration**: Exposes metrics for monitoring
+- **Request Duration Tracking**: Measures and reports request processing times
+- **Cache Hit/Miss Metrics**: Tracks cache effectiveness
+- **Health Endpoint**: Provides a status endpoint for health checks
+- **Detailed Logging**: Comprehensive logging for debugging and monitoring
+
+## Configuration
+
+The OpenVSX-Proxy component is configured through a JSON configuration file:
+
+```json
+{
+  "log_debug": false,
+  "cache_duration_regular": "1h",
+  "cache_duration_backup": "168h",
+  "url_upstream": "https://open-vsx.org",
+  "max_idle_conns": 100,
+  "max_idle_conns_per_host": 10,
+  "redis_addr": "redis:6379",
+  "prometheusAddr": ":9500",
+  "allow_cache_domain": ["open-vsx.org"]
+}
+```
+
+### Configuration Options
+- `log_debug`: Enables debug logging
+- `cache_duration_regular`: Duration for the regular cache tier (e.g., "1h" for 1 hour)
+- `cache_duration_backup`: Duration for the backup cache tier (e.g., "168h" for 1 week)
+- `url_upstream`: URL of the upstream OpenVSX registry
+- `max_idle_conns`: Maximum number of idle connections
+- `max_idle_conns_per_host`: Maximum number of idle connections per host
+- `redis_addr`: Address of the Redis server (if using Redis for caching)
+- `prometheusAddr`: Address for exposing Prometheus metrics
+- `allow_cache_domain`: List of domains for which caching is allowed
+
+## Integration Points
+
+The OpenVSX-Proxy component integrates with:
+1. **OpenVSX Registry**: The upstream source of VS Code extensions
+2. **VS Code/Theia**: The IDE that requests extensions through the proxy
+3. **Redis**: Optional caching backend for distributed deployments
+4. **Prometheus**: For metrics collection and monitoring
+5. **Gitpod Experiment Framework**: For A/B testing and feature flags
+
+## Usage Patterns
+
+### Extension Request Flow
+1. VS Code/Theia requests an extension from the proxy
+2. Proxy checks its cache for a valid response
+3. If a valid cached response exists, it is returned immediately
+4. If no valid cache exists, the request is forwarded to the upstream registry
+5. The response from the upstream is cached and returned to the client
+6. If the upstream is unavailable, the backup cache is used if available
+
+### Cache Tiers
+- **Regular Cache**: Used for frequently accessed extensions, with a shorter TTL
+- **Backup Cache**: Used when the upstream is unavailable, with a longer TTL
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+
+### External Dependencies
+- `github.com/eko/gocache`: Caching library
+- `github.com/allegro/bigcache`: In-memory cache implementation
+- `github.com/go-redis/redis`: Redis client
+- `github.com/sirupsen/logrus`: Logging library
+- `github.com/google/uuid`: UUID generation
+- `github.com/go-ozzo/ozzo-validation`: Configuration validation
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **No Credential Forwarding**: Does not forward authentication credentials to the upstream
+2. **Header Sanitization**: Sanitizes headers to prevent security issues
+3. **CORS Handling**: Properly handles cross-origin requests
+4. **Input Validation**: Validates configuration and inputs
+5. **Error Handling**: Prevents leaking sensitive information in error responses
+
+## Implementation Details
+
+### Caching Strategy
+
+The proxy implements a two-tier caching strategy:
+1. **Regular Cache**: Responses are cached for a short period (configurable, typically hours)
+2. **Backup Cache**: All responses are stored in a longer-term cache (configurable, typically days or weeks)
+
+When a request is received:
+- If a valid regular cache entry exists, it is served immediately
+- If no valid regular cache exists but the request is cacheable, it is forwarded to the upstream
+- If the upstream is unavailable and a backup cache entry exists, the backup is served
+- All successful responses from the upstream are stored in both cache tiers
+
+### Request Handling
+
+The request handling flow:
+1. Generate a unique request ID
+2. Determine the upstream URL (potentially using experiment framework)
+3. Check if caching is allowed for the domain
+4. Generate a cache key based on the request
+5. Check the cache for a valid entry
+6. If a valid entry exists and is within the regular cache TTL, serve it
+7. Otherwise, forward the request to the upstream
+8. Store the response in the cache
+9. Return the response to the client
+
+## Related Components
+
+- **IDE Service**: Uses the OpenVSX-Proxy to provide extensions to workspaces
+- **IDE**: Requests extensions through the proxy
+- **Supervisor**: May interact with the proxy for workspace setup

--- a/memory-bank/components/proxy.md
+++ b/memory-bank/components/proxy.md
@@ -1,0 +1,123 @@
+# Proxy Component
+
+## Overview
+
+The Proxy is a critical component in Gitpod that serves as the main entry point for all HTTP and WebSocket traffic to the platform. It routes requests to the appropriate backend services, handles TLS termination, enforces security policies, and provides various routing and transformation capabilities for the Gitpod platform.
+
+## Purpose
+
+The primary purposes of the Proxy component are:
+- Act as the main ingress point for all Gitpod traffic
+- Route requests to appropriate backend services
+- Terminate TLS connections
+- Enforce security headers and policies
+- Handle workspace-specific routing
+- Provide WebSocket support
+- Implement cross-origin resource sharing (CORS) policies
+- Support custom domain routing
+- Provide health checks and metrics endpoints
+
+## Architecture
+
+The Proxy is built on Caddy, a powerful, extensible web server with automatic HTTPS capabilities. The Gitpod proxy extends Caddy with custom plugins to handle specific Gitpod requirements:
+
+1. **Core Proxy**: Handles general routing and TLS termination
+2. **Workspace Handler**: Routes workspace-specific requests
+3. **Custom Plugins**: Extend Caddy with Gitpod-specific functionality
+4. **Security Layer**: Enforces security headers and policies
+5. **Metrics Endpoint**: Provides monitoring capabilities
+
+## Key Files and Structure
+
+- `Dockerfile`: Builds the proxy container with Caddy and custom plugins
+- `conf/Caddyfile`: Main configuration file for the proxy
+- `conf/workspace-handler.full`: Configuration for handling workspace requests
+- `conf/workspace-handler.meta`: Configuration for handling workspace metadata
+- `plugins/`: Custom Caddy plugins for Gitpod-specific functionality
+
+## Custom Plugins
+
+The proxy includes several custom Caddy plugins to extend its functionality:
+
+1. **corsorigin**: Handles Cross-Origin Resource Sharing (CORS) policies
+2. **secwebsocketkey**: Validates WebSocket connections
+3. **workspacedownload**: Manages workspace content downloads
+4. **headlesslogdownload**: Handles headless log downloads
+5. **configcat**: Integrates with ConfigCat feature flags
+6. **analytics**: Provides analytics functionality
+7. **logif**: Conditional logging
+8. **jsonselect**: JSON selection for logs
+9. **sshtunnel**: SSH tunneling support
+10. **frontend_dev**: Development mode for frontend
+
+## Configuration
+
+The proxy is configured via the Caddyfile, which includes:
+
+### Main Domain Configuration
+- TLS settings
+- Security headers
+- Routing rules for the main Gitpod domain
+- API endpoints
+- Backend service routing
+
+### Workspace Domain Configuration
+- Routing for workspace-specific domains
+- Port forwarding
+- WebSocket handling
+- IDE-specific routing
+
+### Security Configuration
+- HTTP to HTTPS redirection
+- Security headers
+- CORS policies
+- WebSocket validation
+
+## Routing Logic
+
+The proxy implements sophisticated routing logic:
+
+1. **Main Domain Routing**: Routes requests to the main Gitpod domain to appropriate backend services
+2. **Workspace Routing**: Routes workspace requests based on subdomain patterns
+3. **API Routing**: Routes API requests to the server component
+4. **Public API Routing**: Routes public API requests to the public-api-server
+5. **Static Content**: Routes static content requests to appropriate services
+6. **WebSocket Routing**: Handles WebSocket connections for real-time communication
+
+## Workspace Routing
+
+Workspace routing is particularly complex, handling several patterns:
+
+1. **Standard Workspace**: `<workspace-id>.ws.<region>.<domain>`
+2. **Port Forwarding**: `<port>-<workspace-id>.ws.<region>.<domain>`
+3. **Debug Workspace**: `debug-<workspace-id>.ws.<region>.<domain>`
+4. **Foreign Content**: Special routes for VS Code webviews and webworkers
+
+## Security Considerations
+
+The proxy implements several security measures:
+
+- TLS termination with secure configuration
+- HTTP Strict Transport Security (HSTS)
+- Content Security Policy (CSP)
+- Cross-Origin Resource Sharing (CORS) policies
+- XSS protection
+- Referrer policy
+- WebSocket validation
+
+## Common Usage Patterns
+
+The Proxy is typically used to:
+1. Route client requests to appropriate backend services
+2. Provide secure access to workspaces
+3. Handle WebSocket connections for real-time communication
+4. Enforce security policies
+5. Provide health checks and metrics
+
+## Related Components
+
+- **Server**: Receives API requests routed through the proxy
+- **Dashboard**: Serves the web UI through the proxy
+- **WS Proxy**: Handles workspace-specific traffic
+- **IDE Proxy**: Manages IDE-specific routing
+- **Public API Server**: Provides public API endpoints

--- a/memory-bank/components/public-api-server.md
+++ b/memory-bank/components/public-api-server.md
@@ -1,0 +1,167 @@
+# Public API Server Component
+
+## Overview
+
+The Public API Server is a component in Gitpod that provides a versioned, stable, and managed API for programmatic access to Gitpod functionality. It serves as the gateway for external integrations, automation, and third-party tools to interact with Gitpod's core services. The API is designed to be backward compatible, well-documented, and follows modern API design principles.
+
+## Purpose
+
+The primary purposes of the Public API Server component are:
+- Provide a stable, versioned API for programmatic access to Gitpod
+- Enable third-party integrations and community-built tools
+- Offer a consistent interface for automation and orchestration
+- Support authentication and authorization for API access
+- Serve as the canonical way to access Gitpod functionality programmatically
+- Enable richer integrations with IDEs and development platforms
+- Provide OpenID Connect (OIDC) authentication capabilities
+- Support identity provider functionality
+
+## Architecture
+
+The Public API Server is built as a Go service with several key components:
+
+1. **gRPC API**: Core API implementation using gRPC and Connect
+2. **Authentication**: Handles API tokens, session verification, and OIDC flows
+3. **Proxy Layer**: Routes requests to internal Gitpod services
+4. **Metrics & Logging**: Collects and exposes metrics and logs
+5. **Validation**: Ensures request data meets API requirements
+6. **Webhooks**: Handles external service webhooks (e.g., Stripe)
+
+The component is designed to be the primary entry point for all programmatic interactions with Gitpod, abstracting away internal implementation details and providing a stable interface.
+
+## Key Files and Structure
+
+- `main.go`: Entry point for the application
+- `cmd/root.go`: Command-line interface setup
+- `cmd/run.go`: Main server run command
+- `pkg/server/server.go`: Core server implementation
+- `pkg/apiv1/`: API service implementations
+- `pkg/auth/`: Authentication and authorization
+- `pkg/oidc/`: OpenID Connect implementation
+- `pkg/identityprovider/`: Identity provider functionality
+- `pkg/proxy/`: Request proxying to internal services
+- `pkg/webhooks/`: Webhook handlers
+
+## API Services
+
+The Public API Server provides several services:
+
+1. **Workspaces Service**: Manage workspaces (create, start, stop, delete)
+2. **Teams Service**: Manage teams and team membership
+3. **User Service**: User information and management
+4. **SCM Service**: Source code management integrations
+5. **Editor Service**: IDE and editor configuration
+6. **IDE Client Service**: IDE client interactions
+7. **Projects Service**: Project management
+8. **OIDC Service**: OpenID Connect authentication
+9. **Identity Provider Service**: Identity provider functionality
+10. **Tokens Service**: Personal access token management
+
+## Authentication
+
+The component supports multiple authentication methods:
+
+1. **Personal Access Tokens**: Long-lived tokens for API access
+2. **Session Authentication**: Browser session-based authentication
+3. **OIDC Authentication**: OpenID Connect flows for third-party authentication
+4. **Webhook Signatures**: Verification of webhook payloads
+
+Authentication is implemented using JSON Web Signatures (JWS) with both RSA-256 and HMAC-SHA256 algorithms.
+
+## Configuration
+
+The Public API Server is configured through a JSON configuration file:
+
+```json
+{
+  "server": {
+    "port": 3000,
+    "address": "0.0.0.0"
+  },
+  "gitpodServiceURL": "https://gitpod.io/api",
+  "publicURL": "https://api.gitpod.io",
+  "sessionServiceAddress": "session-service:3000",
+  "databaseConfigPath": "/etc/gitpod/db",
+  "redis": {
+    "address": "redis:6379"
+  },
+  "auth": {
+    "pki": {
+      "privateKeyPath": "/etc/gitpod/auth/private-key.pem",
+      "publicKeyPath": "/etc/gitpod/auth/public-key.pem"
+    },
+    "session": {
+      "cookieName": "gp:session",
+      "maxAgeMs": 259200000
+    }
+  },
+  "personalAccessTokenSigningKeyPath": "/etc/gitpod/auth/pat-key",
+  "stripeWebhookSigningSecretPath": "/etc/gitpod/stripe/webhook-secret",
+  "billingServiceAddress": "billing-service:3000"
+}
+```
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+- `components/public-api`: API definitions
+- `components/usage-api`: Usage API definitions
+- `components/gitpod-protocol`: Gitpod protocol definitions
+- `components/gitpod-db`: Database access
+
+### External Dependencies
+- gRPC and Connect for API implementation
+- Redis for caching and session management
+- GORM for database access
+- Chi router for HTTP routing
+- Prometheus for metrics
+
+## Integration Points
+
+The Public API Server integrates with:
+1. **Gitpod Server**: For core Gitpod functionality
+2. **Database**: For persistent storage
+3. **Redis**: For caching and session management
+4. **Billing Service**: For billing-related operations
+5. **Session Service**: For session management
+6. **External Identity Providers**: For authentication
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **Token Signing**: Secure signing of personal access tokens
+2. **Session Verification**: Validation of user sessions
+3. **Webhook Signature Verification**: Ensures webhook payloads are authentic
+4. **CORS Protection**: Controls cross-origin requests
+5. **Encryption**: Database encryption for sensitive data
+6. **Logging**: Comprehensive logging for security auditing
+
+## Metrics
+
+The component exposes various metrics:
+
+- Request counts and latencies
+- Error rates
+- Authentication failures
+- Proxy performance
+- OIDC flow completions
+
+## Common Usage Patterns
+
+The Public API Server is typically used to:
+1. Create and manage workspaces programmatically
+2. Integrate Gitpod with CI/CD pipelines
+3. Build custom dashboards and management tools
+4. Automate workspace provisioning
+5. Implement custom authentication flows
+6. Integrate with third-party services
+
+## Related Components
+
+- **Server**: Provides the core functionality that the Public API exposes
+- **Database**: Stores user, workspace, and other data
+- **Proxy**: Routes incoming traffic to appropriate services
+- **Billing Service**: Handles billing-related operations
+- **Session Service**: Manages user sessions

--- a/memory-bank/components/registry-facade.md
+++ b/memory-bank/components/registry-facade.md
@@ -1,0 +1,111 @@
+# Registry Facade Component
+
+## Overview
+
+The Registry Facade is a specialized component in Gitpod that acts as an intermediary between the container runtime and container registries. It dynamically modifies container images by adding layers required for Gitpod workspaces, such as the supervisor, IDE, and other tools, without actually modifying the original images.
+
+## Purpose
+
+The primary purposes of the Registry Facade are:
+- Intercept container image pulls from the container runtime
+- Dynamically add layers to workspace images (supervisor, IDE, tools)
+- Provide a unified view of modified images to the container runtime
+- Cache image layers for improved performance
+- Handle authentication with upstream container registries
+- Support various image sources and layer types
+
+## Architecture
+
+The Registry Facade operates as a Docker registry-compatible service with several key components:
+
+1. **Registry Server**: Implements the Docker Registry API to serve modified images
+2. **Layer Manager**: Handles the addition of static and dynamic layers to images
+3. **Authentication Handler**: Manages authentication with upstream registries
+4. **Caching System**: Caches image layers for improved performance
+5. **IPFS Integration**: Optional integration with IPFS for distributed layer storage
+
+The component acts as an "image layer smuggler," inserting layers into container images in a specific order to create the complete workspace environment.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/run.go`: Implements the main registry service
+- `cmd/setup.go`: Handles service setup and configuration
+- `pkg/registry/`: Core registry implementation
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities
+- `components/registry-facade-api/go:lib`: Registry facade API definitions
+
+### External Dependencies
+- Docker registry client libraries
+- Containerd remote libraries
+- Prometheus for metrics
+- HTTP libraries for registry communication
+
+## Configuration
+
+The Registry Facade is configured via a JSON configuration file that includes:
+
+### Registry Configuration
+- Port for the registry server
+- Static layers to add to images
+- Storage location for the registry
+- Authentication requirements
+- IPFS integration settings
+
+### Blobserve Configuration
+- Port for the blobserve service
+- Repository configurations
+- Caching settings
+- Pre-pull configurations
+
+### Authentication Configuration
+- Docker authentication configuration file path
+
+## Layer Management
+
+The Registry Facade manages several types of layers that are added to workspace images:
+
+1. **Base Image**: The original container image for the workspace
+2. **Supervisor**: The Gitpod supervisor component
+3. **Workspacekit**: Tools for workspace management
+4. **DockerUp**: Docker support in workspaces
+5. **IDE**: The IDE (VS Code, JetBrains, etc.)
+6. **Desktop IDE**: Desktop versions of IDEs
+
+These layers are added in a specific order to create the complete workspace environment.
+
+## Integration Points
+
+The Registry Facade integrates with:
+1. **Container Runtime**: Serves modified images to the container runtime
+2. **Workspace Manager**: Consults with workspace manager for layer information
+3. **Upstream Registries**: Pulls base images from upstream registries
+4. **Blobserve**: Works with blobserve for static content serving
+5. **IPFS**: Optional integration for distributed layer storage
+
+## Security Considerations
+
+- Handles authentication with upstream registries
+- Manages sensitive Docker credentials
+- Requires proper IAM permissions when using cloud-based registries
+- Implements proper caching and storage security
+
+## Common Usage Patterns
+
+The Registry Facade is typically used to:
+1. Serve workspace images with added layers to the container runtime
+2. Cache frequently used layers for improved performance
+3. Handle authentication with private registries
+4. Provide a unified view of modified images
+
+## Related Components
+
+- **Workspace Manager**: Provides information about required layers
+- **Supervisor**: One of the layers added to workspace images
+- **Blobserve**: Works with Registry Facade for static content
+- **IDE Service**: Provides IDE layers that are added to images

--- a/memory-bank/components/scheduler-extender.md
+++ b/memory-bank/components/scheduler-extender.md
@@ -1,0 +1,122 @@
+# Scheduler-Extender Component
+
+## Overview
+
+The Scheduler-Extender component in Gitpod appears to be a Kubernetes scheduler extender that enhances the default Kubernetes scheduling capabilities. It is implemented as a wrapper around an external image hosted on AWS ECR. Kubernetes scheduler extenders allow for custom scheduling decisions beyond what the default scheduler provides, enabling more sophisticated workload placement based on custom criteria.
+
+## Purpose
+
+While specific implementation details are limited in the codebase, based on the component's name and general knowledge of Kubernetes scheduler extenders, the primary purposes of the Scheduler-Extender component likely include:
+
+- Extend Kubernetes scheduling decisions for Gitpod workspaces
+- Implement custom scheduling logic specific to Gitpod's requirements
+- Optimize workspace placement across cluster nodes
+- Consider specialized resource requirements for workspaces
+- Support advanced scheduling features not available in the default Kubernetes scheduler
+- Enable workload-specific placement policies
+- Integrate with Gitpod's workspace management system
+- Improve resource utilization across the cluster
+- Support specialized node selection criteria
+
+## Architecture
+
+Based on the available information, the Scheduler-Extender component:
+
+1. **External Image**: Uses an image from AWS ECR (`public.ecr.aws/b4b1c2l9/application/k5t9d3j5/application/scheduler-extender`)
+2. **Kubernetes Integration**: Likely integrates with the Kubernetes API server as a scheduler extender
+3. **HTTP API**: Probably exposes an HTTP API that the Kubernetes scheduler calls during scheduling decisions
+
+As a Kubernetes scheduler extender, it would typically:
+1. Register with the Kubernetes scheduler through configuration
+2. Receive filter and prioritize requests from the Kubernetes scheduler
+3. Apply custom logic to determine suitable nodes for workspaces
+4. Return results to the Kubernetes scheduler for final placement decisions
+
+## Key Features
+
+Based on general knowledge of Kubernetes scheduler extenders, the component likely provides:
+
+### Custom Scheduling Logic
+
+- **Workspace-Specific Criteria**: Custom criteria for workspace scheduling
+- **Resource Optimization**: Advanced resource allocation strategies
+- **Node Filtering**: Custom filtering of nodes based on Gitpod-specific requirements
+- **Node Prioritization**: Custom scoring of nodes to optimize workspace placement
+- **Affinity Rules**: Implementation of specialized affinity/anti-affinity rules
+
+### Integration Capabilities
+
+- **Kubernetes API Integration**: Integration with the Kubernetes scheduler
+- **Gitpod Component Awareness**: Awareness of other Gitpod components' requirements
+- **Node Labeling**: Potential integration with node labels for scheduling decisions
+- **Resource Management**: Custom resource tracking and allocation
+
+## Configuration
+
+The component is likely configured through:
+
+1. **Kubernetes Scheduler Configuration**: Registration as an extender in the kube-scheduler configuration
+2. **Custom Configuration**: Specific configuration for Gitpod's scheduling requirements
+3. **Version Management**: Versioned through the `schedulerExtenderVersion` variable
+
+## Integration Points
+
+The Scheduler-Extender component likely integrates with:
+
+1. **Kubernetes Scheduler**: For extending scheduling decisions
+2. **Kubernetes API Server**: For accessing cluster state information
+3. **Workspace Manager**: For understanding workspace requirements
+4. **Node Labeler**: For using node labels in scheduling decisions
+5. **Cluster Autoscaler**: For coordinating with cluster scaling activities
+
+## Usage Patterns
+
+### Scheduling Flow
+
+1. Kubernetes scheduler receives a pod creation request for a workspace
+2. Scheduler performs its default filtering and prioritization
+3. Scheduler calls the scheduler-extender for custom filtering
+4. Scheduler-extender applies Gitpod-specific logic to filter nodes
+5. Scheduler calls the scheduler-extender for custom prioritization
+6. Scheduler-extender scores nodes based on Gitpod-specific criteria
+7. Kubernetes scheduler combines all scores and selects the best node
+8. Workspace pod is scheduled on the selected node
+
+## Dependencies
+
+### Internal Dependencies
+None explicitly specified in the available code.
+
+### External Dependencies
+- AWS ECR hosted image: `public.ecr.aws/b4b1c2l9/application/k5t9d3j5/application/scheduler-extender`
+
+## Security Considerations
+
+As a scheduler extender, the component would need to consider:
+
+1. **API Security**: Secure communication with the Kubernetes API
+2. **Authentication**: Proper authentication for API access
+3. **Authorization**: Appropriate RBAC permissions for scheduling decisions
+4. **Resource Isolation**: Ensuring proper isolation between workspaces
+5. **Denial of Service Prevention**: Preventing scheduling decisions that could lead to resource exhaustion
+
+## Implementation Details
+
+The component appears to be implemented as a wrapper around an external image, suggesting that:
+
+1. The core scheduling logic is maintained separately
+2. The component may be part of Gitpod's enterprise offering
+3. The implementation details are not fully open-sourced
+
+Based on the CODEOWNERS file, the component is maintained by the Gitpod Engine team and Enterprise team.
+
+## Related Components
+
+- **WS-Manager-MK2**: Likely interacts with the scheduler-extender for workspace scheduling
+- **Node-Labeler**: Provides node labels that may be used in scheduling decisions
+- **Cluster-Autoscaler**: May coordinate with the scheduler-extender for scaling decisions
+- **Registry-Facade**: Listed as a dependency in the build configuration
+
+## Notes
+
+This documentation is based on limited information available in the codebase. The scheduler-extender component appears to be a wrapper around an external image, with minimal code present in the open-source repository. For more detailed information, internal Gitpod documentation or the team responsible for the component (Engine and Enterprise teams) should be consulted.

--- a/memory-bank/components/scrubber.md
+++ b/memory-bank/components/scrubber.md
@@ -1,0 +1,162 @@
+# Scrubber Component
+
+## Overview
+
+The Scrubber component in Gitpod is a Go library that provides functionality for removing or masking sensitive information from data. It's designed to protect personally identifiable information (PII) and other sensitive data from being exposed in logs, error messages, and other outputs. The component offers various methods for scrubbing different types of data structures, including strings, key-value pairs, JSON, and Go structs.
+
+## Purpose
+
+The primary purposes of the Scrubber component are:
+- Remove or mask personally identifiable information (PII) from data
+- Protect sensitive information such as passwords, tokens, and secrets
+- Provide consistent data sanitization across the Gitpod platform
+- Support various data formats and structures
+- Enable customizable scrubbing rules
+- Reduce the risk of sensitive data exposure
+- Comply with privacy regulations and best practices
+- Facilitate safe logging and error reporting
+
+## Architecture
+
+The Scrubber component is structured as a Go library with several key parts:
+
+1. **Core Scrubber Interface**: Defines the methods for scrubbing different types of data
+2. **Scrubber Implementation**: Provides the actual scrubbing functionality
+3. **Sanitization Functions**: Implements different sanitization strategies (redaction, hashing)
+4. **Configuration**: Defines what fields and patterns should be scrubbed
+5. **Struct Walking**: Uses reflection to traverse and scrub complex data structures
+
+The component is designed to be used by other Gitpod components that need to sanitize data before logging, storing, or transmitting it.
+
+## Key Features
+
+### Scrubbing Methods
+
+The Scrubber interface provides several methods for scrubbing different types of data:
+
+1. **Value**: Scrubs a single string value using heuristics to detect sensitive data
+2. **KeyValue**: Scrubs a key-value pair, using the key as a hint for how to sanitize the value
+3. **JSON**: Scrubs a JSON structure, handling nested objects and arrays
+4. **Struct**: Scrubs a Go struct in-place, respecting struct tags for customization
+5. **DeepCopyStruct**: Creates a scrubbed deep copy of a Go struct
+
+### Sanitization Strategies
+
+The component implements different sanitization strategies:
+
+1. **Redaction**: Replaces sensitive values with `[redacted]` or `[redacted:keyname]`
+2. **Hashing**: Replaces sensitive values with an MD5 hash (`[redacted:md5:hash:keyname]`)
+3. **URL Path Hashing**: Specially handles URLs by preserving the structure but hashing path segments
+
+### Configuration
+
+The scrubber is configured with several lists and patterns:
+
+1. **RedactedFieldNames**: Field names whose values should be completely redacted
+2. **HashedFieldNames**: Field names whose values should be hashed
+3. **HashedURLPathsFieldNames**: Field names containing URLs whose paths should be hashed
+4. **HashedValues**: Regular expressions that, when matched, cause values to be hashed
+5. **RedactedValues**: Regular expressions that, when matched, cause values to be redacted
+
+### Struct Tag Support
+
+When scrubbing structs, the component respects the `scrub` struct tag:
+
+- `scrub:"ignore"`: Skip scrubbing this field
+- `scrub:"hash"`: Hash this field's value
+- `scrub:"redact"`: Redact this field's value
+
+### Trusted Values
+
+The component supports a `TrustedValue` interface that allows marking specific values to be exempted from scrubbing:
+
+```go
+type TrustedValue interface {
+    IsTrustedValue()
+}
+```
+
+## Usage Patterns
+
+### Basic Value Scrubbing
+```go
+// Scrub a single value
+scrubbedValue := scrubber.Default.Value("user@example.com")
+// Result: "[redacted:md5:hash]" or similar
+```
+
+### Key-Value Scrubbing
+```go
+// Scrub a value with key context
+scrubbedValue := scrubber.Default.KeyValue("password", "secret123")
+// Result: "[redacted]"
+```
+
+### JSON Scrubbing
+```go
+// Scrub a JSON structure
+jsonData := []byte(`{"username": "johndoe", "email": "john@example.com"}`)
+scrubbedJSON, err := scrubber.Default.JSON(jsonData)
+// Result: {"username": "[redacted:md5:hash]", "email": "[redacted]"}
+```
+
+### Struct Scrubbing
+```go
+// Scrub a struct in-place
+type User struct {
+    Username string
+    Email    string `scrub:"redact"`
+    Password string
+}
+user := User{Username: "johndoe", Email: "john@example.com", Password: "secret123"}
+err := scrubber.Default.Struct(&user)
+// Result: user.Username is hashed, user.Email is redacted, user.Password is redacted
+```
+
+### Deep Copy Struct Scrubbing
+```go
+// Create a scrubbed copy of a struct
+type User struct {
+    Username string
+    Email    string `scrub:"redact"`
+    Password string
+}
+user := User{Username: "johndoe", Email: "john@example.com", Password: "secret123"}
+scrubbedUser := scrubber.Default.DeepCopyStruct(user).(User)
+// Original user is unchanged, scrubbedUser has sanitized values
+```
+
+## Integration Points
+
+The Scrubber component integrates with:
+1. **Logging Systems**: To sanitize log messages
+2. **Error Handling**: To sanitize error messages
+3. **API Responses**: To sanitize sensitive data in responses
+4. **Monitoring Systems**: To sanitize metrics and traces
+5. **Other Gitpod Components**: To provide consistent data sanitization
+
+## Dependencies
+
+### Internal Dependencies
+None specified in the component's build configuration.
+
+### External Dependencies
+- `github.com/hashicorp/golang-lru`: For caching sanitization decisions
+- `github.com/mitchellh/reflectwalk`: For traversing complex data structures
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **Default Deny**: Fields are scrubbed by default if they match sensitive patterns
+2. **Multiple Strategies**: Different sanitization strategies for different types of data
+3. **Caching**: Caches sanitization decisions for performance
+4. **Customization**: Allows customization of scrubbing rules
+5. **Trusted Values**: Supports marking values as trusted to exempt them from scrubbing
+
+## Related Components
+
+- **Common-Go**: Uses the Scrubber for logging
+- **Server**: Uses the Scrubber for API request/response sanitization
+- **Workspace Services**: Use the Scrubber to protect workspace data
+- **Monitoring Components**: Use the Scrubber to sanitize metrics and traces

--- a/memory-bank/components/server.md
+++ b/memory-bank/components/server.md
@@ -1,0 +1,136 @@
+# Server Component
+
+## Overview
+
+The Server is a central component in Gitpod that serves as the main backend service, handling API requests, authentication, user management, workspace operations, and integration with various source code management systems. It acts as the core orchestrator for the Gitpod platform, connecting various components and providing a unified API for clients.
+
+## Purpose
+
+The primary purposes of the Server component are:
+- Provide API endpoints for client applications (dashboard, IDE, CLI)
+- Handle user authentication and session management
+- Manage user accounts and preferences
+- Coordinate workspace creation and management
+- Integrate with source code management systems (GitHub, GitLab, Bitbucket)
+- Process webhooks for prebuilds and other automated operations
+- Manage billing and subscription information
+- Provide real-time communication via WebSockets
+- Coordinate with other Gitpod components
+
+## Architecture
+
+The Server operates as an Express.js application with several key components:
+
+1. **API Server**: Provides HTTP and WebSocket endpoints for client communication
+2. **Authentication System**: Handles user authentication and session management
+3. **Database Interface**: Interacts with the database for persistent storage
+4. **WebSocket Manager**: Manages real-time communication with clients
+5. **SCM Integrations**: Connects with GitHub, GitLab, Bitbucket, and other platforms
+6. **Workspace Coordinator**: Manages workspace lifecycle in coordination with ws-manager
+7. **Monitoring Endpoints**: Provides health checks and metrics
+
+The server is designed as a modular application using dependency injection (Inversify) to manage components and their dependencies.
+
+## Key Files and Structure
+
+- `main.ts`: Entry point that initializes the container and starts the server
+- `init.ts`: Handles server initialization and setup
+- `server.ts`: Core server implementation
+- `src/api/`: API endpoints and handlers
+- `src/auth/`: Authentication and authorization
+- `src/workspace/`: Workspace management
+- `src/user/`: User management
+- `src/prebuilds/`: Prebuild functionality
+- `src/billing/`: Billing and subscription management
+- `src/github/`, `src/gitlab/`, `src/bitbucket/`: SCM integrations
+
+## Dependencies
+
+### Internal Dependencies
+- `components/gitpod-db`: Database access layer
+- `components/gitpod-protocol`: Shared protocol definitions
+- `components/content-service-api`: Content service API definitions
+- `components/ws-manager-api`: Workspace manager API definitions
+- `components/image-builder-api`: Image builder API definitions
+- Various other Gitpod component APIs
+
+### External Dependencies
+- Express.js for HTTP server
+- WebSocket for real-time communication
+- Inversify for dependency injection
+- TypeORM for database access
+- Redis for caching and pub/sub
+- Prometheus for metrics
+- Various SCM platform SDKs
+
+## Configuration
+
+The Server is configured via environment variables and configuration files, including:
+
+- Server address and port
+- Database connection details
+- Authentication providers
+- SCM integration settings
+- Feature flags
+- Monitoring and logging settings
+
+## API Services
+
+The Server exposes multiple API endpoints:
+
+1. **User API**: User management, authentication, and preferences
+2. **Workspace API**: Workspace creation, management, and access
+3. **SCM Integration APIs**: GitHub, GitLab, Bitbucket webhooks and OAuth
+4. **Billing API**: Subscription and payment management
+5. **WebSocket API**: Real-time communication with clients
+6. **Health and Metrics API**: System health and monitoring
+
+## Authentication and Authorization
+
+The Server supports multiple authentication methods:
+
+1. **Session-based Authentication**: For web clients
+2. **Bearer Token Authentication**: For API access
+3. **OAuth Integration**: With GitHub, GitLab, Bitbucket, etc.
+4. **Personal Access Tokens**: For programmatic access
+
+Authorization is handled through a combination of user roles, permissions, and access controls.
+
+## Integration Points
+
+The Server integrates with:
+1. **Database**: For persistent storage
+2. **Redis**: For caching and pub/sub messaging
+3. **Workspace Manager**: For workspace lifecycle management
+4. **Image Builder**: For custom workspace images
+5. **Content Service**: For workspace content management
+6. **SCM Platforms**: For repository access and webhooks
+7. **Payment Providers**: For billing and subscriptions
+
+## Security Considerations
+
+- Implements CSRF protection for WebSocket connections
+- Handles authentication and session management securely
+- Validates and sanitizes user input
+- Implements proper error handling and logging
+- Uses HTTPS for secure communication
+- Manages sensitive data securely
+
+## Common Usage Patterns
+
+The Server is typically used to:
+1. Handle API requests from the dashboard and IDE
+2. Process authentication and session management
+3. Coordinate workspace creation and management
+4. Handle webhooks from SCM platforms
+5. Manage user accounts and preferences
+6. Process billing and subscription information
+
+## Related Components
+
+- **Dashboard**: Frontend interface that communicates with the server
+- **Workspace Manager**: Manages workspace instances
+- **Content Service**: Manages workspace content
+- **Image Builder**: Builds custom workspace images
+- **Database**: Stores persistent data
+- **IDE Service**: Provides IDE configuration

--- a/memory-bank/components/service-waiter.md
+++ b/memory-bank/components/service-waiter.md
@@ -1,0 +1,154 @@
+# Service-Waiter Component
+
+## Overview
+
+The Service-Waiter component in Gitpod is a utility service that waits for other services to become available before proceeding. It's designed to be used in initialization and deployment scenarios where services have dependencies on other services being ready. The component can wait for different types of services, including databases, Redis instances, and Kubernetes components, ensuring that a service doesn't start until its dependencies are fully operational.
+
+## Purpose
+
+The primary purposes of the Service-Waiter component are:
+- Ensure services start in the correct order during deployment
+- Prevent services from starting before their dependencies are ready
+- Provide a consistent way to wait for different types of services
+- Handle timeouts and failure scenarios gracefully
+- Support different types of service readiness checks
+- Enable orchestration of complex multi-service deployments
+- Improve reliability of service startup sequences
+- Provide clear logging and error reporting for troubleshooting
+
+## Architecture
+
+The Service-Waiter component is structured as a command-line tool with several subcommands for different types of services:
+
+1. **Database Waiter**: Waits for a MySQL database to become available
+2. **Redis Waiter**: Waits for a Redis instance to become reachable
+3. **Component Waiter**: Waits for a Kubernetes component to be ready with the correct image
+
+The component is designed to be run as a Kubernetes init container or as part of a deployment script, blocking until the target service is ready or a timeout is reached.
+
+## Key Features
+
+### Database Waiting
+
+The database waiter:
+- Connects to a MySQL database using provided credentials
+- Checks if the database is reachable and responsive
+- Optionally verifies that the latest migration has been applied
+- Supports TLS connections with custom CA certificates
+- Retries connections with backoff until success or timeout
+
+### Redis Waiting
+
+The Redis waiter:
+- Connects to a Redis instance at the specified host and port
+- Verifies connectivity by sending a PING command
+- Retries connections until success or timeout
+- Provides detailed logging of connection attempts
+
+### Component Waiting
+
+The component waiter:
+- Checks if Kubernetes pods with specific labels are running
+- Verifies that pods are using the expected container image
+- Ensures that pods are in the Ready state
+- Monitors pod status until all pods are ready or timeout
+- Supports namespace-specific checks
+
+## Configuration
+
+The Service-Waiter component can be configured through command-line flags or environment variables:
+
+### Global Configuration
+- `--timeout`, `-t`: Maximum time to wait (default: 5m or `SERVICE_WAITER_TIMEOUT` env var)
+- `--verbose`, `-v`: Enable verbose logging
+- `--json-log`, `-j`: Produce JSON log output
+
+### Database Waiter Configuration
+- `--host`, `-H`: Database host (from `DB_HOST` env var)
+- `--port`, `-p`: Database port (from `DB_PORT` env var, default: 3306)
+- `--username`, `-u`: Database username (from `DB_USERNAME` env var, default: gitpod)
+- `--password`, `-P`: Database password (from `DB_PASSWORD` env var)
+- `--caCert`: Custom CA certificate (from `DB_CA_CERT` env var)
+- `--migration-check`: Enable checking if the latest migration has been applied
+
+### Redis Waiter Configuration
+- `--host`, `-H`: Redis host (default: redis)
+- `--port`, `-p`: Redis port (default: 6379)
+
+### Component Waiter Configuration
+- `--image`: The latest image of current installer build
+- `--namespace`: The namespace of deployment
+- `--component`: Component name of deployment
+- `--labels`: Labels of deployment
+
+## Usage Patterns
+
+### Waiting for a Database
+```bash
+service-waiter database --host mysql.example.com --port 3306 --username gitpod --password secret
+```
+
+### Waiting for Redis
+```bash
+service-waiter redis --host redis.example.com --port 6379
+```
+
+### Waiting for a Kubernetes Component
+```bash
+service-waiter component --namespace default --component server --labels "app=gitpod,component=server" --image gitpod/server:latest
+```
+
+### Using as an Init Container
+```yaml
+initContainers:
+- name: wait-for-db
+  image: gitpod/service-waiter:latest
+  command: ["service-waiter", "database"]
+  env:
+  - name: DB_HOST
+    value: mysql
+  - name: DB_PASSWORD
+    valueFrom:
+      secretKeyRef:
+        name: mysql-secrets
+        key: password
+```
+
+## Integration Points
+
+The Service-Waiter component integrates with:
+1. **MySQL Databases**: For database readiness checks
+2. **Redis Instances**: For Redis readiness checks
+3. **Kubernetes API**: For component readiness checks
+4. **Deployment Systems**: As part of deployment scripts or init containers
+5. **Logging Systems**: For reporting readiness status
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+- `components/gitpod-db`: For database migration information
+
+### External Dependencies
+- MySQL client for database connections
+- Redis client for Redis connections
+- Kubernetes client for component checks
+- Cobra for command-line interface
+- Viper for configuration management
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **TLS Support**: For secure database connections
+2. **Password Masking**: Passwords are masked in logs
+3. **Minimal Permissions**: Only requires read access to check service status
+4. **Timeout Handling**: Prevents indefinite hanging
+5. **Error Handling**: Proper handling of connection errors
+
+## Related Components
+
+- **Database**: The service-waiter checks database availability
+- **Redis**: The service-waiter checks Redis availability
+- **Kubernetes Components**: The service-waiter checks component readiness
+- **Deployment Systems**: Use service-waiter to orchestrate deployments

--- a/memory-bank/components/spicedb.md
+++ b/memory-bank/components/spicedb.md
@@ -1,0 +1,177 @@
+# SpiceDB Component
+
+## Overview
+
+The SpiceDB component in Gitpod provides authorization and permission management using the SpiceDB authorization system. It defines the relationship-based access control (ReBAC) schema that governs permissions across the Gitpod platform, enabling fine-grained access control for users, organizations, projects, workspaces, and other resources.
+
+## Purpose
+
+The primary purposes of the SpiceDB component are:
+- Define the authorization schema for Gitpod
+- Model relationships between entities (users, organizations, projects, workspaces)
+- Specify permissions based on these relationships
+- Provide a consistent authorization system across the platform
+- Enable fine-grained access control
+- Support complex permission scenarios
+- Facilitate permission checks in other components
+- Ensure secure access to resources
+
+## Architecture
+
+The SpiceDB component consists of:
+
+1. **Schema Definition**: YAML-based schema that defines entities, relationships, and permissions
+2. **Go Library**: Code for loading and managing the schema
+3. **TypeScript Bindings**: Generated TypeScript code for frontend components
+4. **Validation**: Tests and assertions to verify schema correctness
+5. **Integration**: Connection to the SpiceDB service for permission checks
+
+The component follows the SpiceDB authorization model, which is based on the Google Zanzibar paper. It uses a relationship-based approach where permissions are derived from relationships between entities.
+
+## Key Entities and Relationships
+
+### Entities
+1. **User**: Individual users of the Gitpod platform
+2. **Installation**: The global Gitpod installation
+3. **Organization**: Groups of users with shared resources
+4. **Project**: Repositories or codebases within an organization
+5. **Workspace**: Development environments for projects
+
+### Relationships
+- **User-Installation**: Users can be members or admins of the installation
+- **User-Organization**: Users can be members, owners, or collaborators of organizations
+- **Organization-Installation**: Organizations belong to an installation
+- **Project-Organization**: Projects belong to organizations
+- **Project-User**: Users can be viewers or editors of projects
+- **Workspace-Organization**: Workspaces belong to organizations
+- **Workspace-User**: Users can own or share workspaces
+
+## Permissions
+
+The schema defines various permissions for each entity type:
+
+### User Permissions
+- `read_info`: View user information
+- `write_info`: Edit user information
+- `delete`: Delete user account
+- `make_admin`: Make a user an admin
+- `admin_control`: Administrative control over users
+- `read_ssh`: View SSH keys
+- `write_ssh`: Manage SSH keys
+- `read_tokens`: View access tokens
+- `write_tokens`: Manage access tokens
+- `read_env_var`: View environment variables
+- `write_env_var`: Manage environment variables
+- `write_temporary_token`: Create temporary tokens
+- `code_sync`: Synchronize code
+
+### Organization Permissions
+- `read_info`: View organization information
+- `write_info`: Edit organization information
+- `delete`: Delete organization
+- `read_settings`: View organization settings
+- `write_settings`: Edit organization settings
+- `read_env_var`: View organization environment variables
+- `write_env_var`: Manage organization environment variables
+- `read_audit_logs`: View audit logs
+- `read_members`: View organization members
+- `invite_members`: Invite new members
+- `write_members`: Manage organization members
+- `leave`: Leave the organization
+- `create_project`: Create new projects
+- `read_git_provider`: View Git provider information
+- `write_git_provider`: Manage Git provider settings
+- `read_billing`: View billing information
+- `write_billing`: Manage billing settings
+- `read_prebuild`: View prebuilds
+- `create_workspace`: Create workspaces
+- `read_sessions`: View user sessions
+- `write_billing_admin`: Administrative billing control
+
+### Project Permissions
+- `read_info`: View project information
+- `write_info`: Edit project information
+- `delete`: Delete project
+- `read_env_var`: View project environment variables
+- `write_env_var`: Manage project environment variables
+- `read_prebuild`: View project prebuilds
+- `write_prebuild`: Manage project prebuilds
+
+### Workspace Permissions
+- `access`: Access the workspace
+- `start`: Start the workspace
+- `stop`: Stop the workspace
+- `delete`: Delete the workspace
+- `read_info`: View workspace information
+- `create_snapshot`: Create workspace snapshots
+- `admin_control`: Administrative control over workspaces
+
+## Configuration
+
+The SpiceDB component is configured through a YAML schema file:
+
+```yaml
+schema/schema.yaml
+```
+
+This file defines:
+- Entity types (user, organization, project, workspace)
+- Relationships between entities
+- Permissions derived from these relationships
+- Validation rules and assertions for testing
+
+## Integration Points
+
+The SpiceDB component integrates with:
+1. **Server**: For permission checks on API requests
+2. **Dashboard**: For UI permission enforcement
+3. **Public API**: For permission checks on API requests
+4. **Workspace Manager**: For workspace access control
+5. **SpiceDB Service**: The actual authorization service that evaluates permission checks
+
+## Usage Patterns
+
+### Permission Checking
+```go
+// Check if a user can access a workspace
+allowed, err := client.CheckPermission(ctx, "workspace:workspace_1", "access", "user:user_1")
+```
+
+### Relationship Management
+```go
+// Add a user as a member of an organization
+err := client.WriteRelationships(ctx, []spicedb.Relationship{
+    {
+        Resource: "organization:org_1",
+        Relation: "member",
+        Subject: "user:user_1",
+    },
+})
+```
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **Least Privilege**: Permissions follow the principle of least privilege
+2. **Defense in Depth**: Multiple layers of permission checks
+3. **Separation of Concerns**: Clear separation between different entity types
+4. **Validation**: Schema validation to ensure correctness
+5. **Assertions**: Tests to verify expected permission behavior
+
+## Dependencies
+
+### Internal Dependencies
+None specified in the component's build configuration.
+
+### External Dependencies
+- SpiceDB service for authorization checks
+- YAML parsing libraries
+- Code generation tools
+
+## Related Components
+
+- **Server**: Uses SpiceDB for API permission checks
+- **Dashboard**: Uses SpiceDB for UI permission enforcement
+- **Public API**: Uses SpiceDB for API permission checks
+- **Workspace Manager**: Uses SpiceDB for workspace access control

--- a/memory-bank/components/supervisor.md
+++ b/memory-bank/components/supervisor.md
@@ -1,0 +1,119 @@
+# Supervisor Component
+
+## Overview
+
+The Supervisor is a critical component that runs inside each Gitpod workspace container. It serves as the init process (PID 1) for the workspace and manages various aspects of the workspace lifecycle, including terminal management, IDE integration, and process control.
+
+## Purpose
+
+The primary purposes of the Supervisor are:
+- Act as the init process for workspace containers
+- Manage terminal sessions within workspaces
+- Provide an API for workspace interaction
+- Serve the frontend UI for workspace access
+- Handle process lifecycle and graceful termination
+- Integrate with the IDE and other workspace services
+- Provide SSH access to workspaces
+
+## Architecture
+
+The Supervisor operates as a multi-faceted service with several key components:
+
+1. **Init Process**: Runs as PID 1 in the workspace container, responsible for process management
+2. **API Server**: Provides a gRPC API for workspace interaction
+3. **Terminal Manager**: Handles creation and management of terminal sessions
+4. **Frontend Server**: Serves the web UI for workspace access
+5. **IDE Integration**: Manages communication with the IDE
+6. **SSH Server**: Provides SSH access to the workspace
+
+The Supervisor is designed to be lightweight but robust, ensuring proper workspace initialization, operation, and termination.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/init.go`: Implements the init process functionality
+- `cmd/run.go`: Implements the main supervisor service
+- `cmd/terminal-*.go`: Terminal management commands
+- `pkg/`: Supporting packages for supervisor functionality
+- `frontend/`: Web UI for workspace access
+- `openssh/`: SSH server integration
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities
+- `components/content-service-api/go:lib`: Content service API definitions
+- `components/content-service:lib`: Content service client
+- `components/gitpod-protocol/go:lib`: Gitpod protocol definitions
+- `components/supervisor-api/go:lib`: Supervisor API definitions
+- `components/ws-daemon-api/go:lib`: Workspace daemon API definitions
+- `components/ide-metrics-api/go:lib`: IDE metrics API definitions
+- `components/public-api/go:lib`: Public API definitions
+
+### External Dependencies
+- Process management libraries
+- Terminal handling libraries
+- gRPC for API communication
+- Web server for frontend
+
+## Configuration
+
+The Supervisor is configured via a JSON configuration file (`supervisor-config.json`) that includes:
+
+- IDE configuration location
+- Desktop IDE root directory
+- Frontend location
+- API endpoint port
+- SSH port
+
+Additional configuration may be provided through environment variables and command-line flags.
+
+## API Services
+
+The Supervisor exposes a gRPC API that provides:
+- Terminal management (create, attach, list, close)
+- Workspace status information
+- IDE integration
+- Process control
+
+## Integration Points
+
+The Supervisor integrates with:
+1. **IDE**: Provides integration with VS Code, JetBrains, and other supported IDEs
+2. **Content Service**: For workspace content management
+3. **WS Daemon**: For workspace runtime operations
+4. **SSH**: Provides SSH access to the workspace
+5. **Frontend UI**: Serves the web UI for workspace access
+
+## Security Considerations
+
+- Runs as the init process with elevated privileges
+- Manages process isolation within the workspace
+- Handles secure terminal sessions
+- Provides controlled access to workspace resources
+- Implements proper shutdown and cleanup procedures
+
+## Common Usage Patterns
+
+The Supervisor is typically used to:
+1. Initialize the workspace environment
+2. Manage terminal sessions for user interaction
+3. Provide API access for IDE and other tools
+4. Handle graceful shutdown of workspace processes
+5. Serve the frontend UI for workspace access
+6. Enable SSH access to the workspace
+
+## Lifecycle Management
+
+The Supervisor implements sophisticated lifecycle management:
+1. **Initialization**: Sets up the workspace environment and starts required services
+2. **Runtime**: Manages processes, terminals, and API services during workspace operation
+3. **Termination**: Ensures graceful shutdown of all processes when the workspace is stopped
+
+## Related Components
+
+- **WS Daemon**: Works with Supervisor to manage workspace runtime
+- **Content Service**: Manages workspace content
+- **IDE Service**: Integrates with Supervisor for IDE functionality
+- **Workspace Manager**: Manages the workspace container in which Supervisor runs

--- a/memory-bank/components/usage.md
+++ b/memory-bank/components/usage.md
@@ -1,0 +1,167 @@
+# Usage Component
+
+## Overview
+
+The Usage component in Gitpod is responsible for tracking, calculating, and managing workspace usage and billing. It provides services for monitoring workspace usage, calculating credit consumption, managing billing subscriptions, and integrating with payment providers like Stripe. This component is central to Gitpod's usage-based billing model and ensures accurate tracking of resource consumption.
+
+## Purpose
+
+The primary purposes of the Usage component are:
+- Track workspace usage across the platform
+- Calculate credit consumption based on workspace class and usage time
+- Manage billing cycles and subscription periods
+- Integrate with payment providers (primarily Stripe)
+- Enforce usage limits and spending controls
+- Provide usage reporting and analytics
+- Reset usage counters at billing cycle boundaries
+- Manage cost centers and team billing
+- Support different pricing tiers and workspace classes
+
+## Architecture
+
+The Usage component is built as a Go service with several key components:
+
+1. **Usage Service**: Tracks and calculates workspace usage
+2. **Billing Service**: Manages billing subscriptions and payments
+3. **Scheduler**: Runs periodic jobs for usage calculation and billing
+4. **Stripe Integration**: Connects to Stripe for payment processing
+5. **Pricer**: Calculates credit costs based on workspace class
+6. **Cost Center Manager**: Manages spending limits and cost centers
+
+The component uses a scheduler to periodically run jobs that calculate usage, update ledgers, and reset usage counters at billing cycle boundaries.
+
+## Key Files and Structure
+
+- `main.go`: Entry point for the application
+- `cmd/root.go`: Command-line interface setup
+- `cmd/run.go`: Main server run command
+- `pkg/server/server.go`: Core server implementation
+- `pkg/apiv1/usage.go`: Usage service implementation
+- `pkg/apiv1/billing.go`: Billing service implementation
+- `pkg/apiv1/pricer.go`: Credit pricing calculations
+- `pkg/scheduler/`: Scheduling of periodic jobs
+- `pkg/stripe/`: Stripe payment integration
+
+## Scheduler Jobs
+
+The Usage component runs several scheduled jobs:
+
+1. **Ledger Trigger Job**: Periodically calculates usage and updates billing ledgers
+2. **Reset Usage Job**: Resets usage counters at the end of billing cycles
+3. **Billing Sync Job**: Synchronizes billing information with payment providers
+
+These jobs are scheduled based on configuration and use distributed locks (via Redis) to ensure they only run on one instance at a time.
+
+## Credit Calculation
+
+The component calculates credit usage based on:
+
+1. **Workspace Class**: Different workspace classes have different credit rates
+2. **Usage Time**: Time spent in workspaces
+3. **Billing Period**: Usage is tracked within billing periods
+4. **Team Membership**: Usage may be attributed to teams or individuals
+
+The pricer component handles the calculation of credits based on workspace class and usage time.
+
+## Stripe Integration
+
+The Usage component integrates with Stripe for payment processing:
+
+1. **Subscription Management**: Creating and updating subscriptions
+2. **Invoice Generation**: Generating invoices for usage
+3. **Payment Processing**: Processing payments for usage
+4. **Webhook Handling**: Processing Stripe webhook events
+5. **Customer Management**: Creating and updating customer records
+
+## Configuration
+
+The Usage component is configured through a JSON configuration file:
+
+```json
+{
+  "controllerSchedule": "1m",
+  "resetUsageSchedule": "24h",
+  "creditsPerMinuteByWorkspaceClass": {
+    "default": 0.5,
+    "large": 1.0
+  },
+  "stripeCredentialsFile": "/etc/gitpod/stripe/credentials.json",
+  "server": {
+    "port": 3000,
+    "address": "0.0.0.0"
+  },
+  "defaultSpendingLimit": {
+    "forTeams": 500,
+    "forUsers": 100
+  },
+  "stripePrices": {
+    "individualUsagePriceId": "price_1234",
+    "teamUsagePriceId": "price_5678"
+  },
+  "redis": {
+    "address": "redis:6379"
+  },
+  "serverAddress": "server:3000",
+  "gitpodHost": "gitpod.io"
+}
+```
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+- `components/gitpod-db`: Database access
+- `components/public-api`: Public API definitions
+- `components/usage-api`: Usage API definitions
+
+### External Dependencies
+- Stripe API for payment processing
+- Redis for distributed locking and caching
+- GORM for database access
+- gRPC for API communication
+
+## Integration Points
+
+The Usage component integrates with:
+1. **Database**: For storing usage and billing information
+2. **Redis**: For distributed locking and job scheduling
+3. **Stripe**: For payment processing
+4. **Server**: For user and team information
+5. **Workspace Manager**: For workspace usage information
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **Encryption**: Sensitive payment information is encrypted
+2. **Access Control**: Usage information is only accessible to authorized users
+3. **Audit Logging**: Changes to billing and usage are logged
+4. **Webhook Verification**: Stripe webhooks are verified for authenticity
+5. **Rate Limiting**: API endpoints are rate-limited to prevent abuse
+
+## Metrics
+
+The component exposes various metrics:
+
+- Usage calculation durations
+- Billing operation counts
+- Stripe API call latencies
+- Job execution times
+- Error counts
+
+## Common Usage Patterns
+
+The Usage component is typically used to:
+1. Track workspace usage for billing purposes
+2. Calculate credit consumption for users and teams
+3. Process payments through Stripe
+4. Enforce usage limits and spending controls
+5. Generate usage reports and analytics
+6. Reset usage counters at billing cycle boundaries
+
+## Related Components
+
+- **Server**: Provides user and team information
+- **Database**: Stores usage and billing information
+- **Workspace Manager**: Provides workspace usage information
+- **Public API Server**: Exposes usage and billing APIs

--- a/memory-bank/components/workspacekit.md
+++ b/memory-bank/components/workspacekit.md
@@ -1,0 +1,138 @@
+# Workspacekit Component
+
+## Overview
+
+Workspacekit is a critical component in Gitpod that manages the container setup and namespace isolation for workspaces. It serves as the initialization system for workspace containers, setting up the necessary namespaces, mounts, and security configurations to provide a secure and isolated environment for user code execution.
+
+## Purpose
+
+The primary purposes of the Workspacekit component are:
+- Initialize and configure workspace containers
+- Set up user namespace isolation with proper UID/GID mappings
+- Configure mount namespaces and filesystem access
+- Establish network namespace isolation
+- Implement seccomp filtering for syscall security
+- Provide a multi-ring security architecture
+- Enable controlled access to host resources
+- Support workspace-specific configuration
+- Facilitate communication between different security rings
+
+## Architecture
+
+Workspacekit implements a multi-ring security architecture:
+
+1. **Ring0**: The outermost ring that runs with the most privileges, responsible for setting up the container environment
+2. **Ring1**: The middle ring that handles namespace setup, mounts, and communication with the workspace daemon
+3. **Ring2**: The innermost ring where the actual user code runs, with the most restricted permissions
+
+This ring-based architecture provides defense in depth, ensuring that even if a vulnerability is exploited in the innermost ring, additional security boundaries must be crossed to gain access to the host system.
+
+## Key Components
+
+### Ring0
+- Initializes the workspace container
+- Communicates with the workspace daemon to prepare for user namespaces
+- Creates Ring1 with appropriate namespace isolation
+- Handles signals and manages the lifecycle of Ring1
+
+### Ring1
+- Sets up UID/GID mappings for user namespace isolation
+- Configures mount points and filesystem access
+- Establishes network namespace configuration
+- Creates and manages Ring2
+- Handles seccomp filter setup
+- Provides the "lift" service for executing commands in Ring1 from Ring2
+
+### Ring2
+- The most restricted environment where user code runs
+- Communicates with Ring1 for privileged operations
+- Runs the supervisor process that manages the workspace
+
+### Seccomp Filtering
+- Implements syscall filtering for security
+- Provides a mechanism for controlled access to restricted syscalls
+- Handles syscall interception and forwarding to the workspace daemon
+
+## Commands
+
+### ring0
+- Entry point for the workspace container
+- Prepares the environment for user namespaces
+- Launches ring1 with appropriate isolation
+
+### ring1
+- Sets up UID/GID mappings
+- Configures mount points and filesystem access
+- Launches ring2 with additional isolation
+
+### ring2
+- Pivots to the new root filesystem
+- Loads seccomp filters
+- Executes the supervisor process
+
+### lift
+- Allows executing commands in ring1 from ring2
+- Provides a mechanism for controlled privilege escalation
+
+### nsenter
+- Utility for entering namespaces
+- Used for debugging and maintenance
+
+## Integration Points
+
+Workspacekit integrates with:
+1. **Workspace Daemon**: For operations requiring host privileges
+2. **Supervisor**: As the main process running in the workspace
+3. **Container Runtime**: For container initialization and lifecycle management
+4. **Kubernetes**: For pod configuration and resource management
+
+## Security Considerations
+
+The component implements several security measures:
+
+1. **User Namespace Isolation**: Mapping UIDs/GIDs to provide isolation
+2. **Mount Namespace Configuration**: Controlling filesystem access
+3. **Network Namespace Isolation**: Restricting network access
+4. **Seccomp Filtering**: Limiting available syscalls
+5. **Multi-Ring Architecture**: Providing defense in depth
+6. **Controlled Privilege Escalation**: Through the lift mechanism
+
+## Configuration
+
+Workspacekit can be configured through environment variables:
+
+- `GITPOD_WORKSPACE_ID`: Workspace identifier
+- `WORKSPACEKIT_FSSHIFT`: Filesystem shift method (e.g., SHIFTFS)
+- `GITPOD_WORKSPACEKIT_BIND_MOUNTS`: Additional bind mounts
+- `WORKSPACEKIT_RING2_ENCLAVE`: Commands to run in the Ring2 namespace
+- `GITPOD_WORKSPACEKIT_SUPERVISOR_PATH`: Path to the supervisor binary
+- `GITPOD_RLIMIT_CORE`: Core dump size limits
+- `GITPOD_WORKSPACEKIT_SLEEP_FOR_DEBUGGING`: Enable debugging sleep
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go`: Common Go utilities
+- `components/content-service-api`: Content service API definitions
+- `components/ws-daemon-api`: Workspace daemon API definitions
+
+### External Dependencies
+- libseccomp: For seccomp filter implementation
+- rootlesskit: For rootless container utilities
+- Kubernetes libraries: For pod management
+
+## Common Usage Patterns
+
+Workspacekit is typically used to:
+1. Initialize workspace containers with proper isolation
+2. Set up filesystem access with appropriate permissions
+3. Configure network access for workspaces
+4. Implement security boundaries for user code execution
+5. Facilitate communication between different security rings
+
+## Related Components
+
+- **Supervisor**: Runs inside the workspace to manage user sessions
+- **Workspace Daemon**: Provides host-level operations for workspaces
+- **Container Runtime**: Manages the container lifecycle
+- **Kubernetes**: Orchestrates workspace pods

--- a/memory-bank/components/ws-daemon.md
+++ b/memory-bank/components/ws-daemon.md
@@ -1,0 +1,110 @@
+# Workspace Daemon (ws-daemon) Component
+
+## Overview
+
+The Workspace Daemon (ws-daemon) is a critical component that runs on each Kubernetes node in the Gitpod cluster. It manages workspace-related operations at the node level, including workspace initialization, content synchronization, backup, and resource management.
+
+## Purpose
+
+The primary purposes of the Workspace Daemon are:
+- Initialize workspace content on the node
+- Manage workspace backups and snapshots
+- Enforce workspace resource limits (disk space, etc.)
+- Monitor workspace health and status
+- Provide low-level workspace operations that require node-level access
+- Synchronize workspace content with storage backends
+
+## Architecture
+
+The Workspace Daemon operates as a node-level daemon with several key components:
+
+1. **Content Manager**: Handles workspace content initialization and synchronization
+2. **Backup System**: Manages periodic backups of workspace content
+3. **Resource Controller**: Enforces resource limits and quotas
+4. **gRPC API Server**: Provides an API for workspace operations
+5. **Health Monitoring**: Monitors workspace and node health
+
+The daemon runs with elevated privileges on each node to perform operations that require system-level access, such as managing LVM volumes, enforcing disk quotas, and accessing workspace filesystems.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/run.go`: Implements the main daemon service
+- `cmd/client*.go`: Client commands for interacting with the daemon
+- `pkg/daemon/`: Core daemon implementation
+- `pkg/content/`: Workspace content management
+- `nsinsider/`: Namespace operations helper
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities
+- `components/content-service-api/go:lib`: Content service API definitions
+- `components/content-service:lib`: Content service client
+- `components/ws-daemon-api/go:lib`: Workspace daemon API definitions
+- `components/ws-manager-api/go:lib`: Workspace manager API definitions
+- `components/ws-manager-mk2:crd`: Workspace manager custom resource definitions
+
+### External Dependencies
+- Kubernetes client libraries
+- Storage backend libraries (Minio, GCloud)
+- System-level libraries for resource management
+- gRPC for API communication
+
+## Configuration
+
+The Workspace Daemon is configured via a JSON configuration file that includes:
+
+### Content Configuration
+- Working area location
+- Backup period
+- Workspace size limits
+- Storage backend configuration (Minio, GCloud)
+
+### Service Configuration
+- API server address
+- TLS settings
+
+### Monitoring Configuration
+- Prometheus metrics endpoint
+- Health check settings
+
+## Integration Points
+
+The Workspace Daemon integrates with:
+1. **Workspace Manager**: Receives workspace lifecycle events
+2. **Content Service**: For workspace content storage and retrieval
+3. **Supervisor**: For workspace-level operations
+4. **Storage Backends**: For content backup and synchronization
+5. **Kubernetes**: For node and pod information
+
+## Security Considerations
+
+- Runs with elevated privileges on the node
+- Manages sensitive workspace content
+- Enforces isolation between workspaces
+- Handles resource limits and quotas
+- Requires secure communication with other components
+
+## Common Usage Patterns
+
+The Workspace Daemon is typically used to:
+1. Initialize workspace content when a workspace starts
+2. Perform periodic backups of workspace content
+3. Enforce disk quotas and resource limits
+4. Provide workspace snapshots for persistence
+5. Clean up workspace resources when a workspace is deleted
+
+## Resource Management
+
+The Workspace Daemon implements sophisticated resource management:
+1. **Disk Quotas**: Enforces workspace disk usage limits
+2. **Disk Space Monitoring**: Ensures sufficient disk space is available on the node
+3. **LVM Management**: Creates and manages LVM volumes for workspaces (when applicable)
+
+## Related Components
+
+- **Workspace Manager**: Orchestrates workspace lifecycle, interacts with ws-daemon for node-level operations
+- **Supervisor**: Runs inside workspace containers, interacts with ws-daemon for content operations
+- **Content Service**: Provides storage for workspace content

--- a/memory-bank/components/ws-manager-bridge.md
+++ b/memory-bank/components/ws-manager-bridge.md
@@ -1,0 +1,143 @@
+# Workspace Manager Bridge Component
+
+## Overview
+
+The Workspace Manager Bridge (ws-manager-bridge) is a critical component in the Gitpod architecture that acts as an intermediary between the workspace manager (ws-manager) and the rest of the Gitpod platform. It subscribes to workspace status updates from the workspace manager, processes these updates, and synchronizes the information with the database and other components of the system.
+
+## Purpose
+
+The primary purposes of the Workspace Manager Bridge component are:
+- Subscribe to workspace status updates from workspace managers
+- Process and transform workspace status information
+- Update the database with current workspace instance states
+- Trigger appropriate actions based on workspace lifecycle events
+- Provide metrics and monitoring for workspace instances
+- Manage workspace cluster information and available workspace classes
+- Bridge the communication between workspace managers and other Gitpod components
+- Handle prebuild status updates and synchronization
+- Expose a gRPC service for cluster management
+
+## Architecture
+
+The Workspace Manager Bridge consists of several key components:
+
+1. **Bridge Controller**: Manages the lifecycle of bridges to workspace clusters
+2. **Workspace Manager Bridge**: Handles status updates from workspace managers
+3. **Workspace Instance Controller**: Controls workspace instances based on their state
+4. **Prebuild Updater**: Updates prebuild information based on workspace status
+5. **Cluster Service Server**: Provides a gRPC service for cluster management
+6. **Metrics**: Collects and exposes metrics about workspace instances
+
+The component is designed to be resilient to failures, with mechanisms for reconnection, message queuing, and error handling.
+
+## Key Files and Structure
+
+- `src/main.ts`: Entry point for the application
+- `src/bridge.ts`: Core implementation of the workspace manager bridge
+- `src/bridge-controller.ts`: Controls bridges to workspace clusters
+- `src/workspace-instance-controller.ts`: Controls workspace instances
+- `src/prebuild-updater.ts`: Updates prebuild information
+- `src/cluster-service-server.ts`: gRPC service for cluster management
+- `src/wsman-subscriber.ts`: Subscribes to workspace manager events
+- `src/metrics.ts`: Metrics collection and reporting
+- `src/config.ts`: Configuration for the component
+- `src/container-module.ts`: Dependency injection setup
+
+## Workflow
+
+The Workspace Manager Bridge follows this general workflow:
+
+1. **Initialization**:
+   - Connect to the database
+   - Set up metrics and tracing
+   - Start the bridge controller
+   - Start the cluster service server
+   - Start the workspace instance controller
+
+2. **Status Update Handling**:
+   - Subscribe to status updates from workspace managers
+   - Queue updates by instance ID to ensure proper ordering
+   - Process updates and update the database
+   - Trigger appropriate actions based on workspace lifecycle events
+   - Update prebuild information if necessary
+   - Publish instance updates to Redis for other components
+
+3. **Workspace Instance Control**:
+   - Periodically check workspace instances
+   - Enforce timeouts and other policies
+   - Handle stopped workspaces
+
+4. **Workspace Class Management**:
+   - Periodically update workspace class information from clusters
+   - Store updated information in the database
+
+## Status Update Processing
+
+The bridge processes workspace status updates from the workspace manager and maps them to the Gitpod data model:
+
+1. **Phase Mapping**: Maps workspace phases (PENDING, CREATING, INITIALIZING, RUNNING, STOPPING, STOPPED) to the corresponding database representation
+2. **Condition Mapping**: Maps workspace conditions (deployed, failed, timeout, etc.) to the database
+3. **Port Mapping**: Maps exposed ports and their visibility/protocol
+4. **Timestamp Recording**: Records important timestamps (started, deployed, stopped)
+5. **Metrics Collection**: Collects metrics about workspace instances
+6. **Lifecycle Handling**: Triggers appropriate actions based on lifecycle events
+
+## Dependencies
+
+### Internal Dependencies
+- `@gitpod/gitpod-db`: Database access
+- `@gitpod/gitpod-protocol`: Shared protocol definitions
+- `@gitpod/ws-manager`: Workspace manager client
+- `@gitpod/ws-manager-bridge-api`: Bridge API definitions
+- `@gitpod/ws-daemon`: Workspace daemon client
+
+### External Dependencies
+- Express for metrics endpoint
+- Prometheus client for metrics
+- gRPC for communication with workspace managers
+- Redis for publishing instance updates
+
+## Integration Points
+
+The Workspace Manager Bridge integrates with:
+1. **Workspace Manager**: Subscribes to workspace status updates
+2. **Database**: Updates workspace instance information
+3. **Redis**: Publishes instance updates for other components
+4. **Prometheus**: Exposes metrics
+5. **Other Gitpod Components**: Provides workspace status information
+
+## Configuration
+
+The Workspace Manager Bridge is configured through environment variables:
+
+- `CONTROLLER_INTERVAL_SECONDS`: Interval for controller operations
+- `CONTROLLER_MAX_DISCONNECT_SECONDS`: Maximum time to wait for reconnection
+- Various database and connection settings
+
+## Metrics
+
+The component exposes various metrics:
+
+- Workspace instance status updates
+- Workspace startup time
+- First user activity
+- Stale status updates
+- Update processing time
+- Error counts
+
+## Common Usage Patterns
+
+The Workspace Manager Bridge is typically used to:
+1. Monitor workspace instance status
+2. Update the database with current workspace states
+3. Trigger actions based on workspace lifecycle events
+4. Collect metrics about workspace instances
+5. Manage workspace cluster information
+
+## Related Components
+
+- **Workspace Manager**: Manages workspace instances in Kubernetes
+- **Workspace Daemon**: Manages workspace-level operations
+- **Database**: Stores workspace instance information
+- **Server**: Uses workspace instance information for API responses
+- **Dashboard**: Displays workspace status to users

--- a/memory-bank/components/ws-manager-mk2.md
+++ b/memory-bank/components/ws-manager-mk2.md
@@ -1,0 +1,121 @@
+# Workspace Manager MK2 Component
+
+## Overview
+
+The Workspace Manager MK2 (ws-manager-mk2) is a Kubernetes controller responsible for managing the lifecycle of workspaces in Gitpod. It orchestrates the creation, monitoring, and deletion of workspace pods and related resources in the Kubernetes cluster.
+
+## Purpose
+
+The primary purposes of the Workspace Manager MK2 are:
+- Manage the complete lifecycle of workspaces in Kubernetes
+- Implement workspace timeouts and resource management
+- Provide a gRPC API for workspace operations
+- Handle workspace status monitoring and updates
+- Coordinate with other components like content-service and registry-facade
+
+## Architecture
+
+Workspace Manager MK2 is implemented as a Kubernetes controller using the controller-runtime framework. It consists of several key components:
+
+1. **Workspace Controller**: Manages the Workspace custom resources
+2. **Timeout Controller**: Handles workspace timeouts based on configuration
+3. **Maintenance Controller**: Manages maintenance mode for workspaces
+4. **Subscriber Controller**: Handles workspace event subscriptions
+5. **gRPC Service**: Provides API for workspace operations
+
+The component follows the Kubernetes operator pattern, watching for changes to Workspace custom resources and reconciling the actual state with the desired state.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that sets up the controller manager and gRPC service
+- `cmd/`: Command-line interface implementation
+- `controllers/`: Kubernetes controllers for workspace resources
+- `service/`: gRPC service implementation
+- `pkg/`: Supporting packages and utilities
+- `config/`: Configuration files, including CRD definitions
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities
+- `components/content-service-api/go:lib`: Content service API definitions
+- `components/content-service:lib`: Content service client
+- `components/registry-facade-api/go:lib`: Registry facade API definitions
+- `components/ws-manager-api/go:lib`: Workspace manager API definitions
+- `components/image-builder-api/go:lib`: Image builder API definitions
+
+### External Dependencies
+- Kubernetes client-go: For interacting with the Kubernetes API
+- controller-runtime: Framework for building Kubernetes controllers
+- gRPC: For service communication
+- Prometheus: For metrics and monitoring
+
+## Configuration
+
+Workspace Manager MK2 is configured via a JSON configuration file that includes:
+
+### Manager Configuration
+- Namespace settings for workspaces and secrets
+- Timeout configurations for different workspace states
+- URL templates for workspace access
+- TLS configuration for secure communication
+- Integration settings for other components
+
+### Content Storage Configuration
+- Storage backend configuration (Minio, GCloud)
+- Blob quota settings
+
+### RPC Server Configuration
+- Address and rate limits for the gRPC server
+
+### Monitoring Configuration
+- Prometheus metrics endpoint
+- Profiling endpoint
+
+## Integration Points
+
+Workspace Manager MK2 integrates with:
+1. **Kubernetes API**: For managing workspace resources
+2. **Content Service**: For workspace content management
+3. **Registry Facade**: For container image access
+4. **Image Builder**: For custom workspace images
+5. **WS Daemon**: For workspace runtime operations
+
+## Security Considerations
+
+- Implements TLS for secure gRPC communication
+- Manages workspace isolation through Kubernetes
+- Handles sensitive workspace configuration
+- Enforces resource limits and timeouts
+- Uses seccomp profiles for container security
+
+## Common Usage Patterns
+
+Workspace Manager MK2 is typically used to:
+1. Create new workspaces based on user requests
+2. Monitor workspace status and health
+3. Apply timeout policies to workspaces
+4. Clean up workspace resources when no longer needed
+5. Provide workspace status information to other components
+
+## Metrics and Monitoring
+
+The component exposes Prometheus metrics for:
+- Workspace lifecycle operations
+- Request handling times
+- Resource usage
+- Error rates
+- Controller reconciliation metrics
+
+## Known Limitations
+
+- Requires specific Kubernetes RBAC permissions
+- Operates within a specific namespace, not cluster-wide
+- Depends on other Gitpod components for full functionality
+
+## Related Components
+
+- **WS Daemon**: Works with Workspace Manager to manage workspace runtime
+- **Content Service**: Manages workspace content
+- **Registry Facade**: Provides access to container images
+- **Image Builder**: Builds custom workspace images

--- a/memory-bank/components/ws-proxy.md
+++ b/memory-bank/components/ws-proxy.md
@@ -1,0 +1,142 @@
+# Workspace Proxy (ws-proxy) Component
+
+## Overview
+
+The Workspace Proxy (ws-proxy) is a specialized component in Gitpod that handles routing and proxying of HTTP and WebSocket traffic to workspaces. It acts as an intermediary between the main Gitpod proxy and individual workspace pods, providing workspace-specific routing, port forwarding, and SSH gateway functionality.
+
+## Purpose
+
+The primary purposes of the Workspace Proxy are:
+- Route requests to the appropriate workspace pods
+- Handle workspace-specific domain routing
+- Provide port forwarding functionality for workspace ports
+- Implement SSH gateway for direct SSH access to workspaces
+- Manage WebSocket connections to workspaces
+- Handle workspace-specific routing patterns
+- Provide health checks and metrics for workspace connectivity
+
+## Architecture
+
+The Workspace Proxy operates as a specialized proxy service with several key components:
+
+1. **HTTP Proxy**: Routes HTTP requests to workspace pods
+2. **WebSocket Proxy**: Handles WebSocket connections to workspaces
+3. **SSH Gateway**: Provides SSH access to workspaces
+4. **Workspace Info Provider**: Retrieves workspace information from Kubernetes CRDs
+5. **Heartbeat Service**: Monitors workspace connectivity
+6. **Router**: Determines the appropriate workspace for incoming requests
+
+The component is designed to efficiently route traffic to the correct workspace based on the hostname pattern, handling both HTTP and WebSocket protocols.
+
+## Key Files and Structure
+
+- `main.go`: Entry point that calls the Execute function from the cmd package
+- `cmd/root.go`: Defines the root command and basic service configuration
+- `cmd/run.go`: Implements the main proxy service
+- `pkg/proxy/`: Core proxy implementation
+- `pkg/sshproxy/`: SSH gateway implementation
+- `pkg/config/`: Configuration handling
+- `pkg/analytics/`: Analytics functionality
+- `public/`: Static assets for built-in pages
+
+## Dependencies
+
+### Internal Dependencies
+- `components/common-go:lib`: Common Go utilities
+- `components/gitpod-protocol/go:lib`: Gitpod protocol definitions
+- `components/content-service-api/go:lib`: Content service API definitions
+- `components/content-service:lib`: Content service client
+- `components/registry-facade-api/go:lib`: Registry facade API definitions
+- `components/supervisor-api/go:lib`: Supervisor API definitions
+- `components/ws-manager-api/go:lib`: Workspace manager API definitions
+- `components/server/go:lib`: Server component library
+
+### External Dependencies
+- Kubernetes client libraries for CRD access
+- HTTP and WebSocket libraries
+- SSH libraries for SSH gateway
+- Prometheus for metrics
+- Controller-runtime for Kubernetes integration
+
+## Configuration
+
+The Workspace Proxy is configured via a JSON configuration file that includes:
+
+### Ingress Configuration
+- HTTP/HTTPS settings
+- Listening address and port
+- Host header for routing
+
+### Proxy Configuration
+- Transport settings (timeouts, connection limits)
+- Gitpod installation details (hostname, workspace domain patterns)
+- Workspace pod configuration (ports for IDE and supervisor)
+- Built-in pages location
+
+### Workspace Manager Configuration
+- Connection details for the Workspace Manager
+- TLS settings for secure communication
+
+### SSH Gateway Configuration
+- CA key file for SSH certificate signing
+- Host keys for SSH server
+
+## Routing Logic
+
+The Workspace Proxy implements sophisticated routing logic:
+
+1. **Workspace Routing**: Routes requests to workspaces based on hostname patterns
+2. **Port Forwarding**: Routes requests to specific ports in workspaces
+3. **WebSocket Routing**: Handles WebSocket connections to workspaces
+4. **SSH Gateway**: Routes SSH connections to workspaces
+
+### Hostname Patterns
+
+The Workspace Proxy handles several hostname patterns:
+
+1. **Standard Workspace**: `<workspace-id>.ws.<region>.<domain>`
+2. **Port Forwarding**: `<port>-<workspace-id>.ws.<region>.<domain>`
+3. **Debug Workspace**: `debug-<workspace-id>.ws.<region>.<domain>`
+4. **Foreign Content**: Special routes for VS Code webviews and webworkers
+
+## SSH Gateway
+
+The Workspace Proxy includes an SSH gateway that allows direct SSH access to workspaces:
+
+- Listens on port 2200 for SSH connections
+- Uses host keys for server authentication
+- Authenticates users using Gitpod's authentication system
+- Routes SSH connections to the appropriate workspace
+- Provides heartbeat functionality to monitor workspace connectivity
+
+## Integration Points
+
+The Workspace Proxy integrates with:
+1. **Kubernetes API**: Retrieves workspace information from CRDs
+2. **Workspace Manager**: Monitors workspace status
+3. **Workspace Pods**: Routes traffic to workspace containers
+4. **Main Proxy**: Receives traffic from the main Gitpod proxy
+
+## Security Considerations
+
+- Implements secure routing to workspaces
+- Handles TLS for secure communication
+- Provides SSH gateway with proper authentication
+- Validates workspace access permissions
+- Implements proper error handling and logging
+
+## Common Usage Patterns
+
+The Workspace Proxy is typically used to:
+1. Route HTTP requests to workspace pods
+2. Handle WebSocket connections to workspaces
+3. Provide port forwarding for workspace services
+4. Enable SSH access to workspaces
+5. Monitor workspace connectivity
+
+## Related Components
+
+- **Proxy**: Main Gitpod proxy that routes traffic to ws-proxy
+- **Workspace Manager**: Manages workspace lifecycle
+- **Supervisor**: Runs inside workspace containers
+- **Server**: Provides API for workspace operations

--- a/memory-bank/productContext.md
+++ b/memory-bank/productContext.md
@@ -1,0 +1,68 @@
+# Product Context: Gitpod
+
+## Why Gitpod Exists
+Gitpod was created to solve the fundamental problem of development environment inconsistency and setup time. Traditional development workflows require developers to manually set up and maintain their development environments, leading to:
+
+1. **"Works on my machine" problems**: Inconsistent environments across team members
+2. **Onboarding friction**: New team members spending days setting up their environment
+3. **Context switching costs**: Significant time lost when switching between projects
+4. **Resource limitations**: Local machines struggling with resource-intensive development tasks
+5. **Configuration drift**: Environments becoming inconsistent over time
+
+Gitpod addresses these challenges by providing ephemeral, automated, and consistent development environments in the cloud.
+
+## Problems Gitpod Solves
+
+### For Individual Developers
+- Eliminates environment setup and maintenance time
+- Provides consistent, reproducible environments
+- Enables development from any device with a browser
+- Reduces local resource constraints (CPU, memory, storage)
+- Simplifies context switching between projects
+
+### For Teams
+- Ensures all team members work in identical environments
+- Dramatically reduces onboarding time for new developers
+- Improves collaboration through shared workspaces
+- Streamlines code review processes
+- Reduces infrastructure management overhead
+
+### For Organizations
+- Enhances security through containerized environments
+- Improves productivity by eliminating environment-related issues
+- Enables standardization of development tools and practices
+- Provides flexibility for remote and distributed teams
+- Reduces costs associated with powerful local development machines
+
+## How Gitpod Works
+
+1. **Environment Definition**: Developers define their environment in a `.gitpod.yml` file, specifying dependencies, tools, and configurations.
+
+2. **Prebuilding**: Gitpod continuously prebuilds environments for branches, similar to CI systems, preparing environments before they're needed.
+
+3. **Instant Start**: When a developer starts a workspace, Gitpod spins up a container with the prebuild results, providing a ready-to-code environment in seconds.
+
+4. **Development**: Developers work in a familiar IDE interface (VS Code, JetBrains) with full access to all necessary tools and resources.
+
+5. **Collaboration**: Developers can share workspaces, create snapshots, and collaborate in real-time.
+
+6. **Integration**: Gitpod integrates with GitHub, GitLab, Bitbucket, and Azure DevOps, providing seamless workflow integration.
+
+## User Experience Goals
+
+- **Instant Readiness**: Environments should be ready to code within seconds
+- **Familiarity**: Provide the same experience as local development
+- **Seamless Integration**: Work naturally with existing tools and workflows
+- **Minimal Configuration**: Make it easy to define and maintain environment configurations
+- **Reliability**: Ensure consistent, reproducible environments every time
+- **Performance**: Deliver responsive, high-performance development experiences
+- **Accessibility**: Enable development from any device with a browser
+
+## Key Differentiators
+
+- **Ephemeral Environments**: Fresh environment for each task, eliminating configuration drift
+- **Prebuilds**: Environments prepared before they're needed, eliminating wait time
+- **Git Integration**: Deep integration with git platforms for seamless workflow
+- **Open Source**: Core platform is open source, providing transparency and extensibility
+- **Enterprise Ready**: Supports self-hosted deployments with enterprise-grade security and compliance features
+- **IDE Flexibility**: Supports multiple IDEs including VS Code and JetBrains products

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 30 key components
+- **Component Documentation**: Documentation created for 33 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -45,6 +45,9 @@ Our current contributions:
   - docker-up
   - image-builder-bob
   - node-labeler
+  - openvsx-proxy
+  - scheduler-extender
+  - ipfs
 
 The existing functionality of the Gitpod platform:
 
@@ -101,6 +104,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of tenth set of key components (common-go, workspacekit)
 - Documentation of eleventh set of key components (spicedb, scrubber, service-waiter)
 - Documentation of twelfth set of key components (docker-up, image-builder-bob, node-labeler)
+- Documentation of thirteenth set of key components (openvsx-proxy, scheduler-extender, ipfs)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -158,6 +162,9 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented docker-up component
   - Documented image-builder-bob component
   - Documented node-labeler component
+  - Documented openvsx-proxy component
+  - Documented scheduler-extender component
+  - Documented ipfs component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 22 key components
+- **Component Documentation**: Documentation created for 24 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -37,6 +37,8 @@ Our current contributions:
   - local-app
   - public-api-server
   - usage
+  - common-go
+  - workspacekit
 
 The existing functionality of the Gitpod platform:
 
@@ -90,6 +92,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of seventh set of key components (ide, ide-proxy, ws-manager-bridge)
 - Documentation of eighth set of key components (ide-metrics, local-app)
 - Documentation of ninth set of key components (public-api-server, usage)
+- Documentation of tenth set of key components (common-go, workspacekit)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -139,6 +142,8 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented local-app component
   - Documented public-api-server component
   - Documented usage component
+  - Documented common-go component
+  - Documented workspacekit component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -2,16 +2,25 @@
 
 ## Current Status
 
-As of the memory bank initialization, we are at the beginning of our work with the Gitpod codebase. The current status is:
+We are in the early stages of our work with the Gitpod codebase. The current status is:
 
-- **Memory Bank**: Initial setup complete
-- **Codebase Understanding**: Basic overview obtained
+- **Memory Bank**: Initial setup complete with core files and component documentation
+- **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
+- **Component Documentation**: Documentation created for 4 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
 ## What Works
 
-Since we are just beginning our work with Gitpod, this section primarily reflects the existing functionality of the Gitpod platform rather than our specific contributions:
+Our current contributions:
+- Memory bank structure established
+- Component documentation for:
+  - blobserve
+  - content-service
+  - dashboard
+  - ws-manager-mk2
+
+The existing functionality of the Gitpod platform:
 
 ### Core Functionality
 - Workspace creation from Git repositories
@@ -29,9 +38,13 @@ Since we are just beginning our work with Gitpod, this section primarily reflect
 
 ## What's Left to Build
 
-This section will be updated as specific tasks and improvements are identified. Initially, it serves as a placeholder for tracking future work:
-
 ### Immediate Tasks
+- Document additional key components:
+  - supervisor
+  - ws-daemon
+  - ide-service
+  - registry-facade
+  - image-builder
 - Set up local development environment
 - Identify specific components for deeper exploration
 - Establish testing methodology
@@ -53,9 +66,12 @@ As we begin working with the codebase, we have not yet identified specific issue
 ## Milestones
 
 ### Completed Milestones
-- Memory bank initialization (Current)
+- Memory bank initialization
+- Component documentation structure
+- Documentation of first set of key components
 
 ### Upcoming Milestones
+- Documentation of remaining key components
 - Development environment setup
 - First component deep dive
 - Initial contribution
@@ -77,7 +93,13 @@ No specific blockers or dependencies have been identified yet. This section will
 
 ## Recent Progress
 
-- **2/26/2025**: Memory bank initialized with core documentation files
+- **2/26/2025**:
+  - Memory bank initialized with core documentation files
+  - Created components subdirectory in memory bank
+  - Documented blobserve component
+  - Documented content-service component
+  - Documented dashboard component
+  - Documented ws-manager-mk2 component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 15 key components
+- **Component Documentation**: Documentation created for 18 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -30,6 +30,9 @@ Our current contributions:
   - gitpod-cli
   - gitpod-db
   - gitpod-protocol
+  - ide
+  - ide-proxy
+  - ws-manager-bridge
 
 The existing functionality of the Gitpod platform:
 
@@ -50,7 +53,7 @@ The existing functionality of the Gitpod platform:
 ## What's Left to Build
 
 ### Immediate Tasks
-- Explore component interactions
+- Explore component interactios
 - Set up local development environment
 - Identify specific components for deeper exploration
 - Establish testing methodology
@@ -80,6 +83,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of fourth set of key components (server, proxy, ws-proxy)
 - Documentation of fifth set of key components (gitpod-cli, gitpod-db)
 - Documentation of sixth set of key components (gitpod-protocol)
+- Documentation of seventh set of key components (ide, ide-proxy, ws-manager-bridge)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -122,6 +126,9 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented gitpod-cli component
   - Documented gitpod-db component
   - Documented gitpod-protocol component
+  - Documented ide component
+  - Documented ide-proxy component
+  - Documented ws-manager-bridge component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 18 key components
+- **Component Documentation**: Documentation created for 20 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -33,6 +33,8 @@ Our current contributions:
   - ide
   - ide-proxy
   - ws-manager-bridge
+  - ide-metrics
+  - local-app
 
 The existing functionality of the Gitpod platform:
 
@@ -84,6 +86,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of fifth set of key components (gitpod-cli, gitpod-db)
 - Documentation of sixth set of key components (gitpod-protocol)
 - Documentation of seventh set of key components (ide, ide-proxy, ws-manager-bridge)
+- Documentation of eighth set of key components (ide-metrics, local-app)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -129,6 +132,8 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented ide component
   - Documented ide-proxy component
   - Documented ws-manager-bridge component
+  - Documented ide-metrics component
+  - Documented local-app component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 9 key components
+- **Component Documentation**: Documentation created for 12 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -24,6 +24,9 @@ Our current contributions:
   - ide-service
   - registry-facade
   - image-builder-mk3
+  - server
+  - proxy
+  - ws-proxy
 
 The existing functionality of the Gitpod platform:
 
@@ -71,6 +74,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of first set of key components (blobserve, content-service, dashboard, ws-manager-mk2)
 - Documentation of second set of key components (supervisor, ws-daemon)
 - Documentation of third set of key components (ide-service, registry-facade, image-builder-mk3)
+- Documentation of fourth set of key components (server, proxy, ws-proxy)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -107,6 +111,9 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented ide-service component
   - Documented registry-facade component
   - Documented image-builder-mk3 component
+  - Documented server component
+  - Documented proxy component
+  - Documented ws-proxy component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 24 key components
+- **Component Documentation**: Documentation created for 27 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -39,6 +39,9 @@ Our current contributions:
   - usage
   - common-go
   - workspacekit
+  - spicedb
+  - scrubber
+  - service-waiter
 
 The existing functionality of the Gitpod platform:
 
@@ -93,6 +96,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of eighth set of key components (ide-metrics, local-app)
 - Documentation of ninth set of key components (public-api-server, usage)
 - Documentation of tenth set of key components (common-go, workspacekit)
+- Documentation of eleventh set of key components (spicedb, scrubber, service-waiter)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -144,6 +148,9 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented usage component
   - Documented common-go component
   - Documented workspacekit component
+  - Documented spicedb component
+  - Documented scrubber component
+  - Documented service-waiter component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 12 key components
+- **Component Documentation**: Documentation created for 14 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -27,6 +27,8 @@ Our current contributions:
   - server
   - proxy
   - ws-proxy
+  - gitpod-cli
+  - gitpod-db
 
 The existing functionality of the Gitpod platform:
 
@@ -75,6 +77,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of second set of key components (supervisor, ws-daemon)
 - Documentation of third set of key components (ide-service, registry-facade, image-builder-mk3)
 - Documentation of fourth set of key components (server, proxy, ws-proxy)
+- Documentation of fifth set of key components (gitpod-cli, gitpod-db)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -114,6 +117,8 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented server component
   - Documented proxy component
   - Documented ws-proxy component
+  - Documented gitpod-cli component
+  - Documented gitpod-db component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 6 key components
+- **Component Documentation**: Documentation created for 9 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -21,6 +21,9 @@ Our current contributions:
   - ws-manager-mk2
   - supervisor
   - ws-daemon
+  - ide-service
+  - registry-facade
+  - image-builder-mk3
 
 The existing functionality of the Gitpod platform:
 
@@ -41,10 +44,7 @@ The existing functionality of the Gitpod platform:
 ## What's Left to Build
 
 ### Immediate Tasks
-- Document additional key components:
-  - ide-service
-  - registry-facade
-  - image-builder
+- Explore component interactions
 - Set up local development environment
 - Identify specific components for deeper exploration
 - Establish testing methodology
@@ -70,6 +70,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Component documentation structure
 - Documentation of first set of key components (blobserve, content-service, dashboard, ws-manager-mk2)
 - Documentation of second set of key components (supervisor, ws-daemon)
+- Documentation of third set of key components (ide-service, registry-facade, image-builder-mk3)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -103,6 +104,9 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented ws-manager-mk2 component
   - Documented supervisor component
   - Documented ws-daemon component
+  - Documented ide-service component
+  - Documented registry-facade component
+  - Documented image-builder-mk3 component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 14 key components
+- **Component Documentation**: Documentation created for 15 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -29,6 +29,7 @@ Our current contributions:
   - ws-proxy
   - gitpod-cli
   - gitpod-db
+  - gitpod-protocol
 
 The existing functionality of the Gitpod platform:
 
@@ -78,6 +79,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of third set of key components (ide-service, registry-facade, image-builder-mk3)
 - Documentation of fourth set of key components (server, proxy, ws-proxy)
 - Documentation of fifth set of key components (gitpod-cli, gitpod-db)
+- Documentation of sixth set of key components (gitpod-protocol)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -119,6 +121,7 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented ws-proxy component
   - Documented gitpod-cli component
   - Documented gitpod-db component
+  - Documented gitpod-protocol component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -1,0 +1,89 @@
+# Progress: Gitpod
+
+## Current Status
+
+As of the memory bank initialization, we are at the beginning of our work with the Gitpod codebase. The current status is:
+
+- **Memory Bank**: Initial setup complete
+- **Codebase Understanding**: Basic overview obtained
+- **Development Environment**: Not yet configured
+- **Task Identification**: Not yet started
+
+## What Works
+
+Since we are just beginning our work with Gitpod, this section primarily reflects the existing functionality of the Gitpod platform rather than our specific contributions:
+
+### Core Functionality
+- Workspace creation from Git repositories
+- IDE integration (VS Code, JetBrains)
+- Prebuild system for faster startup
+- Git platform integrations (GitHub, GitLab, Bitbucket, Azure DevOps)
+- Containerized workspaces with Docker support
+- Collaborative features
+
+### Development Infrastructure
+- Leeway build system for component management
+- Kubernetes-based deployment
+- Microservices architecture
+- Testing frameworks
+
+## What's Left to Build
+
+This section will be updated as specific tasks and improvements are identified. Initially, it serves as a placeholder for tracking future work:
+
+### Immediate Tasks
+- Set up local development environment
+- Identify specific components for deeper exploration
+- Establish testing methodology
+- Create initial contribution plan
+
+### Future Improvements
+This section will be populated as we identify specific improvements or features to implement.
+
+## Known Issues
+
+As we begin working with the codebase, we have not yet identified specific issues. This section will be updated as issues are discovered during development and testing.
+
+### Potential Areas of Concern
+- Component coupling and dependencies
+- Build system complexity
+- Testing coverage
+- Documentation completeness
+
+## Milestones
+
+### Completed Milestones
+- Memory bank initialization (Current)
+
+### Upcoming Milestones
+- Development environment setup
+- First component deep dive
+- Initial contribution
+- First feature implementation
+
+## Metrics and Progress Indicators
+
+As we progress, we'll track various metrics to gauge our progress and effectiveness:
+
+- **Code Understanding**: Percentage of components with detailed documentation
+- **Test Coverage**: Percentage of code covered by tests
+- **Issue Resolution**: Number of issues identified and resolved
+- **Feature Implementation**: Number of features successfully implemented
+- **Documentation Quality**: Completeness and accuracy of memory bank
+
+## Blockers and Dependencies
+
+No specific blockers or dependencies have been identified yet. This section will be updated as we encounter any obstacles that impede progress.
+
+## Recent Progress
+
+- **2/26/2025**: Memory bank initialized with core documentation files
+
+## Next Evaluation Point
+
+The next evaluation of progress will occur after:
+1. Setting up the development environment
+2. Completing the first deep dive into a specific component
+3. Identifying initial tasks for contribution
+
+At that point, this document will be updated to reflect new findings and progress.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 4 key components
+- **Component Documentation**: Documentation created for 6 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -19,6 +19,8 @@ Our current contributions:
   - content-service
   - dashboard
   - ws-manager-mk2
+  - supervisor
+  - ws-daemon
 
 The existing functionality of the Gitpod platform:
 
@@ -40,8 +42,6 @@ The existing functionality of the Gitpod platform:
 
 ### Immediate Tasks
 - Document additional key components:
-  - supervisor
-  - ws-daemon
   - ide-service
   - registry-facade
   - image-builder
@@ -68,7 +68,8 @@ As we begin working with the codebase, we have not yet identified specific issue
 ### Completed Milestones
 - Memory bank initialization
 - Component documentation structure
-- Documentation of first set of key components
+- Documentation of first set of key components (blobserve, content-service, dashboard, ws-manager-mk2)
+- Documentation of second set of key components (supervisor, ws-daemon)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -100,6 +101,8 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented content-service component
   - Documented dashboard component
   - Documented ws-manager-mk2 component
+  - Documented supervisor component
+  - Documented ws-daemon component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 27 key components
+- **Component Documentation**: Documentation created for 30 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -42,6 +42,9 @@ Our current contributions:
   - spicedb
   - scrubber
   - service-waiter
+  - docker-up
+  - image-builder-bob
+  - node-labeler
 
 The existing functionality of the Gitpod platform:
 
@@ -97,6 +100,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of ninth set of key components (public-api-server, usage)
 - Documentation of tenth set of key components (common-go, workspacekit)
 - Documentation of eleventh set of key components (spicedb, scrubber, service-waiter)
+- Documentation of twelfth set of key components (docker-up, image-builder-bob, node-labeler)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -151,6 +155,9 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented spicedb component
   - Documented scrubber component
   - Documented service-waiter component
+  - Documented docker-up component
+  - Documented image-builder-bob component
+  - Documented node-labeler component
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -6,7 +6,7 @@ We are in the early stages of our work with the Gitpod codebase. The current sta
 
 - **Memory Bank**: Initial setup complete with core files and component documentation
 - **Codebase Understanding**: Basic overview obtained, with detailed understanding of key components
-- **Component Documentation**: Documentation created for 20 key components
+- **Component Documentation**: Documentation created for 22 key components
 - **Development Environment**: Not yet configured
 - **Task Identification**: Not yet started
 
@@ -35,6 +35,8 @@ Our current contributions:
   - ws-manager-bridge
   - ide-metrics
   - local-app
+  - public-api-server
+  - usage
 
 The existing functionality of the Gitpod platform:
 
@@ -87,6 +89,7 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of sixth set of key components (gitpod-protocol)
 - Documentation of seventh set of key components (ide, ide-proxy, ws-manager-bridge)
 - Documentation of eighth set of key components (ide-metrics, local-app)
+- Documentation of ninth set of key components (public-api-server, usage)
 
 ### Upcoming Milestones
 - Documentation of remaining key components
@@ -134,6 +137,8 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented ws-manager-bridge component
   - Documented ide-metrics component
   - Documented local-app component
+  - Documented public-api-server component
+  - Documented usage component
 
 ## Next Evaluation Point
 

--- a/memory-bank/projectbrief.md
+++ b/memory-bank/projectbrief.md
@@ -1,0 +1,39 @@
+# Project Brief: Gitpod
+
+## Overview
+Gitpod is a developer platform that provides on-demand, pre-configured development environments that automatically integrate with any tool, library, or dependency required for creating software. It enables developers to spin up fresh, automated dev environments for each task, in the cloud, in seconds.
+
+## Core Features
+- **Dev Environments as Code**: Define editor extensions and dependencies in a declarative `.gitpod.yml` configuration
+- **Prebuilt Dev Environments**: Continuously prebuilds all git branches similar to a CI server
+- **Security**: Each workspace runs on a secured single-use container
+- **Docker-based Workspaces**: Instantly starts a container in the cloud based on a Docker image
+- **Git Platform Integration**: Seamlessly integrates with GitHub, GitLab, Bitbucket, and Azure DevOps
+- **Integrated Code Reviews**: Native code reviews on any PR/MR
+- **Collaboration**: Invite team members to your dev environment or share snapshots
+- **Customizable Developer Experience**: Same capabilities as a Linux machine, pre-configured and optimized
+
+## Project Goals
+1. Provide instant, ready-to-code development environments
+2. Eliminate environment setup and maintenance overhead
+3. Enable consistent development experiences across teams
+4. Improve collaboration and code review workflows
+5. Enhance security through containerized environments
+6. Support a wide range of development workflows and technologies
+
+## Target Audience
+- Software developers and development teams
+- Open source contributors
+- Educational institutions
+- Enterprise development organizations
+
+## Project Scope
+Gitpod encompasses:
+- Cloud-based development environment infrastructure
+- IDE integration (VS Code, JetBrains)
+- Git platform integrations
+- Prebuild and caching systems
+- Collaboration tools
+- Self-hosted and managed deployment options
+
+This project brief serves as the foundation for all other memory bank documents and defines the core requirements and goals of Gitpod.

--- a/memory-bank/systemPatterns.md
+++ b/memory-bank/systemPatterns.md
@@ -1,0 +1,131 @@
+# System Patterns: Gitpod
+
+## System Architecture
+
+Gitpod follows a microservices architecture composed of several key components that work together to provide the complete development environment platform. The system is designed to be:
+
+- **Scalable**: Handles many concurrent users and workspaces
+- **Resilient**: Maintains availability despite component failures
+- **Extensible**: Allows for adding new features and integrations
+- **Secure**: Isolates workspaces and protects user data
+
+### High-Level Architecture
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Git Platforms  │     │  User Browser   │     │  IDE Clients    │
+│  (GitHub, etc.) │     │                 │     │  (VS Code, etc.)│
+└────────┬────────┘     └────────┬────────┘     └────────┬────────┘
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                           API Gateway                           │
+└─────────────────────────────────────────────────────────────────┘
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Auth Service   │     │  Dashboard      │     │  IDE Service    │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+         │                       │                       │
+         └───────────────┬───────┴───────────────┬───────┘
+                         │                       │
+                         ▼                       ▼
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  WS Manager     │     │  Image Builder  │     │  Content Service│
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+         │                       │                       │
+         ▼                       ▼                       ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                     Kubernetes Infrastructure                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Key Components
+
+### Core Services
+
+1. **Workspace Manager (ws-manager)**: Orchestrates workspace lifecycle, managing creation, starting, stopping, and deletion of workspaces.
+
+2. **Workspace Daemon (ws-daemon)**: Runs on each node, managing workspace resources, file system operations, and runtime aspects.
+
+3. **Image Builder**: Builds Docker images for workspaces based on configuration and caches them for quick startup.
+
+4. **Content Service**: Manages file content, including git operations, file synchronization, and backup.
+
+5. **IDE Service**: Manages the IDE instances (VS Code, JetBrains) that run in workspaces.
+
+6. **Dashboard**: Web UI for managing workspaces, projects, and user settings.
+
+7. **Auth Service**: Handles authentication and authorization across the platform.
+
+8. **Proxy**: Routes traffic to the appropriate services and workspaces.
+
+### Supporting Components
+
+1. **Registry Facade**: Provides efficient access to container images.
+
+2. **Blobserve**: Serves static content from container images.
+
+3. **Supervisor**: Runs inside each workspace, managing the workspace's internal services.
+
+4. **Public API**: Provides programmatic access to Gitpod functionality.
+
+## Design Patterns
+
+### Microservices Pattern
+Gitpod is built as a collection of loosely coupled services, each with a specific responsibility. This enables independent scaling, deployment, and maintenance of components.
+
+### Container Orchestration
+Kubernetes is used to manage the deployment, scaling, and operation of application containers across clusters of hosts.
+
+### Event-Driven Architecture
+Components communicate through events for asynchronous operations, improving scalability and resilience.
+
+### API Gateway Pattern
+A central API gateway routes requests to appropriate services, handling cross-cutting concerns like authentication.
+
+### Circuit Breaker Pattern
+Services implement circuit breakers to prevent cascading failures when downstream services are unavailable.
+
+### Sidecar Pattern
+The Supervisor component runs alongside workspace applications as a sidecar, providing common functionality.
+
+### Immutable Infrastructure
+Workspaces are treated as immutable, with changes to configuration resulting in new environments rather than modifications to existing ones.
+
+## Component Relationships
+
+### Workspace Lifecycle
+
+1. User requests a workspace through the dashboard or Git integration
+2. Auth service validates the request
+3. Workspace Manager creates the workspace specification
+4. Image Builder ensures the required image is available
+5. Workspace Manager instructs Kubernetes to create the workspace pod
+6. Workspace Daemon initializes the workspace environment
+7. Supervisor starts within the workspace
+8. IDE Service connects the IDE to the workspace
+9. Proxy routes user traffic to the workspace
+
+### Data Flow
+
+1. **User Code**: Managed by Content Service, synchronized between workspace and git repositories
+2. **Configuration**: Stored in database, applied by Workspace Manager during workspace creation
+3. **Build Artifacts**: Cached by Image Builder for reuse in future workspaces
+4. **User Data**: Stored in database, accessed through Dashboard and API
+
+## Key Technical Decisions
+
+1. **Kubernetes-Based**: Leveraging Kubernetes for container orchestration provides scalability and standardized infrastructure management.
+
+2. **Multi-IDE Support**: Supporting multiple IDEs (VS Code, JetBrains) increases flexibility for users with different preferences.
+
+3. **Prebuild System**: Prebuilding environments before they're needed significantly reduces startup times.
+
+4. **Workspace Pods**: Each workspace runs in its own Kubernetes pod, providing isolation and resource management.
+
+5. **TypeScript and Go**: Core services are implemented in TypeScript (user-facing) and Go (system-level), balancing developer productivity and performance.
+
+6. **gRPC Communication**: Internal services communicate using gRPC for efficient, typed communication.
+
+7. **Leeway Build System**: Custom build system for managing the complex dependencies between components.

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -1,0 +1,141 @@
+# Technical Context: Gitpod
+
+## Technologies Used
+
+### Programming Languages
+- **Go**: Used for system-level services, performance-critical components, and Kubernetes integration
+- **TypeScript**: Used for user-facing services, dashboard, and IDE integration
+- **Java**: Used for JetBrains IDE integration
+- **Shell Scripts**: Used for automation, build scripts, and development tools
+
+### Frameworks & Libraries
+- **React**: Frontend dashboard UI
+- **gRPC**: Service-to-service communication
+- **Protocol Buffers**: Data serialization
+- **Kubernetes API**: Workspace orchestration
+- **Docker API**: Container management
+- **Leeway**: Custom build system for managing component dependencies
+
+### Infrastructure
+- **Kubernetes**: Container orchestration platform
+- **Docker**: Containerization technology
+- **MySQL**: Primary database for persistent data
+- **Redis**: Caching and ephemeral data storage
+- **Helm**: Kubernetes package management
+- **Terraform**: Infrastructure as code for deployment
+
+### Development Tools
+- **VS Code**: Primary IDE for TypeScript/JavaScript development
+- **GoLand/IntelliJ**: IDE for Go development
+- **pre-commit**: Git hooks for code quality
+- **ESLint/Prettier**: Code formatting and linting
+- **Werft**: CI/CD system
+
+## Development Setup
+
+### Local Development
+The project uses a Gitpod-based development workflow (dogfooding), with the following key aspects:
+
+1. **Gitpod Workspace**: Development occurs in Gitpod workspaces defined by `.gitpod.yml`
+2. **Component-Based**: Each component can be developed and tested independently
+3. **Leeway Build System**: Manages dependencies between components
+4. **Dev Containers**: Development occurs in containers that mirror production
+
+### Build Process
+1. **Leeway**: Custom build system that manages the complex dependencies between components
+2. **Component Compilation**: Each component is compiled independently
+   - TypeScript components use `yarn build`
+   - Go components use `go build`
+   - Java components use Gradle
+3. **Docker Images**: Components are packaged as Docker images
+4. **Helm Charts**: Deployment configurations are managed as Helm charts
+
+### Testing Strategy
+1. **Unit Tests**: Component-level tests for individual functions and classes
+2. **Integration Tests**: Tests for interactions between components
+3. **End-to-End Tests**: Tests for complete user workflows
+4. **Preview Environments**: Dedicated test environments for feature validation
+
+## Technical Constraints
+
+### Performance Requirements
+- **Workspace Startup Time**: Workspaces should start in under 10 seconds when prebuilt
+- **IDE Responsiveness**: IDE should maintain low latency even over internet connections
+- **Resource Efficiency**: Efficient use of cluster resources to maximize density
+
+### Security Constraints
+- **Workspace Isolation**: Strong isolation between user workspaces
+- **Least Privilege**: Components operate with minimal required permissions
+- **Data Protection**: Secure handling of user code and credentials
+- **Network Security**: Controlled network access between components
+
+### Scalability Requirements
+- **Horizontal Scaling**: All components must support horizontal scaling
+- **Multi-Cluster Support**: Support for distributing workspaces across multiple clusters
+- **Resource Limits**: Enforced limits on workspace resource consumption
+
+### Compliance Requirements
+- **GDPR Compliance**: Proper handling of user data
+- **SOC2 Compliance**: Security and availability controls
+- **Data Residency**: Support for region-specific data storage
+
+## Dependencies
+
+### External Dependencies
+- **Git Providers**: GitHub, GitLab, Bitbucket, Azure DevOps
+- **Container Registries**: Docker Hub, GCR, ECR
+- **Cloud Providers**: GCP, AWS, Azure (for self-hosted deployments)
+- **IDE Platforms**: VS Code, JetBrains IDEs
+
+### Internal Dependencies
+The system has several internal dependencies between components:
+
+1. **Workspace Manager** depends on:
+   - Kubernetes API
+   - Image Builder
+   - Content Service
+
+2. **Dashboard** depends on:
+   - Auth Service
+   - Workspace Manager
+   - Content Service
+
+3. **IDE Service** depends on:
+   - Workspace Manager
+   - Content Service
+   - Supervisor
+
+4. **Content Service** depends on:
+   - Git providers
+   - Storage systems
+
+5. **Supervisor** depends on:
+   - IDE Service
+   - Content Service
+
+### Third-Party Libraries
+Key third-party libraries and their purposes:
+
+1. **Kubernetes Client Libraries**: Interaction with Kubernetes API
+2. **Docker Client Libraries**: Container management
+3. **Database Drivers**: MySQL, Redis connectivity
+4. **gRPC/Protocol Buffers**: Service communication
+5. **React and UI Libraries**: Dashboard frontend
+6. **Authentication Libraries**: OAuth, JWT handling
+
+## Development Workflow
+
+1. **Feature Planning**: Features are planned and designed
+2. **Implementation**: Code is written and tested locally
+3. **Code Review**: Changes are reviewed through pull requests
+4. **CI/CD**: Automated testing and deployment
+5. **Preview**: Features are tested in preview environments
+6. **Release**: Changes are deployed to production
+
+## Technical Debt and Challenges
+
+1. **Component Coupling**: Some components have tight coupling that could be improved
+2. **Test Coverage**: Certain areas lack comprehensive test coverage
+3. **Documentation**: Some internal APIs lack detailed documentation
+4. **Legacy Components**: Some older components need modernization
+5. **Build System Complexity**: The custom build system has a learning curve


### PR DESCRIPTION
## Description
Created using `cline` and the "memory bank" instructions: https://docs.cline.bot/improving-your-prompting-skills/custom-instructions-library/cline-memory-bank?ref=cline.ghost.io

**Why commit this** It's documentation `cline`'s wrote **for itself**. It will update as we go, and use it to reduce context window need while working on the repository.

:point_right: The **number one blocker to use AI tools** on Gitpod Classic is that the **required context size is too large**, which renders all higher-level approaches to code editing **broken**. This is an attempt on fixing that. :dart: 
:point_right: Let's merge this, and see how/if it works as intended! :slightly_smiling_face: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - install the `cline` extension: https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev
 - Configure:
   - an anthropic API key
   - choose Sonnet 3.7
   - copy the instructions from [here](https://docs.cline.bot/improving-your-prompting-skills/custom-instructions-library/cline-memory-bank?ref=cline.ghost.io#custom-instructions-copy-this) into the "Custom Instructions" field
 - see how cline picks up the knowledge :exploding_head: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
