### PR TITLE
[server, bridge] Switch base-images to node:18.20.7-alpine to avoid CVEs

### DIFF
--- a/components/server/leeway.Dockerfile
+++ b/components/server/leeway.Dockerfile
@@ -2,20 +2,19 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:18.17.1-slim AS builder
+FROM node:18.20.7-alpine AS builder
 
 # Install Python, make, gcc and g++ for node-gyp
-RUN apt-get update && \
-    apt-get install -y python3 make gcc g++ && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add python3 make gcc g++ bash && \
+    rm -rf /var/cache/apk/*
 
 COPY components-server--app /installer/
 
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM cgr.dev/chainguard/node:18.17.1@sha256:af073516c203b6bd0b55a77a806a0950b486f2e9ea7387a32b0f41ea72f20886
+FROM node:18.20.7-alpine
 ENV NODE_OPTIONS="--unhandled-rejections=warn --max_old_space_size=2048"
 
 EXPOSE 3000

--- a/components/ws-manager-bridge/leeway.Dockerfile
+++ b/components/ws-manager-bridge/leeway.Dockerfile
@@ -2,13 +2,19 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:18.17.1-slim as builder
+FROM node:18.20.7-alpine AS builder
+
+# Install bash for the installer script
+RUN apk update && \
+    apk add bash && \
+    rm -rf /var/cache/apk/*
+
 COPY components-ws-manager-bridge--app /installer/
 
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM cgr.dev/chainguard/node:18.17.1@sha256:af073516c203b6bd0b55a77a806a0950b486f2e9ea7387a32b0f41ea72f20886
+FROM node:18.20.7-alpine
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 EXPOSE 3000
 COPY --from=builder --chown=node:node /app /app/


### PR DESCRIPTION
## Description
Mitigates multiple CVEs in the outdated wolfi images

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
