### PR TITLE
Reapply "[image-builder-bob] bump up buildkit (#20690)" (#20693)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ permissions:
   contents: write # This is required for actions/checkout and create release
   pull-requests: write
   actions: write  # This is required for trigger another action which is used by JetBrains integrateion tests
+  packages: read
 on:
   pull_request:
     types: [ opened, edited ]
@@ -229,6 +230,12 @@ jobs:
           cat report.html >> $GITHUB_STEP_SUMMARY
 
           exit $RESULT
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Leeway Build
         id: leeway
         shell: bash

--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM eu.gcr.io/gitpod-core-dev/build/buildkit:v0.12.5-gitpod.0
+FROM ghcr.io/gitpod-io/buildkit:v0.20.1-gitpod.2
 
 USER root
 RUN apk --no-cache add sudo bash \

--- a/components/workspacekit/pkg/seccomp/notify.go
+++ b/components/workspacekit/pkg/seccomp/notify.go
@@ -275,7 +275,9 @@ func (h *InWorkspaceHandler) Mount(req *libseccomp.ScmpNotifReq) (val uint64, er
 		if strings.HasPrefix(dest, "/proc/self/") {
 			target = filepath.Join("/proc", strconv.Itoa(int(req.Pid)), strings.TrimPrefix(dest, "/proc/self/"))
 		}
-
+		if strings.HasPrefix(dest, "/proc/thread-self/") {
+			target = filepath.Join("/proc", strconv.Itoa(int(req.Pid)), strings.TrimPrefix(dest, "/proc/thread-self/"))
+		}
 		stat, err := os.Lstat(target)
 		if errors.Is(err, fs.ErrNotExist) {
 			err = os.MkdirAll(target, 0755)


### PR DESCRIPTION
This reverts commit 71378332359c80940e1c1b0dc158bf430cd67636.

Tool: gitpod/catfood.gitpod.cloud

## Description
<!-- Describe your changes in detail -->

This pid is actually thread id, it should be safe if we use in `thread-self`

see doc [link](https://man7.org/linux/man-pages/man2/seccomp_unotify.2.html#:~:text=The%20seccomp_notif%20structure,and%20SECCOMP_IOCTL_NOTIF_SEND%0A%20%20%20%20%20%20%20%20%20%20%20%20operations.)
<img width="707" alt="image" src="https://github.com/user-attachments/assets/fc47e438-e5b5-49d5-84cf-e77191c5a688" />

workspace integration test are success https://github.com/gitpod-io/gitpod/actions/runs/13993623337/job/39183946713?pr=20694

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1252

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-upgrade-buildkit</li>
	<li><b>🔗 URL</b> - <a href="https://pd-upgrade-buildkit.preview.gitpod-dev.com/workspaces" target="_blank">pd-upgrade-buildkit.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-upgrade-buildkit-gha.31961</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-upgrade-buildkit%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
