### PR TITLE
[ide-proxy] update extension control manifest

### DIFF
--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -14,7 +14,7 @@ RUN for FILE in `ls /bin/gitpod-local-companion*`;do \
   done
 
 RUN mkdir -p static/code
-RUN curl -o static/code/marketplace.json "https://raw.githubusercontent.com/open-vsx/publish-extensions/e5c7f0ac781b430049c9f07fed10ee5c388b0097/extension-control/extensions.json"
+RUN curl -o static/code/marketplace.json "https://raw.githubusercontent.com/EclipseFdn/publish-extensions/6967d878b5c3e01ff4fc1c1f5f1b2113e8aac36f/extension-control/extensions.json"
 
 FROM caddy/caddy:2.7.6-alpine
 

--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -14,7 +14,7 @@ RUN for FILE in `ls /bin/gitpod-local-companion*`;do \
   done
 
 RUN mkdir -p static/code
-RUN curl -o static/code/marketplace.json "https://raw.githubusercontent.com/EclipseFdn/publish-extensions/6967d878b5c3e01ff4fc1c1f5f1b2113e8aac36f/extension-control/extensions.json"
+RUN curl -o static/code/marketplace.json "https://raw.githubusercontent.com/EclipseFdn/publish-extensions/d9a7cc2d486ca881e9df310324f9752f48156283/extension-control/extensions.json"
 
 FROM caddy/caddy:2.7.6-alpine
 


### PR DESCRIPTION
## Description

A chore update of https://github.com/EclipseFdn/publish-extensions/blob/master/extension-control/extensions.json. This time also with the repo migration from `open-vsx` to `EclipseFdn`, just like https://github.com/gitpod-io/gitpod/pull/20285.

No need to test besides it building correctly.