### PR TITLE
[spicedb] Fix intermittent "Error: 4 DEADLINE_EXCEEDED...Waiting for LB pick"

### DIFF
--- a/components/content-service-api/typescript/package.json
+++ b/components/content-service-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.10.8",
+    "@grpc/grpc-js": "1.12.6",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -10,7 +10,7 @@
         "src"
     ],
     "devDependencies": {
-        "@grpc/grpc-js": "1.10.8",
+        "@grpc/grpc-js": "1.12.6",
         "@testdeck/mocha": "^0.3.3",
         "@types/analytics-node": "^3.1.9",
         "@types/chai-subset": "^1.3.3",

--- a/components/gitpod-protocol/src/util/grpc.ts
+++ b/components/gitpod-protocol/src/util/grpc.ts
@@ -6,6 +6,8 @@
 
 import * as grpc from "@grpc/grpc-js";
 import { Status } from "@grpc/grpc-js/build/src/constants";
+import { log } from "./logging";
+import { TrustedValue } from "./scrubbing";
 
 export const defaultGRPCOptions = {
     "grpc.keepalive_timeout_ms": 10000,
@@ -101,6 +103,72 @@ export function createClientCallMetricsInterceptor(metrics: IClientCallMetrics):
                     metrics.sent(labels);
                 } finally {
                     next(message);
+                }
+            })
+            .build();
+        return new grpc.InterceptingCall(nextCall(options), requester);
+    };
+}
+
+export function createDebugLogInterceptor(): grpc.Interceptor {
+    const FAILURE_STATUS_CODES = new Map([
+        [Status.ABORTED, true],
+        [Status.CANCELLED, true],
+        [Status.DATA_LOSS, true],
+        [Status.DEADLINE_EXCEEDED, true],
+        [Status.FAILED_PRECONDITION, true],
+        [Status.INTERNAL, true],
+        [Status.PERMISSION_DENIED, true],
+        [Status.RESOURCE_EXHAUSTED, true],
+        [Status.UNAUTHENTICATED, true],
+        [Status.UNAVAILABLE, true],
+        [Status.UNIMPLEMENTED, true],
+        [Status.UNKNOWN, true],
+    ]);
+
+    return (options, nextCall): grpc.InterceptingCall => {
+        const methodDef = options.method_definition;
+        const method = methodDef.path.substring(methodDef.path.lastIndexOf("/") + 1);
+        const service = methodDef.path.substring(1, methodDef.path.length - method.length - 1);
+        const labels = {
+            service,
+            method,
+            type: getGrpcMethodType(options.method_definition.requestStream, options.method_definition.responseStream),
+        };
+        const requester = new grpc.RequesterBuilder()
+            .withStart((metadata, listener, next) => {
+                const newListener = new grpc.ListenerBuilder()
+                    .withOnReceiveStatus((status, next) => {
+                        try {
+                            const info = {
+                                labels: new TrustedValue(labels),
+                                metadata: new TrustedValue(metadata.toJSON()),
+                                code: Status[status.code],
+                            };
+                            if (FAILURE_STATUS_CODES.has(status.code)) {
+                                log.warn(`grpc call failed`, info);
+                            } else {
+                                log.debug(`grpc call status`, info);
+                            }
+                        } finally {
+                            next(status);
+                        }
+                    })
+                    .build();
+                try {
+                    log.debug(`grpc call started`, {
+                        labels: new TrustedValue(labels),
+                        metadata: new TrustedValue(metadata.toJSON()),
+                    });
+                } finally {
+                    next(metadata, newListener);
+                }
+            })
+            .withCancel((next) => {
+                try {
+                    log.debug(`grpc call cancelled`, { labels: new TrustedValue(labels) });
+                } finally {
+                    next();
                 }
             })
             .build();

--- a/components/gitpod-protocol/src/util/grpc.ts
+++ b/components/gitpod-protocol/src/util/grpc.ts
@@ -179,3 +179,12 @@ export function createDebugLogInterceptor(): grpc.Interceptor {
 export function isGrpcError(err: any): err is grpc.StatusObject {
     return err.code && err.details;
 }
+
+export function isConnectionAlive(client: grpc.Client) {
+    const cs = client.getChannel().getConnectivityState(false);
+    return (
+        cs == grpc.connectivityState.CONNECTING ||
+        cs == grpc.connectivityState.IDLE ||
+        cs == grpc.connectivityState.READY
+    );
+}

--- a/components/ide-metrics-api/typescript-grpc/package.json
+++ b/components/ide-metrics-api/typescript-grpc/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.10.8",
+    "@grpc/grpc-js": "1.12.6",
     "google-protobuf": "^3.19.1"
   },
   "devDependencies": {

--- a/components/image-builder-api/typescript/package.json
+++ b/components/image-builder-api/typescript/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "1.10.8",
+    "@grpc/grpc-js": "1.12.6",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/image-builder-api/typescript/src/sugar.ts
+++ b/components/image-builder-api/typescript/src/sugar.ts
@@ -8,7 +8,7 @@ import { ImageBuilderClient } from "./imgbuilder_grpc_pb";
 import { TraceContext } from "@gitpod/gitpod-protocol/lib/util/tracing";
 import { Deferred } from "@gitpod/gitpod-protocol/lib/util/deferred";
 import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
-import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
+import { createClientCallMetricsInterceptor, IClientCallMetrics, isConnectionAlive } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import * as opentracing from "opentracing";
 import { Metadata } from "@grpc/grpc-js";
 import {
@@ -130,12 +130,7 @@ export class PromisifiedImageBuilderClient {
     ) {}
 
     public isConnectionAlive() {
-        const cs = this.client.getChannel().getConnectivityState(false);
-        return (
-            cs == grpc.connectivityState.CONNECTING ||
-            cs == grpc.connectivityState.IDLE ||
-            cs == grpc.connectivityState.READY
-        );
+        return isConnectionAlive(this.client);
     }
 
     public resolveBaseImage(ctx: TraceContext, request: ResolveBaseImageRequest): Promise<ResolveBaseImageResponse> {

--- a/components/server/package.json
+++ b/components/server/package.json
@@ -45,7 +45,7 @@
     "/src"
   ],
   "dependencies": {
-    "@authzed/authzed-node": "^0.15.0",
+    "@authzed/authzed-node": "^1.2.2",
     "@connectrpc/connect": "1.1.2",
     "@connectrpc/connect-express": "1.1.2",
     "@gitbeaker/rest": "^39.12.0",

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -15,7 +15,6 @@ import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
 import {
     IClientCallMetrics,
     createClientCallMetricsInterceptor,
-    createDebugLogInterceptor,
     defaultGRPCOptions,
 } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nice-grpc";
@@ -342,7 +341,7 @@ export const productionContainerModule = new ContainerModule(
                 const clientCallMetrics = ctx.container.get<IClientCallMetrics>(IClientCallMetrics);
                 return new SpiceDBClientProvider(
                     config, //
-                    [createClientCallMetricsInterceptor(clientCallMetrics), createDebugLogInterceptor()],
+                    [createClientCallMetricsInterceptor(clientCallMetrics)],
                 );
             })
             .inSingletonScope();

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -15,6 +15,7 @@ import { DebugApp } from "@gitpod/gitpod-protocol/lib/util/debug-app";
 import {
     IClientCallMetrics,
     createClientCallMetricsInterceptor,
+    createDebugLogInterceptor,
     defaultGRPCOptions,
 } from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { prometheusClientMiddleware } from "@gitpod/gitpod-protocol/lib/util/nice-grpc";
@@ -341,7 +342,7 @@ export const productionContainerModule = new ContainerModule(
                 const clientCallMetrics = ctx.container.get<IClientCallMetrics>(IClientCallMetrics);
                 return new SpiceDBClientProvider(
                     config, //
-                    [createClientCallMetricsInterceptor(clientCallMetrics)],
+                    [createClientCallMetricsInterceptor(clientCallMetrics), createDebugLogInterceptor()],
                 );
             })
             .inSingletonScope();

--- a/components/server/src/util/content-service-sugar.ts
+++ b/components/server/src/util/content-service-sugar.ts
@@ -6,7 +6,11 @@
 
 import { inject, injectable, interfaces, optional } from "inversify";
 import * as grpc from "@grpc/grpc-js";
-import { createClientCallMetricsInterceptor, IClientCallMetrics } from "@gitpod/gitpod-protocol/lib/util/grpc";
+import {
+    createClientCallMetricsInterceptor,
+    IClientCallMetrics,
+    isConnectionAlive,
+} from "@gitpod/gitpod-protocol/lib/util/grpc";
 import { IDEPluginServiceClient } from "@gitpod/content-service/lib/ideplugin_grpc_pb";
 import { ContentServiceClient } from "@gitpod/content-service/lib/content_grpc_pb";
 import { BlobServiceClient } from "@gitpod/content-service/lib/blobs_grpc_pb";
@@ -141,13 +145,4 @@ export class CachingHeadlessLogServiceClientProvider extends CachingClientProvid
             return new HeadlessLogServiceClient(config.address, config.credentials, config.options);
         });
     }
-}
-
-function isConnectionAlive(client: grpc.Client) {
-    const cs = client.getChannel().getConnectivityState(false);
-    return (
-        cs == grpc.connectivityState.CONNECTING ||
-        cs == grpc.connectivityState.IDLE ||
-        cs == grpc.connectivityState.READY
-    );
 }

--- a/components/supervisor-api/typescript-grpc/package.json
+++ b/components/supervisor-api/typescript-grpc/package.json
@@ -9,7 +9,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.10.8",
+    "@grpc/grpc-js": "1.12.6",
     "google-protobuf": "^3.19.1"
   },
   "devDependencies": {

--- a/components/ws-daemon-api/typescript/package.json
+++ b/components/ws-daemon-api/typescript/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
-    "@grpc/grpc-js": "1.10.8",
+    "@grpc/grpc-js": "1.12.6",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/ws-manager-api/typescript/package.json
+++ b/components/ws-manager-api/typescript/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@gitpod/content-service": "0.1.5",
     "@gitpod/gitpod-protocol": "0.1.5",
-    "@grpc/grpc-js": "1.10.8",
+    "@grpc/grpc-js": "1.12.6",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/components/ws-manager-bridge-api/typescript/package.json
+++ b/components/ws-manager-bridge-api/typescript/package.json
@@ -11,7 +11,7 @@
     "lib"
   ],
   "dependencies": {
-    "@grpc/grpc-js": "1.10.8",
+    "@grpc/grpc-js": "1.12.6",
     "google-protobuf": "^3.19.1",
     "inversify": "^6.0.1",
     "opentracing": "^0.14.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -24,15 +24,15 @@
     jsonpointer "^5.0.0"
     leven "^3.1.0"
 
-"@authzed/authzed-node@^0.15.0":
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-0.15.0.tgz#2163357d76ebf4068d0735a19357c8fa689d1c85"
-  integrity sha512-juB03KDkxuPShvWz4coJeDzKN7obSZwm6a5Ii4xcCAUT6IItSS+7hOQtFYDMSQVz6ynchwleqqzbhAWMZ1NISQ==
+"@authzed/authzed-node@^1.2.2":
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/@authzed/authzed-node/-/authzed-node-1.2.2.tgz#a1f1fed945d1746ff933c938e6e4068c179e5be6"
+  integrity sha512-Br25e/1K4dmBIXqqCodvdcT3Ii2N3TSHYpwPrh8PCyhswgiVbUhiXO/PHuqIqEmlC6N1F78FEvlNiyGK4VXw6g==
   dependencies:
-    "@grpc/grpc-js" "^1.10.7"
+    "@grpc/grpc-js" "^1.12.5"
     "@protobuf-ts/runtime" "^2.9.4"
     "@protobuf-ts/runtime-rpc" "^2.9.4"
-    google-protobuf "^3.15.3"
+    google-protobuf "^3.21.4"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4", "@babel/code-frame@^7.12.13", "@babel/code-frame@^7.16.0", "@babel/code-frame@^7.22.10", "@babel/code-frame@^7.22.5", "@babel/code-frame@^7.8.3":
   version "7.22.10"
@@ -1666,10 +1666,10 @@
   resolved "https://registry.yarnpkg.com/@google-cloud/promisify/-/promisify-4.0.0.tgz#a906e533ebdd0f754dca2509933334ce58b8c8b1"
   integrity sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==
 
-"@grpc/grpc-js@1.10.8", "@grpc/grpc-js@^1.10.7":
-  version "1.10.8"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.10.8.tgz#99787785cd8335be861afd1cd485ae9f058e4484"
-  integrity sha512-vYVqYzHicDqyKB+NQhAc54I1QWCBLCrYG6unqOIcBTHx+7x8C9lcoLj3KVJXs2VB4lUbpWY+Kk9NipcbXYWmvg==
+"@grpc/grpc-js@1.12.6", "@grpc/grpc-js@^1.12.5":
+  version "1.12.6"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.12.6.tgz#a3586ffdfb6a1f5cd5b4866dec9074c4a1e65472"
+  integrity sha512-JXUj6PI0oqqzTGvKtzOkxtpsyPRNsrmhh41TtIz/zEB6J+AUiZZ0dxWzcMwO9Ns5rmSPuMdghlTbUuqIM48d3Q==
   dependencies:
     "@grpc/proto-loader" "^0.7.13"
     "@js-sdsl/ordered-map" "^4.4.2"
@@ -8776,15 +8776,15 @@ google-protobuf@3.15.8:
   resolved "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.15.8.tgz"
   integrity sha512-2jtfdqTaSxk0cuBJBtTTWsot4WtR9RVr2rXg7x7OoqiuOKopPrwXpM1G4dXIkLcUNRh3RKzz76C8IOkksZSeOw==
 
-google-protobuf@^3.15.3:
-  version "3.21.2"
-  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.2.tgz#4580a2bea8bbb291ee579d1fefb14d6fa3070ea4"
-  integrity sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==
-
 google-protobuf@^3.19.1, google-protobuf@^3.6.1:
   version "3.19.1"
   resolved "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.19.1.tgz"
   integrity sha512-Isv1RlNC+IzZzilcxnlVSf+JvuhxmY7DaxYCBy+zPS9XVuJRtlTTIXR9hnZ1YL1MMusJn/7eSy2swCzZIomQSg==
+
+google-protobuf@^3.21.4:
+  version "3.21.4"
+  resolved "https://registry.yarnpkg.com/google-protobuf/-/google-protobuf-3.21.4.tgz#2f933e8b6e5e9f8edde66b7be0024b68f77da6c9"
+  integrity sha512-MnG7N936zcKTco4Jd2PX2U96Kf9PxygAPKBug+74LHzmHXmceN16MmRcdgZv+DGef/S9YvQAfRsNCn4cjf9yyQ==
 
 gopd@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description
This PR is a fresh attempt at fixing the gRPC error `Error: 4 DEADLINE_EXCEEDED...Waiting for LB pick` we see every couple of weeks between `server` and `spicedb`. This seems always be triggered by the `spicedb` pods restarting, while we have active/new requests coming in.

Most likely it's fixed by bumping `grpc/grpc-js`, as there were at couple of potential fixes between `1.10.8` and `1.12.6` [[1](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.11.3), [2](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.10.11), [3](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.10.10), [4](https://github.com/grpc/grpc-node/releases/tag/%40grpc%2Fgrpc-js%401.12.4), ....].

It turned out we still get the `Waiting for LB pick`, where the client stalls for ~120s before connecting to upstream again, although the pod is up and `Ready` after ~5-8s.

To we are catching that specific case now, and re-trying the call with a fresh client.

Next steps:
 - [ ] ~load test in cluster (while manually tearing down `spicedb`~
 - [x] :question: controlled, temporary rollout to an internal installation

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-370

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
