### PR TITLE
[dashboard] Fix org-suggested repositories when settings org query is fetching

### DIFF
--- a/components/dashboard/src/data/organizations/suggested-repositories-query.ts
+++ b/components/dashboard/src/data/organizations/suggested-repositories-query.ts
@@ -28,12 +28,12 @@ export type SuggestedOrgRepository = PlainMessage<SuggestedRepository> & {
 
 export function useOrgSuggestedRepos() {
     const organizationId = useCurrentOrg().data?.id;
-    const orgSettings = useOrgSettingsQuery();
+    const { data: orgSettings, isLoading: isOrgSettingsLoading } = useOrgSettingsQuery();
 
     const query = useQuery<SuggestedOrgRepository[], Error>(
         getQueryKey(organizationId),
         async () => {
-            const repos = orgSettings.data?.onboardingSettings?.recommendedRepositories ?? [];
+            const repos = orgSettings?.onboardingSettings?.recommendedRepositories ?? [];
 
             const suggestions: SuggestedOrgRepository[] = [];
             for (const configurationId of repos) {
@@ -58,7 +58,7 @@ export function useOrgSuggestedRepos() {
             return suggestions;
         },
         {
-            enabled: !!organizationId,
+            enabled: !!organizationId && !isOrgSettingsLoading,
             cacheTime: 1000 * 60 * 60 * 24 * 7, // 1 week
             staleTime: 1000 * 60 * 5, // 5 minutes
         },


### PR DESCRIPTION
## Description

Fixes a regression from #20603 that would let the query give up and be fine with not having any data when org settings weren't loaded yet.

## How to test

1. Sign up for https://ft-fix-orga9fb4e52ec.preview.gitpod-dev.com/workspaces
2. Observe the repo in the getting started section loads fine


/hold
