### PR TITLE
[server] Fix broken /ready endpoint and chaned the probe to be a StartupProbe

### DIFF
--- a/components/server/src/liveness/probes.ts
+++ b/components/server/src/liveness/probes.ts
@@ -4,22 +4,41 @@
  * See License.AGPL.txt in the project root for license information.
  */
 
+import * as http from "http";
 import express from "express";
 import { inject, injectable } from "inversify";
 import { LivenessController } from "./liveness-controller";
 import { ReadinessController } from "./readiness-controller";
+import { AddressInfo } from "net";
 
 @injectable()
 export class ProbesApp {
+    private app: express.Application;
+    private httpServer: http.Server | undefined = undefined;
+
     constructor(
         @inject(LivenessController) protected readonly livenessController: LivenessController,
         @inject(ReadinessController) protected readonly readinessController: ReadinessController,
-    ) {}
-
-    public create(): express.Application {
+    ) {
         const probesApp = express();
         probesApp.use("/live", this.livenessController.apiRouter);
         probesApp.use("/ready", this.readinessController.apiRouter);
-        return probesApp;
+        this.app = probesApp;
+    }
+
+    public async start(port: number): Promise<number> {
+        await this.readinessController.start();
+
+        return new Promise((resolve, reject) => {
+            const probeServer = this.app.listen(port, () => {
+                resolve((<AddressInfo>probeServer.address()).port);
+            });
+            this.httpServer = probeServer;
+        });
+    }
+
+    public async stop(): Promise<void> {
+        this.httpServer?.close();
+        await this.readinessController.stop();
     }
 }

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -371,7 +371,9 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								PeriodSeconds:       10,
 								FailureThreshold:    6,
 							},
-							ReadinessProbe: &corev1.Probe{
+							// StartupProbe, as we are only interested in controlling the startup of the server pod, and
+							// not interferring with the readiness afterwards.
+							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
 										Path: "/ready",
@@ -383,7 +385,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								},
 								InitialDelaySeconds: 5,
 								PeriodSeconds:       10,
-								FailureThreshold:    12, // try for 120 seconds
+								FailureThreshold:    18, // try for 180 seconds, then the Pod is restarted
 							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               pointer.Bool(false),


### PR DESCRIPTION
## Description
The root issues was a dependency cycle which I did not test in the preview, where I only deployed server. :see_no_evil:
On full rollout, this happened
 - dashboard deployed, pod waiting for server to come online
 - server's ReadyProbe tried to retrieve feature flag synchronously, which never resolved :cross:
    - maybe due to dashboard not being available?


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1233

## How to test
 - go to https://gpl-fix-rollout.preview.gitpod-dev.com/workspaces
 - open a workspace on this PR
 - scale server pods up/down, and check logs for ready prove (`grep Readi`)
 - note that feature flag resolution is async now

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
