### PR TITLE
[server] Add /ready probe to smooth rollout of server pods

### DIFF
--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -71,7 +71,7 @@ import { WebhookEventGarbageCollector } from "./jobs/webhook-gc";
 import { WorkspaceGarbageCollector } from "./jobs/workspace-gc";
 import { LinkedInService } from "./linkedin-service";
 import { LivenessController } from "./liveness/liveness-controller";
-import { ReadinessController } from "./liveness/readiness-controller";
+import { StartupController } from "./liveness/startup-controller";
 import { RedisSubscriber } from "./messaging/redis-subscriber";
 import { MonitoringEndpointsApp } from "./monitoring-endpoints";
 import { OAuthController } from "./oauth-server/oauth-controller";
@@ -245,7 +245,7 @@ export const productionContainerModule = new ContainerModule(
 
         bind(ProbesApp).toSelf().inSingletonScope();
         bind(LivenessController).toSelf().inSingletonScope();
-        bind(ReadinessController).toSelf().inSingletonScope();
+        bind(StartupController).toSelf().inSingletonScope();
 
         bind(OneTimeSecretServer).toSelf().inSingletonScope();
 

--- a/components/server/src/container-module.ts
+++ b/components/server/src/container-module.ts
@@ -137,6 +137,7 @@ import { InstallationAdminCleanup } from "./jobs/installation-admin-cleanup";
 import { AuditLogService } from "./audit/AuditLogService";
 import { AuditLogGarbageCollectorJob } from "./jobs/auditlog-gc";
 import { ProbesApp } from "./liveness/probes";
+import { ReadinessController } from "./liveness/readiness-controller";
 
 export const productionContainerModule = new ContainerModule(
     (bind, unbind, isBound, rebind, unbindAsync, onActivation, onDeactivation) => {
@@ -246,6 +247,7 @@ export const productionContainerModule = new ContainerModule(
         bind(ProbesApp).toSelf().inSingletonScope();
         bind(LivenessController).toSelf().inSingletonScope();
         bind(StartupController).toSelf().inSingletonScope();
+        bind(ReadinessController).toSelf().inSingletonScope();
 
         bind(OneTimeSecretServer).toSelf().inSingletonScope();
 

--- a/components/server/src/liveness/probes.ts
+++ b/components/server/src/liveness/probes.ts
@@ -8,7 +8,7 @@ import * as http from "http";
 import express from "express";
 import { inject, injectable } from "inversify";
 import { LivenessController } from "./liveness-controller";
-import { ReadinessController } from "./readiness-controller";
+import { StartupController } from "./startup-controller";
 import { AddressInfo } from "net";
 
 @injectable()
@@ -18,17 +18,15 @@ export class ProbesApp {
 
     constructor(
         @inject(LivenessController) protected readonly livenessController: LivenessController,
-        @inject(ReadinessController) protected readonly readinessController: ReadinessController,
+        @inject(StartupController) protected readonly startupController: StartupController,
     ) {
         const probesApp = express();
         probesApp.use("/live", this.livenessController.apiRouter);
-        probesApp.use("/ready", this.readinessController.apiRouter);
+        probesApp.use("/startup", this.startupController.apiRouter);
         this.app = probesApp;
     }
 
     public async start(port: number): Promise<number> {
-        await this.readinessController.start();
-
         return new Promise((resolve, reject) => {
             const probeServer = this.app.listen(port, () => {
                 resolve((<AddressInfo>probeServer.address()).port);
@@ -39,6 +37,5 @@ export class ProbesApp {
 
     public async stop(): Promise<void> {
         this.httpServer?.close();
-        await this.readinessController.stop();
     }
 }

--- a/components/server/src/liveness/probes.ts
+++ b/components/server/src/liveness/probes.ts
@@ -10,6 +10,7 @@ import { inject, injectable } from "inversify";
 import { LivenessController } from "./liveness-controller";
 import { StartupController } from "./startup-controller";
 import { AddressInfo } from "net";
+import { ReadinessController } from "./readiness-controller";
 
 @injectable()
 export class ProbesApp {
@@ -19,10 +20,12 @@ export class ProbesApp {
     constructor(
         @inject(LivenessController) protected readonly livenessController: LivenessController,
         @inject(StartupController) protected readonly startupController: StartupController,
+        @inject(ReadinessController) protected readonly readinessController: ReadinessController,
     ) {
         const probesApp = express();
         probesApp.use("/live", this.livenessController.apiRouter);
         probesApp.use("/startup", this.startupController.apiRouter);
+        probesApp.use("/ready", this.readinessController.apiRouter);
         this.app = probesApp;
     }
 
@@ -33,6 +36,10 @@ export class ProbesApp {
             });
             this.httpServer = probeServer;
         });
+    }
+
+    public notifyShutdown(): void {
+        this.readinessController.notifyShutdown();
     }
 
     public async stop(): Promise<void> {

--- a/components/server/src/liveness/readiness-controller.ts
+++ b/components/server/src/liveness/readiness-controller.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { injectable } from "inversify";
+import express from "express";
+import { log } from "@gitpod/gitpod-protocol/lib/util/logging";
+
+/**
+ * ReadinessController is mimicking the behavior server had in the past: Behave as there is not ready probe - except during shutdown.
+ *
+ * Why? In Gitpod, our error strategy has always been "keep it local and retry", instead of "fail loud and have someone else handle it".
+ * As we don't want to change this now, we keep the same behavior for most of the services lifetime.
+ *
+ * Only during shutdown, we want to signal that the service is not ready anymore, to reduce error peaks.
+ */
+@injectable()
+export class ReadinessController {
+    private shutdown: boolean = false;
+
+    get apiRouter(): express.Router {
+        const router = express.Router();
+        this.addReadinessHandler(router);
+        return router;
+    }
+
+    public notifyShutdown(): void {
+        this.shutdown = true;
+    }
+
+    protected addReadinessHandler(router: express.Router) {
+        router.get("/", async (_, res) => {
+            if (this.shutdown) {
+                log.warn("Readiness check failed: Server is shutting down");
+                res.status(503).send("Server is shutting down");
+                return;
+            }
+
+            res.status(200).send("Ready");
+            log.debug("Readiness check successful");
+        });
+    }
+}

--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -387,6 +387,9 @@ export class Server {
     }
 
     public async stop() {
+        // mark as not-ready
+        this.probesApp.notifyShutdown();
+
         // run each stop with a timeout of 30s
         async function race(workLoad: Promise<any>, task: string, ms: number = 30 * 1000): Promise<void> {
             const before = Date.now();
@@ -413,9 +416,12 @@ export class Server {
             race(this.stopServer(this.httpServer), "stop httpserver"),
             race(this.stopServer(this.privateApiServer), "stop private api server"),
             race(this.stopServer(this.publicApiServer), "stop public api server"),
-            race(this.probesApp.stop(), "stop probe server"),
             race((async () => this.disposables.dispose())(), "dispose disposables"),
         ]);
+
+        this.probesApp.stop().catch(() => {
+            /* ignore */
+        });
 
         log.info("server stopped.");
     }

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -387,6 +387,21 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 								PeriodSeconds:       10,
 								FailureThreshold:    18, // try for 180 seconds, then the Pod is restarted
 							},
+							// /ready will only return false on shutdown (SIGTERM), always true otherwise
+							ReadinessProbe: &corev1.Probe{
+								ProbeHandler: corev1.ProbeHandler{
+									HTTPGet: &corev1.HTTPGetAction{
+										Path: "/ready",
+										Port: intstr.IntOrString{
+											Type:   intstr.Int,
+											IntVal: ProbesPort,
+										},
+									},
+								},
+								InitialDelaySeconds: 5,
+								PeriodSeconds:       5,
+								FailureThreshold:    1, // mark as "not ready" as quick as possible after receiving SIGTERM
+							},
 							SecurityContext: &corev1.SecurityContext{
 								Privileged:               pointer.Bool(false),
 								AllowPrivilegeEscalation: pointer.Bool(false),

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -376,7 +376,7 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 							StartupProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path: "/ready",
+										Path: "/startup",
 										Port: intstr.IntOrString{
 											Type:   intstr.Int,
 											IntVal: ProbesPort,


### PR DESCRIPTION
## Description
This PR does two things:
 1. Rename `ReadinessController` to `StartupController` and mount it on `/startup`, because it's used by the `StartupProbe`
 2. Introduce a fresh  `ReadinessController` which:
    - always returns :+1:
    - **except** when we already received SIGTERM, switching to :-1: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1234

## How to test
 - installation: https://gpl-1234-sda36a70e7c.preview.gitpod-dev.com/workspaces 
 - open a workspace on this PR
 - do theses changes on the `server` deployment:
   - scale `server` up and down
   - `edit` and add/remove/change an env var
 - and notice how you no longer see `2/2 Terminating` but `0/2 Terminating` instead :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
