### PR TITLE
[memory-bank] Update with more details

### DIFF
--- a/memory-bank/.clinerules
+++ b/memory-bank/.clinerules
@@ -92,8 +92,7 @@ This file captures important patterns, preferences, and project intelligence tha
 - **Memory Bank Documentation**:
   - Component-specific documentation is stored in `memory-bank/components/` directory
   - Each component gets its own markdown file with detailed information about its purpose, architecture, and implementation
-  - API components (with "*-api" suffix) should NOT be documented separately as they are typically just interface definitions
-  - Component documentation should focus on the main service components that implement business logic
+  - Component documentation should focus on both service components that implement business logic and API components that define interfaces
   - Documentation follows a consistent structure with sections for Overview, Purpose, Architecture, Key Features, etc.
 
 ## Evolution of Project Decisions
@@ -108,11 +107,11 @@ This section will be updated as I learn about how and why certain architectural 
   3. Make it easier to find information about specific components
   4. Enable incremental updates to component documentation without affecting other files
 
-- **API Component Exclusion**: The decision to exclude "*-api" components from separate documentation was made because:
-  1. API components primarily contain interface definitions, not implementation logic
-  2. The interfaces are typically documented within the main service component that implements them
-  3. Documenting API components separately would create redundancy
-  4. The focus should be on documenting the service components that implement business logic
+- **API Component Documentation**: The decision to include "*-api" components in separate documentation was made because:
+  1. API components define critical interfaces between services
+  2. Understanding these interfaces is essential for developers working across components
+  3. API documentation helps clarify system boundaries and communication patterns
+  4. Separate documentation makes it easier to track API changes and versioning
 
 ## User Preferences
 

--- a/memory-bank/.clinerules
+++ b/memory-bank/.clinerules
@@ -94,6 +94,10 @@ This file captures important patterns, preferences, and project intelligence tha
   - Each component gets its own markdown file with detailed information about its purpose, architecture, and implementation
   - Component documentation should focus on both service components that implement business logic and API components that define interfaces
   - Documentation follows a consistent structure with sections for Overview, Purpose, Architecture, Key Features, etc.
+  - API component documentation should include a "Code Generation and Building" section that explains:
+    - How to regenerate code from protobuf definitions
+    - The implementation details of the generation process
+    - How to build components that depend on the API after regeneration
 
 ## Evolution of Project Decisions
 

--- a/memory-bank/.clinerules
+++ b/memory-bank/.clinerules
@@ -26,19 +26,35 @@ This file captures important patterns, preferences, and project intelligence tha
 
 ## Development Workflow
 
-- **Build System**: Use Leeway for building components
-  - `leeway build` to build specific components
-  - `leeway exec` to run commands across components
+- **Build Approaches**:
+  - **In-tree builds** (primary for local development):
+    - TypeScript components: Use `yarn` commands defined in package.json
+      - `yarn build`: Compile the component
+      - `yarn test`: Run tests
+      - `yarn lint`: Check code style
+      - `yarn watch`: Watch for changes and rebuild
+    - Go components: Use standard Go tools
+      - `go build ./...`: Build all packages
+      - `go test ./...`: Test all packages
+      - `go run main.go`: Build and run
+
+  - **Out-of-tree builds** (Leeway, primary for CI):
+    - `leeway build components/component-name:app`: Build a specific component
+    - `leeway build -D components/component-name:app`: Build with dependencies
+    - `leeway exec --package components/component-name:app -- command`: Run a command for a package
 
 - **Testing**:
   - Unit tests alongside code
   - Integration tests in separate directories
   - End-to-end tests in the `test/` directory
+  - Component-specific test commands in package.json (for TypeScript)
+  - Go tests use standard `go test` command
 
 - **Local Development**:
   - Use Gitpod workspaces for development (dogfooding)
   - Components can be run individually for testing
   - Preview environments for testing changes
+  - Use in-tree builds for rapid iteration during development
 
 ## Critical Implementation Paths
 
@@ -101,6 +117,23 @@ This section will be updated as I learn about how and why certain architectural 
 ## User Preferences
 
 This section will be updated as I learn about specific user preferences for working with the codebase.
+
+## Build and Test Information
+
+When working with components, I should always document:
+
+- **Build Commands**: Document any new or component-specific build commands I encounter
+- **Test Commands**: Document how to run tests for each component
+- **Dependencies**: Note any special dependencies required for building or testing
+- **Common Issues**: Document common build or test issues and their solutions
+- **Performance Considerations**: Note any performance considerations for builds
+
+Whenever I encounter new build patterns or commands, I should update:
+1. The relevant component documentation in `memory-bank/components/`
+2. The `.clinerules` file with general patterns
+3. The `techContext.md` file if it represents a significant pattern
+
+This information is critical for effective development work, as being able to build and test components is fundamental to making changes and verifying their correctness.
 
 ---
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -49,6 +49,15 @@ Key areas of focus include:
   - openvsx-proxy: Caching proxy service for the OpenVSX registry
   - scheduler-extender: Extends Kubernetes scheduling capabilities for workspaces
   - ipfs: Provides distributed content-addressable storage for container images
+- Created documentation for API components:
+  - content-service-api: Interfaces for managing workspace content, blobs, logs, and IDE plugins
+  - ide-metrics-api: Interfaces for collecting metrics and error reports from IDE components
+  - ide-service-api: Interfaces for managing IDE configurations and resolving workspace IDE requirements
+- Enhanced API component documentation with code generation information:
+  - Added details on how to regenerate code from protobuf definitions
+  - Documented the implementation details of the generation process
+  - Included instructions for building components after code regeneration
+  - Updated .clinerules to standardize API documentation with code generation sections
 
 As work progresses, this section will continue to be updated to reflect:
 - Additional component documentation
@@ -61,10 +70,7 @@ As work progresses, this section will continue to be updated to reflect:
 
 The immediate next steps are:
 
-1. **Document API Components**: Create documentation for the following API components:
-   - content-service-api
-   - ide-metrics-api
-   - ide-service-api
+1. **Document Remaining API Components**: Create documentation for the following API components:
    - image-builder-api
    - local-app-api
    - registry-facade-api

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -53,6 +53,9 @@ Key areas of focus include:
   - content-service-api: Interfaces for managing workspace content, blobs, logs, and IDE plugins
   - ide-metrics-api: Interfaces for collecting metrics and error reports from IDE components
   - ide-service-api: Interfaces for managing IDE configurations and resolving workspace IDE requirements
+  - image-builder-api: Interfaces for building Docker images for workspaces
+  - local-app-api: Interfaces for communication between local machines and remote workspaces
+  - registry-facade-api: Interfaces for dynamically assembling workspace container images
 - Enhanced API component documentation with code generation information:
   - Added details on how to regenerate code from protobuf definitions
   - Documented the implementation details of the generation process
@@ -71,9 +74,6 @@ As work progresses, this section will continue to be updated to reflect:
 The immediate next steps are:
 
 1. **Document Remaining API Components**: Create documentation for the following API components:
-   - image-builder-api
-   - local-app-api
-   - registry-facade-api
    - supervisor-api
    - usage-api
    - ws-daemon-api

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -18,7 +18,7 @@ Key areas of focus include:
 - Created detailed documentation for key components:
   - blobserve: Service that provides static assets from OCI images
   - content-service: Manages various types of content within the platform
-  - dashboard: Web-based user interface for Gitpod
+  - dashboard: Web-based user inSterface for Gitpod
   - ws-manager-mk2: Kubernetes controller for managing workspace lifecycle
   - supervisor: Init process that runs inside each workspace container
   - ws-daemon: Node-level daemon for workspace operations
@@ -59,6 +59,8 @@ Key areas of focus include:
   - supervisor-api: Interfaces for workspace management, terminal handling, and port forwarding
   - usage-api: Interfaces for tracking, calculating, and managing workspace usage and billing
   - ws-daemon-api: Interfaces for workspace content management and container operations
+  - ws-manager-api: Interfaces for managing the lifecycle of workspaces in Kubernetes clusters
+  - ws-manager-bridge-api: Interfaces for dynamic management of workspace clusters
 - Enhanced API component documentation with code generation information:
   - Added details on how to regenerate code from protobuf definitions
   - Documented the implementation details of the generation process
@@ -76,17 +78,13 @@ As work progresses, this section will continue to be updated to reflect:
 
 The immediate next steps are:
 
-1. **Document Remaining API Components**: Create documentation for the following API components:
-   - ws-manager-api
-   - ws-manager-bridge-api
-
-2. **Explore Component Interactions**: Understand how components interact with each other
-3. **Set Up Development Environment**: Configure a local development environment for effective testing
-4. **Explore Build System**: Gain hands-on experience with both in-tree and Leeway builds
-5. **Test Component Builds**: Practice building and testing different component types
-6. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
-7. **Establish Testing Approach**: Define how changes will be tested and validated
-8. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
+1. **Explore Component Interactions**: Understand how components interact with each other
+2. **Set Up Development Environment**: Configure a local development environment for effective testing
+3. **Explore Build System**: Gain hands-on experience with both in-tree and Leeway builds
+4. **Test Component Builds**: Practice building and testing different component types
+5. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
+6. **Establish Testing Approach**: Define how changes will be tested and validated
+7. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
 
 ## Active Decisions and Considerations
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -63,9 +63,11 @@ The immediate next steps are:
 
 1. **Explore Component Interactions**: Understand how components interact with each other
 2. **Set Up Development Environment**: Configure a local development environment for effective testing
-3. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
-4. **Establish Testing Approach**: Define how changes will be tested and validated
-5. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
+3. **Explore Build System**: Gain hands-on experience with both in-tree and Leeway builds
+4. **Test Component Builds**: Practice building and testing different component types
+5. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
+6. **Establish Testing Approach**: Define how changes will be tested and validated
+7. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
 
 ## Active Decisions and Considerations
 
@@ -115,5 +117,15 @@ Initial exploration of the Gitpod codebase has revealed:
   - Go services typically have a cmd/ directory with command implementations
   - TypeScript services use React and modern frontend practices
   - Most components have a clear separation between API definitions and implementations
+- **Build System Approaches**: Gitpod uses two primary approaches for building components:
+  - **In-tree builds**: Using language-specific tools (yarn, go) directly in the workspace
+    - Primary method for local development
+    - TypeScript components use commands defined in package.json (yarn build, yarn test, etc.)
+    - Go components use standard Go tools (go build, go test, etc.)
+  - **Out-of-tree builds**: Using Leeway, a custom build tool
+    - Primary method for CI to generate build artifacts
+    - Works by copying relevant sources into a separate file tree
+    - Can also be run from inside the workspace
+    - Manages complex dependencies between components
 
 This section will be continuously updated as new insights are gained through working with the system.

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -61,13 +61,26 @@ As work progresses, this section will continue to be updated to reflect:
 
 The immediate next steps are:
 
-1. **Explore Component Interactions**: Understand how components interact with each other
-2. **Set Up Development Environment**: Configure a local development environment for effective testing
-3. **Explore Build System**: Gain hands-on experience with both in-tree and Leeway builds
-4. **Test Component Builds**: Practice building and testing different component types
-5. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
-6. **Establish Testing Approach**: Define how changes will be tested and validated
-7. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
+1. **Document API Components**: Create documentation for the following API components:
+   - content-service-api
+   - ide-metrics-api
+   - ide-service-api
+   - image-builder-api
+   - local-app-api
+   - registry-facade-api
+   - supervisor-api
+   - usage-api
+   - ws-daemon-api
+   - ws-manager-api
+   - ws-manager-bridge-api
+
+2. **Explore Component Interactions**: Understand how components interact with each other
+3. **Set Up Development Environment**: Configure a local development environment for effective testing
+4. **Explore Build System**: Gain hands-on experience with both in-tree and Leeway builds
+5. **Test Component Builds**: Practice building and testing different component types
+6. **Identify Initial Tasks**: Determine specific tasks or improvements to focus on
+7. **Establish Testing Approach**: Define how changes will be tested and validated
+8. **Update Memory Bank**: Continue to refine and expand the memory bank as new information is discovered
 
 ## Active Decisions and Considerations
 

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -56,6 +56,9 @@ Key areas of focus include:
   - image-builder-api: Interfaces for building Docker images for workspaces
   - local-app-api: Interfaces for communication between local machines and remote workspaces
   - registry-facade-api: Interfaces for dynamically assembling workspace container images
+  - supervisor-api: Interfaces for workspace management, terminal handling, and port forwarding
+  - usage-api: Interfaces for tracking, calculating, and managing workspace usage and billing
+  - ws-daemon-api: Interfaces for workspace content management and container operations
 - Enhanced API component documentation with code generation information:
   - Added details on how to regenerate code from protobuf definitions
   - Documented the implementation details of the generation process
@@ -74,9 +77,6 @@ As work progresses, this section will continue to be updated to reflect:
 The immediate next steps are:
 
 1. **Document Remaining API Components**: Create documentation for the following API components:
-   - supervisor-api
-   - usage-api
-   - ws-daemon-api
    - ws-manager-api
    - ws-manager-bridge-api
 

--- a/memory-bank/components/content-service-api.md
+++ b/memory-bank/components/content-service-api.md
@@ -1,0 +1,127 @@
+# Content Service API
+
+## Overview
+The Content Service API defines the gRPC interfaces for the Content Service, which is responsible for managing various types of content within the Gitpod platform, including workspace files, blobs, logs, and IDE plugins.
+
+## Purpose
+This API provides a standardized interface for other components to interact with the Content Service, enabling operations such as:
+- Managing workspace content (downloading, deleting, checking snapshots)
+- Handling blob storage (uploading, downloading, deleting)
+- Accessing headless logs
+- Managing IDE plugins
+- Defining workspace initialization methods
+
+## Architecture
+The Content Service API is implemented as a set of gRPC services defined in Protocol Buffer files. These definitions are used to generate client and server code in various languages (Go, TypeScript) for use by other components in the system.
+
+## Key Services
+
+### ContentService
+Provides core content management functionality:
+- `DeleteUserContent`: Deletes all content associated with a user
+
+### WorkspaceService
+Manages workspace content:
+- `WorkspaceDownloadURL`: Provides a URL from which workspace content can be downloaded
+- `DeleteWorkspace`: Deletes the content of a single workspace
+- `WorkspaceSnapshotExists`: Checks whether a workspace snapshot exists
+
+### BlobService
+Handles blob storage operations:
+- `UploadUrl`: Provides a URL to which clients can upload content via HTTP PUT
+- `DownloadUrl`: Provides a URL from which clients can download content via HTTP GET
+- `Delete`: Deletes uploaded content
+
+### HeadlessLogService
+Manages access to headless logs:
+- `LogDownloadURL`: Provides a URL from which logs can be downloaded
+- `ListLogs`: Returns a list of task IDs for a specified workspace instance
+
+### IDEPluginService
+Manages IDE plugins:
+- `UploadURL`: Provides a URL for uploading plugin content
+- `DownloadURL`: Provides a URL for downloading plugin content
+- `PluginHash`: Provides a hash of a plugin
+
+## Key Data Structures
+
+### WorkspaceInitializer
+Defines how a workspace is initialized, with several initialization methods:
+- `EmptyInitializer`: Creates an empty workspace
+- `GitInitializer`: Initializes from a Git repository
+- `SnapshotInitializer`: Initializes from a snapshot
+- `PrebuildInitializer`: Combines snapshots with Git
+- `CompositeInitializer`: Uses multiple initializers in sequence
+- `FileDownloadInitializer`: Downloads files for workspace content
+- `FromBackupInitializer`: Initializes from a backup
+
+### GitStatus
+Describes the current Git working copy status, similar to a combination of "git status" and "git branch".
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication between services
+- Many operations return URLs rather than content directly, allowing for efficient transfer of large files
+- Authentication information is passed in request messages
+
+## Dependencies
+- Used by various components that need to interact with workspace content
+- Depends on underlying storage systems (not specified in the API)
+
+## Usage Examples
+- Workspace Manager uses this API to initialize workspaces
+- Dashboard uses this API to provide download links for workspace content
+- IDE components use this API to access plugins
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Content Service API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in various languages needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the content-service-api directory:
+   ```bash
+   cd components/content-service-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Generates TypeScript code
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`, which provides common functionality for all API components:
+
+- `install_dependencies`: Installs required protoc plugins
+- `protoc_buf_generate`: Uses the `buf` tool to generate code based on the configuration in `buf.gen.yaml`
+- `update_license`: Updates license headers in generated files
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Content Service API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```

--- a/memory-bank/components/ide-metrics-api.md
+++ b/memory-bank/components/ide-metrics-api.md
@@ -1,0 +1,125 @@
+# IDE Metrics API
+
+## Overview
+The IDE Metrics API defines the gRPC interfaces for collecting metrics and error reports from IDE components within the Gitpod platform. It provides a standardized way for IDE instances to report performance data and errors to a central metrics service.
+
+## Purpose
+This API enables:
+- Collection of performance metrics from IDE instances
+- Reporting of errors encountered in IDE components
+- Aggregation of metrics for monitoring and analysis
+- Standardized error reporting for debugging and issue resolution
+
+## Architecture
+The IDE Metrics API is implemented as a gRPC service defined in Protocol Buffer files. These definitions are used to generate client and server code in various languages (Go, TypeScript, Java) for use by IDE components and the metrics collection service.
+
+## Key Services
+
+### MetricsService
+Provides methods for reporting metrics and errors:
+
+- `AddCounter`: Increments a counter metric with specified labels
+- `ObserveHistogram`: Records an observation in a histogram metric
+- `AddHistogram`: Adds pre-aggregated histogram data
+- `reportError`: Reports an error with detailed context information
+
+## Key Data Structures
+
+### Metric Types
+The API supports two primary metric types:
+- **Counters**: Simple incrementing counters for tracking occurrences
+- **Histograms**: Distribution metrics for measuring values that can be aggregated
+
+### Error Reports
+Error reports include:
+- Error stack trace
+- Component and version information
+- User, workspace, and instance identifiers
+- Custom properties for additional context
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- HTTP REST endpoints are also exposed for the same operations (via Google API annotations)
+- Metrics are reported asynchronously without waiting for responses
+- Error reports include comprehensive context for effective debugging
+
+## Dependencies
+- Used by IDE components (VS Code, JetBrains) to report metrics and errors
+- Integrated with monitoring and alerting systems
+- May feed into analytics dashboards for performance monitoring
+
+## Usage Examples
+- VS Code extensions report performance metrics for editor operations
+- JetBrains IDE plugins report error conditions
+- Supervisor monitors IDE health and reports metrics
+- Dashboard displays aggregated metrics for system health monitoring
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new metric types and error reporting fields without breaking existing clients.
+
+## Security Considerations
+- Error reports may contain sensitive information and should be handled accordingly
+- User identifiers in metrics should be anonymized or aggregated for privacy
+- Access to raw metrics and error reports should be restricted to authorized personnel
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The IDE Metrics API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in various languages needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the ide-metrics-api directory:
+   ```bash
+   cd components/ide-metrics-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Generates gRPC Gateway code for REST API endpoints
+- Generates Java code
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh` and defines some custom functions:
+
+- `install_dependencies`: Installs required protoc plugins
+- `local_go_protoc`: Generates Go code with specific include paths
+- `go_protoc_gateway`: Generates gRPC Gateway code for REST endpoints
+- `local_java_protoc`: Generates Java code
+- `update_license`: Updates license headers in generated files
+
+The IDE Metrics API is unique in that it generates both gRPC and REST API endpoints using the gRPC Gateway, and it also generates Java code for use in JetBrains IDE plugins.
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the IDE Metrics API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. For Java components:
+   ```bash
+   cd <component-directory>/java
+   ./gradlew build
+   ```
+
+4. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```

--- a/memory-bank/components/ide-service-api.md
+++ b/memory-bank/components/ide-service-api.md
@@ -1,0 +1,137 @@
+# IDE Service API
+
+## Overview
+The IDE Service API defines the gRPC interfaces for the IDE Service, which is responsible for managing IDE configurations and resolving workspace IDE requirements within the Gitpod platform. This API enables the dynamic configuration of IDEs based on user preferences and workspace requirements.
+
+## Purpose
+This API provides a standardized interface for:
+- Retrieving user-specific IDE configurations
+- Resolving workspace IDE requirements based on multiple factors
+- Determining the appropriate IDE images and configurations for workspaces
+- Managing environment variables and settings for IDE instances
+
+## Architecture
+The IDE Service API is implemented as a gRPC service defined in Protocol Buffer files. These definitions are used to generate client and server code in various languages (Go, TypeScript, Java) for use by other components in the system.
+
+## Key Services
+
+### IDEService
+Provides methods for IDE configuration and workspace resolution:
+
+- `GetConfig`: Retrieves IDE configuration for a specific user
+- `ResolveWorkspaceConfig`: Resolves the IDE configuration for a workspace based on various inputs
+
+## Key Data Structures
+
+### User
+Represents a user in the system:
+- User ID
+- Optional email
+
+### WorkspaceType
+Enum defining the type of workspace:
+- `REGULAR`: Standard development workspace
+- `PREBUILD`: Prebuild workspace for faster startup
+
+### EnvironmentVariable
+Represents an environment variable as a key-value pair:
+- Name
+- Value
+
+### ResolveWorkspaceConfigResponse
+Contains the resolved configuration for a workspace:
+- Environment variables
+- Supervisor image
+- Web image
+- IDE image layers
+- Referer IDE (for controlling default IDE configuration)
+- Tasks configuration
+- IDE settings
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication between services
+- Methods are marked as idempotent where appropriate
+- Configuration is returned as structured data for easy consumption by clients
+
+## Dependencies
+- Used by workspace manager to configure IDE environments
+- Used by supervisor to set up the IDE within a workspace
+- Depends on user preferences and workspace configuration
+
+## Usage Examples
+- Workspace creation process uses this API to determine the appropriate IDE configuration
+- User preference changes trigger updates to IDE configurations
+- Prebuild processes use this API to ensure consistent IDE setup
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new configuration options without breaking existing clients.
+
+## Configuration Resolution Process
+The workspace configuration resolution process considers multiple factors:
+1. Workspace type (regular or prebuild)
+2. Context information about the workspace
+3. User's IDE settings
+4. Workspace-specific configuration
+5. User information
+
+The resolution process produces a complete configuration including:
+- Environment variables for the IDE
+- Container images to use
+- IDE-specific settings
+- Task configurations
+
+This allows for a highly customizable yet consistent IDE experience across different workspaces and users.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The IDE Service API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in various languages needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the ide-service-api directory:
+   ```bash
+   cd components/ide-service-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Generates TypeScript code using `ts_proto`
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`:
+
+- `install_dependencies`: Installs required protoc plugins
+- `go_protoc`: Generates Go code
+- `typescript_ts_protoc`: Generates TypeScript code using ts_proto
+- `update_license`: Updates license headers in generated files
+
+The IDE Service API generates TypeScript code using the ts_proto plugin, which creates more modern TypeScript interfaces compared to the standard protoc TypeScript generator.
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the IDE Service API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```

--- a/memory-bank/components/image-builder-api.md
+++ b/memory-bank/components/image-builder-api.md
@@ -1,0 +1,143 @@
+# Image Builder API
+
+## Overview
+The Image Builder API defines the gRPC interfaces for the Image Builder service, which is responsible for building Docker images for workspaces within the Gitpod platform. This API enables the dynamic creation, management, and monitoring of workspace image builds.
+
+## Purpose
+This API provides a standardized interface for:
+- Resolving Docker image references to their digest form
+- Building workspace Docker images based on configuration
+- Streaming build logs during the image building process
+- Managing and monitoring ongoing builds
+- Creating and retrieving subassemblies from OCI images
+
+## Architecture
+The Image Builder API is implemented as a set of gRPC services defined in Protocol Buffer files. These definitions are used to generate client and server code in various languages (Go, TypeScript) for use by other components in the system.
+
+## Key Services
+
+### ImageBuilder
+Provides methods for building and managing Docker images:
+
+- `ResolveBaseImage`: Returns the "digest" form of a Docker image tag, making it absolute
+- `ResolveWorkspaceImage`: Returns information about a build configuration without actually building
+- `Build`: Initiates the build of a Docker image using a build configuration
+- `Logs`: Streams the build output of an ongoing Docker build
+- `ListBuilds`: Returns a list of currently running builds
+
+### SubassemblyService
+Provides methods for managing subassemblies (pre-built components that can be used in workspace images):
+
+- `CreateSubassembly`: Creates a subassembly from an OCI image
+- `GetSubassembly`: Returns the status and URL for a subassembly
+
+## Key Data Structures
+
+### BuildSource
+Defines the source for a build, which can be either:
+- A reference to an existing image
+- A Dockerfile with associated context and initialization
+
+### BuildRegistryAuth
+Defines authentication settings for accessing Docker registries during the build process.
+
+### BuildStatus
+Enum representing the status of a build:
+- `unknown`: Status is not known
+- `running`: Build is currently in progress
+- `done_success`: Build completed successfully
+- `done_failure`: Build failed
+
+### BuildInfo
+Contains detailed information about a build:
+- Reference to the built image
+- Base image reference
+- Build status
+- Start time
+- Build ID
+- Log information
+
+### SubassemblyStatus
+Contains information about a subassembly:
+- Phase (creating, available, unavailable)
+- Message describing the state
+- Digest of the subassembly file
+- URL for downloading the subassembly
+- Manifest describing requirements
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication between services
+- The `Build` and `Logs` methods use server-side streaming to provide real-time updates
+- Authentication information is passed in request messages
+- Subassembly operations are designed for asynchronous processing
+
+## Dependencies
+- Depends on the Content Service API for workspace initialization
+- Used by workspace manager to build workspace images
+- Integrated with container registries for image storage and retrieval
+
+## Usage Examples
+- Workspace creation process uses this API to build custom workspace images
+- Prebuild processes use this API to prepare images ahead of time
+- Monitoring systems use this API to track build status and logs
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new build options and features without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Image Builder API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in various languages needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the image-builder-api directory:
+   ```bash
+   cd components/image-builder-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Generates TypeScript code
+- Generates mock implementations for testing
+- Patches the generated TypeScript code for compatibility
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`:
+
+- `install_dependencies`: Installs required protoc plugins
+- `go_protoc`: Generates Go code
+- `typescript_protoc`: Generates TypeScript code
+- `update_license`: Updates license headers in generated files
+
+Additionally, the script:
+- Generates mock implementations using `mockgen` for testing
+- Patches the generated TypeScript code using a script from the content-service-api
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Image Builder API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```

--- a/memory-bank/components/local-app-api.md
+++ b/memory-bank/components/local-app-api.md
@@ -1,0 +1,100 @@
+# Local App API
+
+## Overview
+The Local App API defines the gRPC interfaces for the Local App service, which facilitates communication between a user's local machine and Gitpod workspaces. This API enables port tunneling, SSH connection management, and other local-to-remote interactions.
+
+## Purpose
+This API provides a standardized interface for:
+- Monitoring and managing port tunnels between local machines and remote workspaces
+- Enabling automatic port tunneling for seamless local-to-remote communication
+- Resolving SSH connection details for connecting to workspaces via SSH
+
+## Architecture
+The Local App API is implemented as a gRPC service defined in Protocol Buffer files. These definitions are used to generate client and server code in Go for use by the local app and other components in the system.
+
+## Key Services
+
+### LocalApp
+Provides methods for managing local-to-remote communication:
+
+- `TunnelStatus`: Streams the status of port tunnels for a workspace instance
+- `AutoTunnel`: Enables or disables automatic port tunneling for a workspace instance
+- `ResolveSSHConnection`: Resolves SSH connection details for connecting to a workspace
+
+## Key Data Structures
+
+### TunnelStatus
+Represents the status of a port tunnel:
+- Remote port number
+- Local port number
+- Visibility setting (public, private, etc.)
+
+### ResolveSSHConnectionResponse
+Contains SSH connection details:
+- Path to the SSH configuration file
+- Host identifier for the SSH connection
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- The `TunnelStatus` method uses server-side streaming to provide real-time updates on tunnel status
+- Requests include workspace instance identifiers to target specific workspaces
+
+## Dependencies
+- Depends on the Supervisor API for tunnel visibility definitions
+- Used by the local app client running on users' machines
+- Integrated with SSH configuration management
+
+## Usage Examples
+- Local development tools use this API to establish port forwarding to workspace services
+- IDE extensions use this API to enable SSH-based remote development
+- CLI tools use this API to connect to workspace resources
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new tunneling and connection options without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Local App API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in various languages needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the local-app-api directory:
+   ```bash
+   cd components/local-app-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh` and defines some custom functions:
+
+- `install_dependencies`: Installs required protoc plugins
+- `local_go_protoc`: Generates Go code with specific include paths for third-party dependencies
+- `update_license`: Updates license headers in generated files
+
+The Local App API has a dependency on the Supervisor API for tunnel visibility definitions, which is included in the protoc generation process.
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Local App API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```
+
+The Local App API is primarily used by the local-app component, which is a desktop application that runs on users' machines to facilitate communication with remote Gitpod workspaces.

--- a/memory-bank/components/registry-facade-api.md
+++ b/memory-bank/components/registry-facade-api.md
@@ -1,0 +1,112 @@
+# Registry Facade API
+
+## Overview
+The Registry Facade API defines the gRPC interfaces and data structures for the Registry Facade service, which provides a container registry interface that dynamically assembles workspace images on-demand. This API enables the specification and retrieval of composite container images that combine base images, IDE layers, and workspace content.
+
+## Purpose
+This API provides a standardized interface for:
+- Defining composite container images with multiple sources
+- Specifying workspace content layers that can be added to images
+- Retrieving image specifications for specific workspace instances
+- Supporting dynamic image assembly in the container registry facade
+
+## Architecture
+The Registry Facade API is implemented as a set of gRPC services and message definitions in Protocol Buffer files. These definitions are used to generate client and server code in Go for use by the registry facade and other components in the system.
+
+## Key Services
+
+### SpecProvider
+Provides methods for retrieving image specifications:
+
+- `GetImageSpec`: Retrieves the image specification for a particular ID (typically a workspace instance ID)
+
+## Key Data Structures
+
+### ImageSpec
+Defines the composition of a workspace image:
+- `base_ref`: Reference to the base image in another registry
+- `ide_ref`: Reference to the IDE image to use
+- `content_layer`: Layers that provide the workspace's content
+- `supervisor_ref`: Reference to the supervisor image to use
+- `ide_layer_ref`: Layers needed by the IDE
+
+### ContentLayer
+Represents a layer that provides workspace content, which can be one of:
+- `RemoteContentLayer`: Content that can be downloaded from a remote URL
+- `DirectContentLayer`: Content provided directly as bytes
+
+### RemoteContentLayer
+Defines a layer that can be downloaded from a remote URL:
+- URL pointing to the content location
+- Digest (content hash) of the file
+- Diff ID for uncompressed content
+- Media type of the layer
+- Size of the layer in bytes
+
+### DirectContentLayer
+Contains the bytes of an uncompressed tar file that is served directly as a layer.
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- Image specifications are retrieved by ID, typically a workspace instance ID
+- Content layers can be specified either by reference (URL) or directly (bytes)
+
+## Dependencies
+- Used by workspace manager to specify workspace images
+- Used by registry facade to dynamically assemble images
+- Integrated with container registry protocols
+
+## Usage Examples
+- Workspace manager uses this API to specify the composition of workspace images
+- Registry facade uses this API to retrieve image specifications when serving container images
+- Content service uses this API to provide workspace content layers
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new image specification options without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Registry Facade API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in Go needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the registry-facade-api directory:
+   ```bash
+   cd components/registry-facade-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`:
+
+- `install_dependencies`: Installs required protoc plugins
+- `go_protoc`: Generates Go code
+- `update_license`: Updates license headers in generated files
+
+The Registry Facade API is relatively simple compared to other APIs, focusing primarily on defining the structure of image specifications rather than complex service interactions.
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Registry Facade API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```
+
+The Registry Facade API is primarily used by the registry-facade component, which provides a container registry interface that dynamically assembles workspace images on-demand.

--- a/memory-bank/components/supervisor-api.md
+++ b/memory-bank/components/supervisor-api.md
@@ -1,0 +1,193 @@
+# Supervisor API
+
+## Overview
+The Supervisor API defines the gRPC interfaces for the Supervisor service, which runs inside each workspace container and provides core functionality for workspace management, terminal handling, port forwarding, and other essential workspace operations. This API enables communication between various components and the supervisor process.
+
+## Purpose
+This API provides a standardized interface for:
+- Managing terminal sessions within workspaces
+- Controlling port exposure and tunneling
+- Retrieving workspace information
+- Managing workspace tasks
+- Handling notifications and status updates
+- Managing SSH access to workspaces
+- Controlling workspace lifecycle
+
+## Architecture
+The Supervisor API is implemented as a set of gRPC services defined in multiple Protocol Buffer files. These definitions are used to generate client and server code in various languages (Go, TypeScript, Java) for use by the supervisor and other components in the system.
+
+## Key Services
+
+### ControlService
+Provides methods for workspace control operations:
+- `ExposePort`: Exposes a port from the workspace
+- `CreateSSHKeyPair`: Creates SSH keys for accessing the workspace
+- `CreateDebugEnv`: Creates a debug workspace environment
+- `SendHeartBeat`: Sends heartbeats to keep the workspace alive
+
+### InfoService
+Provides methods for retrieving workspace information:
+- `WorkspaceInfo`: Returns detailed information about the workspace
+
+### PortService
+Manages port forwarding and tunneling:
+- `Tunnel`: Notifies clients to install listeners on remote machines
+- `CloseTunnel`: Notifies clients to remove listeners on remote machines
+- `EstablishTunnel`: Establishes a tunnel for an incoming connection
+- `AutoTunnel`: Controls enablement of auto tunneling
+- `RetryAutoExpose`: Retries auto-exposing a port
+
+### TerminalService
+Manages terminal sessions within the workspace:
+- `Open`: Opens a new terminal running the login shell
+- `Shutdown`: Closes a terminal, killing all child processes
+- `Get`: Returns information about an opened terminal
+- `List`: Lists all open terminals
+- `Listen`: Streams terminal output
+- `Write`: Writes input to a terminal
+- `SetSize`: Sets the terminal's size
+- `SetTitle`: Sets the terminal's title
+- `UpdateAnnotations`: Updates the terminal's annotations
+
+### TaskService
+Manages workspace tasks:
+- `ListenToOutput`: Streams the output of a given task
+
+### StatusService (inferred from status.proto)
+Provides status information about the workspace:
+- Status updates for workspace components
+- Health checks
+
+### NotificationService (inferred from notification.proto)
+Handles notifications within the workspace:
+- Sending notifications to users
+- Managing notification state
+
+### TokenService (inferred from token.proto)
+Manages authentication tokens:
+- Token generation and validation
+- Token-based access control
+
+## Key Data Structures
+
+### Terminal
+Represents a terminal session:
+- Alias (identifier)
+- Command being executed
+- Title
+- Process ID
+- Working directory
+- Annotations
+- Title source
+
+### TunnelVisiblity
+Enum defining the visibility of a port tunnel:
+- `none`: Not visible
+- `host`: Visible to the host
+- `network`: Visible to the network
+
+### WorkspaceInfoResponse
+Contains detailed information about a workspace:
+- Workspace ID and instance ID
+- Checkout and workspace locations
+- User home directory
+- Gitpod API information
+- Repository information
+- IDE configuration
+- Workspace class information
+
+### DebugWorkspaceType
+Enum defining the type of debug workspace:
+- `noDebug`: Not a debug workspace
+- `regular`: Regular debug workspace
+- `prebuild`: Prebuild debug workspace
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- Many services provide REST endpoints via gRPC Gateway annotations
+- Several services use server-side streaming for real-time updates
+- Terminal and task services stream output data
+- Port tunneling uses bidirectional streaming
+
+## Dependencies
+- Used by IDE components to interact with the workspace
+- Used by the workspace manager to control workspace lifecycle
+- Used by the local app for port forwarding and SSH access
+- Integrated with the content service for workspace content management
+
+## Usage Examples
+- IDE extensions use the terminal service to create and manage terminal sessions
+- Port forwarding tools use the port service to expose workspace ports
+- Workspace manager uses the control service to manage workspace lifecycle
+- Task runners use the task service to execute and monitor workspace tasks
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new methods and message fields without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Supervisor API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in various languages needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the supervisor-api directory:
+   ```bash
+   cd components/supervisor-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Generates gRPC Gateway code for REST endpoints
+- Generates Java code using `generate-java.sh`
+- Updates license headers
+- Removes trailing whitespace from Java files
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh` and defines some custom functions:
+
+- `install_dependencies`: Installs required protoc plugins
+- `local_go_protoc`: Generates Go code with specific include paths for third-party dependencies
+- `go_protoc_gateway`: Generates gRPC Gateway code for REST endpoints
+- `update_license`: Updates license headers in generated files
+
+The `generate-java.sh` script:
+- Temporarily modifies proto files to handle Java reserved keywords
+- Downloads the gRPC Java plugin if needed
+- Generates Java code
+- Reverts the temporary modifications to proto files
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Supervisor API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. For Java components:
+   ```bash
+   cd <component-directory>/java
+   ./gradlew build
+   ```
+
+4. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```
+
+The Supervisor API is a critical component of the Gitpod platform, as it provides the interface through which various components interact with the workspace environment.

--- a/memory-bank/components/usage-api.md
+++ b/memory-bank/components/usage-api.md
@@ -1,0 +1,154 @@
+# Usage API
+
+## Overview
+The Usage API defines the gRPC interfaces for the Usage service, which is responsible for tracking, calculating, and managing workspace usage, billing, and credits within the Gitpod platform. This API enables the management of cost centers, usage tracking, and integration with payment providers like Stripe.
+
+## Purpose
+This API provides a standardized interface for:
+- Tracking workspace usage and associated credits
+- Managing cost centers and spending limits
+- Reconciling usage data for billing purposes
+- Integrating with payment providers (primarily Stripe)
+- Managing customer subscriptions and payment methods
+- Handling billing-related operations like invoices and disputes
+
+## Architecture
+The Usage API is implemented as a set of gRPC services defined in Protocol Buffer files. These definitions are used to generate client and server code in Go and TypeScript for use by the usage service and other components in the system.
+
+## Key Services
+
+### UsageService
+Provides methods for managing usage and credits:
+
+- `GetCostCenter`: Retrieves the active cost center for a given attribution ID
+- `SetCostCenter`: Stores a cost center configuration
+- `ReconcileUsage`: Triggers reconciliation of usage data
+- `ResetUsage`: Resets usage for cost centers that have expired or will expire soon
+- `ListUsage`: Retrieves all usage for a specified attribution ID and time range
+- `GetBalance`: Returns the current credits balance for a given attribution ID
+- `AddUsageCreditNote`: Adds a usage credit note to a cost center
+
+### BillingService
+Provides methods for managing billing and payment integration:
+
+- `ReconcileInvoices`: Retrieves current credit balance and reflects it in the billing system
+- `FinalizeInvoice`: Marks sessions as having been invoiced
+- `CancelSubscription`: Cancels a Stripe subscription
+- `GetStripeCustomer`: Retrieves a Stripe customer
+- `CreateStripeCustomer`: Creates a new Stripe customer
+- `CreateHoldPaymentIntent`: Creates a payment intent to verify a payment method
+- `CreateStripeSubscription`: Creates a new Stripe subscription
+- `UpdateCustomerSubscriptionsTaxState`: Updates tax state for customer subscriptions
+- `GetPriceInformation`: Returns price information for a given attribution ID
+- `OnChargeDispute`: Handles charge disputes with the payment provider
+
+## Key Data Structures
+
+### CostCenter
+Represents a cost center configuration:
+- Attribution ID
+- Spending limit
+- Billing strategy (Stripe or Other)
+- Next billing time
+- Billing cycle start
+
+### Usage
+Represents a usage entry:
+- ID
+- Attribution ID
+- Description
+- Credits
+- Effective time
+- Kind (Workspace Instance or Invoice)
+- Workspace instance ID
+- Draft status
+- Metadata
+
+### StripeCustomer
+Represents a Stripe customer:
+- ID
+- Currency
+- Billing address validity
+
+### StripeSubscription
+Represents a Stripe subscription:
+- ID
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- Requests include attribution IDs to identify the relevant account
+- Pagination is supported for listing operations
+- Time ranges are used to specify periods for usage data
+
+## Dependencies
+- Integrated with Stripe for payment processing
+- Used by the server component for user billing management
+- Used by the workspace manager to track workspace usage
+- Used by administrative tools for billing management
+
+## Usage Examples
+- Workspace creation process uses this API to check credit availability
+- Billing system uses this API to generate invoices
+- Administrative interfaces use this API to manage user credits
+- Reporting tools use this API to analyze usage patterns
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new billing options and features without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Usage API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in Go and TypeScript needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the usage-api directory:
+   ```bash
+   cd components/usage-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Lints the proto files using buf
+- Generates Go and TypeScript code using buf
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`:
+
+- `install_dependencies`: Installs required protoc plugins
+- `lint`: Lints the proto files using buf
+- `protoc_buf_generate`: Generates code using buf based on the configuration in `buf.gen.yaml`
+- `update_license`: Updates license headers in generated files
+
+The `buf.gen.yaml` file configures the code generation:
+- Generates Go code with appropriate module paths
+- Generates TypeScript code using ts_proto with specific options for nice-grpc compatibility
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Usage API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```
+
+The Usage API is primarily used by the usage component, which manages workspace usage tracking, billing, and credits within the Gitpod platform. It plays a critical role in the business operations of the platform by enabling usage-based billing and credit management.

--- a/memory-bank/components/ws-daemon-api.md
+++ b/memory-bank/components/ws-daemon-api.md
@@ -1,0 +1,156 @@
+# Workspace Daemon API
+
+## Overview
+The Workspace Daemon API defines the gRPC interfaces for the Workspace Daemon service, which is responsible for managing workspace content, filesystem operations, and low-level container operations within the Gitpod platform. This API enables the initialization, backup, and disposal of workspace content, as well as advanced container operations like user namespace setup and network configuration.
+
+## Purpose
+This API provides a standardized interface for:
+- Initializing workspace content from various sources
+- Creating and managing workspace snapshots and backups
+- Configuring user namespaces for workspace containers
+- Managing filesystem mounts and network interfaces
+- Monitoring workspace resource usage
+- Handling workspace teardown and cleanup
+
+## Architecture
+The Workspace Daemon API is implemented as a set of gRPC services defined in Protocol Buffer files. These definitions are used to generate client and server code in Go and TypeScript for use by the workspace daemon and other components in the system.
+
+## Key Services
+
+### WorkspaceContentService
+Provides methods for managing workspace content:
+
+- `InitWorkspace`: Initializes a new workspace folder in the working area
+- `WaitForInit`: Waits until a workspace is fully initialized
+- `IsWorkspaceExists`: Checks if ws-daemon knows about a workspace
+- `TakeSnapshot`: Creates a backup/snapshot of a workspace
+- `DisposeWorkspace`: Cleans up a workspace, possibly after taking a final backup
+- `BackupWorkspace`: Creates a backup of a workspace
+
+### InWorkspaceService
+Provides methods for low-level container operations:
+
+- `PrepareForUserNS`: Prepares a workspace container for wrapping it in a user namespace
+- `WriteIDMapping`: Writes a new user/group ID mapping for user namespaces
+- `EvacuateCGroup`: Empties the workspace pod cgroup and produces a new substructure
+- `MountProc`: Mounts a masked proc in the container's rootfs
+- `UmountProc`: Unmounts a masked proc from the container's rootfs
+- `MountSysfs`: Mounts a masked sysfs in the container's rootfs
+- `UmountSysfs`: Unmounts a masked sysfs from the container's rootfs
+- `MountNfs`: Mounts an NFS share into the container's rootfs
+- `UmountNfs`: Unmounts an NFS share from the container's rootfs
+- `Teardown`: Prepares workspace content backups and unmounts shiftfs mounts
+- `WipingTeardown`: Undoes everything PrepareForUserNS does
+- `SetupPairVeths`: Sets up a pair of virtual Ethernet interfaces
+- `WorkspaceInfo`: Gets information about the workspace
+
+### WorkspaceInfoService
+Provides methods for retrieving workspace information:
+
+- `WorkspaceInfo`: Gets information about the workspace resources
+
+## Key Data Structures
+
+### WorkspaceMetadata
+Contains metadata associated with a workspace:
+- Owner ID
+- Meta ID (workspace ID on the "meta pool" side)
+
+### WorkspaceContentState
+Enum defining the state of workspace content:
+- `NONE`: No workspace content and no work is underway
+- `SETTING_UP`: Workspace content is being produced/checked out/unarchived
+- `AVAILABLE`: Workspace content is fully present and ready for use
+- `WRAPPING_UP`: Workspace is being torn down
+
+### FSShiftMethod
+Enum defining the method for establishing ID shift for user namespaced workspaces:
+- `SHIFTFS`: Using shiftfs for ID shifting
+
+### Resources
+Contains information about workspace resources:
+- CPU usage and limits
+- Memory usage and limits
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- Requests include workspace IDs to identify the relevant workspace
+- Some operations are designed to be called from within the workspace container
+- Low-level operations often require process IDs (PIDs) to target specific namespaces
+
+## Dependencies
+- Depends on the Content Service API for workspace initialization
+- Used by workspace manager to manage workspace lifecycle
+- Used by workspacekit for container setup and namespace isolation
+- Integrated with Kubernetes for pod management
+
+## Usage Examples
+- Workspace creation process uses this API to initialize workspace content
+- Snapshot creation uses this API to create backups of workspace content
+- Workspace teardown uses this API to clean up resources
+- Container setup uses this API to configure user namespaces and mounts
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new workspace management features without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Workspace Daemon API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in Go and TypeScript needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the ws-daemon-api directory:
+   ```bash
+   cd components/ws-daemon-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Generates TypeScript code
+- Generates mock implementations for testing
+- Updates JSON tags in the generated Go code
+- Patches the generated TypeScript code for compatibility
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`:
+
+- `install_dependencies`: Installs required protoc plugins
+- `go_protoc`: Generates Go code
+- `typescript_protoc`: Generates TypeScript code
+- `update_license`: Updates license headers in generated files
+
+Additionally, the script:
+- Generates mock implementations using `mockgen` for testing
+- Updates JSON tags in the generated Go code using `gomodifytags`
+- Patches the generated TypeScript code using a script from the content-service-api
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Workspace Daemon API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```
+
+The Workspace Daemon API is primarily used by the ws-daemon component, which runs on each Kubernetes node and manages workspace content and container operations. It plays a critical role in the workspace lifecycle by handling content initialization, backup, and disposal, as well as advanced container operations.

--- a/memory-bank/components/ws-manager-api.md
+++ b/memory-bank/components/ws-manager-api.md
@@ -1,0 +1,175 @@
+# Workspace Manager API
+
+## Overview
+The Workspace Manager API defines the gRPC interfaces for the Workspace Manager service, which is responsible for managing the lifecycle of workspaces within the Gitpod platform. This API enables the creation, monitoring, and control of workspaces running in Kubernetes clusters.
+
+## Purpose
+This API provides a standardized interface for:
+- Starting and stopping workspaces
+- Monitoring workspace status
+- Managing workspace timeouts and activity
+- Controlling port exposure and admission settings
+- Creating snapshots and backups of workspaces
+- Retrieving information about available workspace classes
+
+## Architecture
+The Workspace Manager API is implemented as a gRPC service defined in Protocol Buffer files. These definitions are used to generate client and server code in Go and TypeScript for use by the workspace manager and other components in the system.
+
+## Key Services
+
+### WorkspaceManager
+Provides methods for managing workspaces:
+
+- `GetWorkspaces`: Retrieves a list of running workspaces and their status
+- `StartWorkspace`: Creates a new running workspace within the manager's cluster
+- `StopWorkspace`: Stops a running workspace
+- `DescribeWorkspace`: Investigates a workspace and returns its status and configuration
+- `BackupWorkspace`: Backs up a running workspace
+- `Subscribe`: Streams all status updates to a client
+- `MarkActive`: Records a workspace as being active, preventing it from timing out
+- `SetTimeout`: Changes the default timeout for a running workspace
+- `ControlPort`: Publicly exposes or un-exposes a network port for a workspace
+- `TakeSnapshot`: Creates a copy of the workspace content for initializing a new workspace
+- `ControlAdmission`: Makes a workspace accessible for everyone or for the owner only
+- `DeleteVolumeSnapshot`: Deletes a specific volume snapshot
+- `UpdateSSHKey`: Updates SSH keys for a workspace
+- `DescribeCluster`: Provides information about the cluster
+
+## Key Data Structures
+
+### WorkspaceStatus
+Represents the current status of a workspace:
+- ID and metadata
+- Specification
+- Phase (e.g., PENDING, CREATING, INITIALIZING, RUNNING)
+- Conditions (detailed state information)
+- Runtime information
+- Authentication settings
+- Initializer metrics
+
+### WorkspacePhase
+Enum defining the high-level state of a workspace:
+- `UNKNOWN`: Cannot determine the actual phase
+- `PENDING`: Workspace is waiting for resources in the cluster
+- `CREATING`: Workspace is being created (downloading images)
+- `INITIALIZING`: Workspace is executing the initializer
+- `RUNNING`: Workspace is actively performing work
+- `INTERRUPTED`: Workspace is temporarily unavailable
+- `STOPPING`: Workspace is shutting down
+- `STOPPED`: Workspace has ended regularly
+
+### WorkspaceSpec
+Defines the runtime configuration of a workspace:
+- Workspace image
+- IDE image and layers
+- Exposed ports
+- Timeout settings
+- Workspace class
+
+### StartWorkspaceSpec
+Defines the configuration for starting a workspace:
+- Workspace image
+- IDE image and layers
+- Feature flags
+- Initializer configuration
+- Ports to expose
+- Environment variables
+- Git configuration
+- Timeout settings
+- Admission level
+- SSH public keys
+
+### PortSpec
+Describes a networking port exposed on a workspace:
+- Port number
+- Visibility (private or public)
+- URL
+- Protocol (HTTP or HTTPS)
+
+### WorkspaceClass
+Describes a workspace class supported by the cluster:
+- ID
+- Display name
+- Description
+- Credits per minute
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- The `Subscribe` method uses server-side streaming to provide real-time updates
+- Requests include workspace IDs to identify the relevant workspace
+- Filtering can be applied using metadata to target specific workspaces
+
+## Dependencies
+- Depends on the Content Service API for workspace initialization
+- Used by the server component for workspace management
+- Used by the ws-manager-bridge to communicate with workspace managers
+- Integrated with Kubernetes for cluster management
+
+## Usage Examples
+- Workspace creation process uses this API to start new workspaces
+- Monitoring systems use this API to track workspace status
+- Billing systems use this API to track workspace activity
+- Administrative tools use this API to manage workspaces
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new workspace management features without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Workspace Manager API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in Go and TypeScript needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the ws-manager-api directory:
+   ```bash
+   cd components/ws-manager-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates Go code using `protoc-gen-go` and `protoc-gen-go-grpc`
+- Generates TypeScript code
+- Generates mock implementations for testing
+- Patches the generated TypeScript code for compatibility
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`:
+
+- `install_dependencies`: Installs required protoc plugins
+- `go_protoc`: Generates Go code
+- `typescript_protoc`: Generates TypeScript code
+- `update_license`: Updates license headers in generated files
+
+Additionally, the script:
+- Generates mock implementations using `mockgen` for testing
+- Patches the generated TypeScript code using a script from the content-service-api
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Workspace Manager API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```
+
+The Workspace Manager API is primarily used by the ws-manager-mk2 component, which is a Kubernetes controller for managing workspace lifecycle. It plays a critical role in the platform by enabling the creation, monitoring, and control of workspaces running in Kubernetes clusters.

--- a/memory-bank/components/ws-manager-bridge-api.md
+++ b/memory-bank/components/ws-manager-bridge-api.md
@@ -1,0 +1,129 @@
+# Workspace Manager Bridge API
+
+## Overview
+The Workspace Manager Bridge API defines the gRPC interfaces for the Workspace Manager Bridge service, which enables dynamic management of workspace clusters within the Gitpod platform. This API allows for the registration, updating, and deregistration of workspace clusters, facilitating multi-cluster deployments and cluster lifecycle management.
+
+## Purpose
+This API provides a standardized interface for:
+- Registering new workspace clusters
+- Updating properties of existing workspace clusters
+- Deregistering workspace clusters
+- Listing currently registered workspace clusters
+- Managing admission constraints for workspace clusters
+- Controlling cluster state (available, cordoned, draining)
+
+## Architecture
+The Workspace Manager Bridge API is implemented as a gRPC service defined in Protocol Buffer files. These definitions are used to generate client and server code in Go and TypeScript for use by the workspace manager bridge and other components in the system.
+
+## Key Services
+
+### ClusterService
+Provides methods for managing workspace clusters:
+
+- `Register`: Registers a new workspace cluster
+- `Update`: Modifies properties of an already registered workspace cluster
+- `Deregister`: Removes a workspace cluster from available clusters
+- `List`: Returns the currently registered workspace clusters
+
+## Key Data Structures
+
+### ClusterStatus
+Represents the current status of a workspace cluster:
+- Name and URL
+- State (UNKNOWN, AVAILABLE, CORDONED, DRAINING)
+- Score and maximum score
+- Admission constraints
+- Region information
+- Whether the cluster is static or governed
+
+### TlsConfig
+Contains TLS configuration for secure communication with a cluster:
+- CA certificate
+- Client certificate
+- Client key
+
+### RegistrationHints
+Provides hints for cluster registration:
+- Preferability (None, Prefer, DontSchedule)
+- Cordoned status
+
+### AdmissionConstraint
+Defines constraints for workspace admission to a cluster:
+- Feature preview constraints
+- Permission-based constraints
+
+## Communication Patterns
+- The API uses gRPC for efficient, typed communication
+- Requests include cluster names to identify the relevant cluster
+- Updates can be applied to specific properties of a cluster
+- Deregistration can be forced even if instances are still running
+
+## Dependencies
+- Used by the server component for cluster management
+- Used by the ws-manager-bridge to communicate with workspace managers
+- Integrated with Kubernetes for cluster management
+
+## Usage Examples
+- Cluster management systems use this API to register new workspace clusters
+- Load balancing systems use this API to update cluster scores
+- Administrative tools use this API to cordon or drain clusters
+- Monitoring systems use this API to list available clusters
+
+## Version Compatibility
+The API uses Protocol Buffers version 3 (proto3) syntax, which provides forward and backward compatibility features. The service is designed to allow for the addition of new cluster management features without breaking existing clients.
+
+## Code Generation and Building
+
+### Regenerating Code from Protobuf Definitions
+The Workspace Manager Bridge API uses Protocol Buffers and gRPC for defining interfaces. When changes are made to the `.proto` files, the corresponding code in Go and TypeScript needs to be regenerated.
+
+To regenerate the code:
+
+1. Navigate to the ws-manager-bridge-api directory:
+   ```bash
+   cd components/ws-manager-bridge-api
+   ```
+
+2. Run the generate script:
+   ```bash
+   ./generate.sh
+   ```
+
+This script performs the following actions:
+- Installs necessary dependencies (protoc plugins)
+- Generates code using buf based on the configuration in `buf.gen.yaml`
+- Updates license headers
+
+### Implementation Details
+The `generate.sh` script uses functions from the shared script at `scripts/protoc-generator.sh`:
+
+- `install_dependencies`: Installs required protoc plugins
+- `protoc_buf_generate`: Generates code using buf based on the configuration in `buf.gen.yaml`
+- `update_license`: Updates license headers in generated files
+
+The `buf.gen.yaml` file configures the code generation:
+- Generates Go code with appropriate module paths
+- Generates JavaScript and TypeScript code with gRPC support
+
+### Building After Code Generation
+After regenerating the code, you may need to rebuild components that depend on the Workspace Manager Bridge API. This typically involves:
+
+1. For Go components:
+   ```bash
+   cd <component-directory>
+   go build ./...
+   ```
+
+2. For TypeScript components:
+   ```bash
+   cd <component-directory>
+   yarn install
+   yarn build
+   ```
+
+3. Using Leeway (for CI/CD):
+   ```bash
+   leeway build -D components/<component-name>:app
+   ```
+
+The Workspace Manager Bridge API is primarily used by the ws-manager-bridge component, which bridges between workspace managers and the rest of the platform. It plays a critical role in multi-cluster deployments by enabling dynamic management of workspace clusters, facilitating load balancing, and providing a unified interface for cluster operations.

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -109,12 +109,10 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of thirteenth set of key components (openvsx-proxy, scheduler-extender, ipfs)
 - Documentation of first set of API components (content-service-api, ide-metrics-api, ide-service-api)
 - Documentation of second set of API components (image-builder-api, local-app-api, registry-facade-api)
+- Documentation of third set of API components (supervisor-api, usage-api, ws-daemon-api)
 
 ### Upcoming Milestones
 - Documentation of remaining API components:
-  - supervisor-api
-  - usage-api
-  - ws-daemon-api
   - ws-manager-api
   - ws-manager-bridge-api
 - Development environment setup
@@ -200,6 +198,10 @@ No specific blockers or dependencies have been identified yet. This section will
     - image-builder-api: Interfaces for building Docker images for workspaces
     - local-app-api: Interfaces for communication between local machines and remote workspaces
     - registry-facade-api: Interfaces for dynamically assembling workspace container images
+  - Documented third set of API components:
+    - supervisor-api: Interfaces for workspace management, terminal handling, and port forwarding
+    - usage-api: Interfaces for tracking, calculating, and managing workspace usage and billing
+    - ws-daemon-api: Interfaces for workspace content management and container operations
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -107,12 +107,10 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of eleventh set of key components (spicedb, scrubber, service-waiter)
 - Documentation of twelfth set of key components (docker-up, image-builder-bob, node-labeler)
 - Documentation of thirteenth set of key components (openvsx-proxy, scheduler-extender, ipfs)
+- Documentation of first set of API components (content-service-api, ide-metrics-api, ide-service-api)
 
 ### Upcoming Milestones
-- Documentation of API components:
-  - content-service-api
-  - ide-metrics-api
-  - ide-service-api
+- Documentation of remaining API components:
   - image-builder-api
   - local-app-api
   - registry-facade-api
@@ -191,6 +189,15 @@ No specific blockers or dependencies have been identified yet. This section will
     - Identified 11 API components that need documentation
     - Updated .clinerules to reflect new documentation approach
     - Updated activeContext.md and progress.md with new documentation tasks
+  - Documented first set of API components:
+    - content-service-api: Interfaces for managing workspace content, blobs, logs, and IDE plugins
+    - ide-metrics-api: Interfaces for collecting metrics and error reports from IDE components
+    - ide-service-api: Interfaces for managing IDE configurations and resolving workspace IDE requirements
+  - Enhanced API component documentation with code generation information:
+    - Added details on how to regenerate code from protobuf definitions
+    - Documented the implementation details of the generation process
+    - Included instructions for building components after code regeneration
+    - Updated .clinerules to standardize API documentation with code generation sections
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -108,12 +108,10 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of twelfth set of key components (docker-up, image-builder-bob, node-labeler)
 - Documentation of thirteenth set of key components (openvsx-proxy, scheduler-extender, ipfs)
 - Documentation of first set of API components (content-service-api, ide-metrics-api, ide-service-api)
+- Documentation of second set of API components (image-builder-api, local-app-api, registry-facade-api)
 
 ### Upcoming Milestones
 - Documentation of remaining API components:
-  - image-builder-api
-  - local-app-api
-  - registry-facade-api
   - supervisor-api
   - usage-api
   - ws-daemon-api
@@ -198,6 +196,10 @@ No specific blockers or dependencies have been identified yet. This section will
     - Documented the implementation details of the generation process
     - Included instructions for building components after code regeneration
     - Updated .clinerules to standardize API documentation with code generation sections
+  - Documented second set of API components:
+    - image-builder-api: Interfaces for building Docker images for workspaces
+    - local-app-api: Interfaces for communication between local machines and remote workspaces
+    - registry-facade-api: Interfaces for dynamically assembling workspace container images
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -109,7 +109,18 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of thirteenth set of key components (openvsx-proxy, scheduler-extender, ipfs)
 
 ### Upcoming Milestones
-- Documentation of remaining key components
+- Documentation of API components:
+  - content-service-api
+  - ide-metrics-api
+  - ide-service-api
+  - image-builder-api
+  - local-app-api
+  - registry-facade-api
+  - supervisor-api
+  - usage-api
+  - ws-daemon-api
+  - ws-manager-api
+  - ws-manager-bridge-api
 - Development environment setup
 - First component deep dive
 - Initial contribution
@@ -175,6 +186,11 @@ No specific blockers or dependencies have been identified yet. This section will
   - Updated techContext.md with detailed build process information
   - Updated .clinerules with build patterns and commands
   - Added build information tracking to memory bank maintenance procedures
+  - Updated documentation approach to include API components:
+    - Removed exclusion of "*-api" components from documentation
+    - Identified 11 API components that need documentation
+    - Updated .clinerules to reflect new documentation approach
+    - Updated activeContext.md and progress.md with new documentation tasks
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -110,11 +110,9 @@ As we begin working with the codebase, we have not yet identified specific issue
 - Documentation of first set of API components (content-service-api, ide-metrics-api, ide-service-api)
 - Documentation of second set of API components (image-builder-api, local-app-api, registry-facade-api)
 - Documentation of third set of API components (supervisor-api, usage-api, ws-daemon-api)
+- Documentation of fourth set of API components (ws-manager-api, ws-manager-bridge-api)
 
 ### Upcoming Milestones
-- Documentation of remaining API components:
-  - ws-manager-api
-  - ws-manager-bridge-api
 - Development environment setup
 - First component deep dive
 - Initial contribution
@@ -202,6 +200,9 @@ No specific blockers or dependencies have been identified yet. This section will
     - supervisor-api: Interfaces for workspace management, terminal handling, and port forwarding
     - usage-api: Interfaces for tracking, calculating, and managing workspace usage and billing
     - ws-daemon-api: Interfaces for workspace content management and container operations
+  - Documented fourth set of API components:
+    - ws-manager-api: Interfaces for managing the lifecycle of workspaces in Kubernetes clusters
+    - ws-manager-bridge-api: Interfaces for dynamic management of workspace clusters
 
 ## Next Evaluation Point
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -68,8 +68,10 @@ The existing functionality of the Gitpod platform:
 ## What's Left to Build
 
 ### Immediate Tasks
-- Explore component interactios
+- Explore component interactions
 - Set up local development environment
+- Explore build system approaches (in-tree and Leeway)
+- Test component builds for different component types
 - Identify specific components for deeper exploration
 - Establish testing methodology
 - Create initial contribution plan
@@ -165,6 +167,14 @@ No specific blockers or dependencies have been identified yet. This section will
   - Documented openvsx-proxy component
   - Documented scheduler-extender component
   - Documented ipfs component
+
+- **2/27/2025**:
+  - Documented build system approaches:
+    - In-tree builds using language-specific tools (yarn, go)
+    - Out-of-tree builds using Leeway
+  - Updated techContext.md with detailed build process information
+  - Updated .clinerules with build patterns and commands
+  - Added build information tracking to memory bank maintenance procedures
 
 ## Next Evaluation Point
 

--- a/memory-bank/techContext.md
+++ b/memory-bank/techContext.md
@@ -42,13 +42,57 @@ The project uses a Gitpod-based development workflow (dogfooding), with the foll
 4. **Dev Containers**: Development occurs in containers that mirror production
 
 ### Build Process
-1. **Leeway**: Custom build system that manages the complex dependencies between components
-2. **Component Compilation**: Each component is compiled independently
-   - TypeScript components use `yarn build`
-   - Go components use `go build`
-   - Java components use Gradle
-3. **Docker Images**: Components are packaged as Docker images
-4. **Helm Charts**: Deployment configurations are managed as Helm charts
+
+Gitpod uses two primary approaches for building components:
+
+#### 1. In-tree Builds (Primary for Local Development)
+Components are built directly in the workspace using language-specific tools:
+
+- **TypeScript/JavaScript Components**:
+  - Commands are defined in each component's `package.json`
+  - Common commands:
+    - `yarn build`: Compiles the component
+    - `yarn test`: Runs unit tests
+    - `yarn lint`: Checks code style
+    - `yarn watch`: Watches for changes and rebuilds automatically
+  - Example (from server component):
+    ```bash
+    cd components/server
+    yarn build        # Build the component
+    yarn test:unit    # Run unit tests
+    yarn test:db      # Run database tests
+    ```
+
+- **Go Components**:
+  - Use standard Go tools
+  - Common commands:
+    - `go build`: Compiles the component
+    - `go test`: Runs tests
+    - `go run`: Builds and runs the component
+  - Example:
+    ```bash
+    cd components/ws-daemon
+    go build ./...    # Build all packages
+    go test ./...     # Test all packages
+    ```
+
+#### 2. Leeway Builds (Out-of-tree, Primary for CI)
+Leeway is a custom build tool that:
+- Copies relevant sources into a separate file tree
+- Manages complex dependencies between components
+- Generates build artifacts for CI/CD pipelines
+- Can also be run from inside the workspace
+
+Common Leeway commands:
+```bash
+leeway build components/server:app    # Build a specific component
+leeway build -D components/server:app # Build with dependencies
+leeway exec --package components/server:app -- yarn test  # Run a command for a package
+```
+
+#### 3. Component Packaging
+- **Docker Images**: Components are packaged as Docker images using `leeway.Dockerfile` files
+- **Helm Charts**: Deployment configurations are managed as Helm charts for Kubernetes deployment
 
 ### Testing Strategy
 1. **Unit Tests**: Component-level tests for individual functions and classes


### PR DESCRIPTION
## Description
Teach cline more things about the repo:
 - how to build components
 - document the "-api" components as well (incl. how those are re-generated)

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
