### PR TITLE
[dashboard] Fix usage/insights download toast description color

### DIFF
--- a/components/dashboard/src/insights/download/DownloadInsights.tsx
+++ b/components/dashboard/src/insights/download/DownloadInsights.tsx
@@ -82,7 +82,7 @@ export const DownloadInsightsToast = ({ organizationId, from, to, organizationNa
         <div className="flex flex-row items-start justify-between space-x-2">
             <div>
                 <span>Insights export complete.</span>
-                <p className="dark:text-gray-500">
+                <p className="text-pk-content-invert-primary/90">
                     {readableSize} &middot; {formattedCount} {data.count !== 1 ? "entries" : "entry"} exported
                 </p>
             </div>

--- a/components/dashboard/src/usage/download/DownloadUsage.tsx
+++ b/components/dashboard/src/usage/download/DownloadUsage.tsx
@@ -124,7 +124,7 @@ const DownloadUsageToast: FC<DownloadUsageToastProps> = ({ attributionId, endDat
         <div className="flex flex-row items-start justify-between space-x-2">
             <div>
                 <span>Usage export complete.</span>
-                <p className="dark:text-gray-500">
+                <p className="text-pk-content-invert-primary/90">
                     {readableSize} &middot; {formattedCount} {data.count !== 1 ? "entries" : "entry"} exported
                 </p>
             </div>


### PR DESCRIPTION
## Description

| Before | After |
|--------|--------|
| <img width="482" alt="image" src="https://github.com/user-attachments/assets/15a9e89b-fd6c-421b-b6c4-25383da84a70" /> | <img width="482" alt="image" src="https://github.com/user-attachments/assets/db9e0765-249b-45bd-bf80-314253a3890d" /> | 

The dark mode versions were in a good state already, and the color doesn't change much there.

## How to test

1. join my org: https://ft-fix-usage-toast.preview.gitpod-dev.com/orgs/join?inviteId=631bbcaf-bf33-40c4-aae0-ef27678eb745
2. visit https://ft-fix-usage-toast.preview.gitpod-dev.com/insights and try to download usage

/hold
