### PR TITLE
[.github] fix workspace integration tests

### DIFF
--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -89,10 +89,10 @@ jobs:
                   echo "version=${{ inputs.version }}"
               } >> $GITHUB_OUTPUT
           else
-              # Search the last 10 builds regardless of status (success and failed)
-              RUNID=$(gh run list --repo gitpod-io/gitpod --branch main --workflow build.yml --limit 10 --json createdAt,conclusion,databaseId --jq 'map(select(.conclusion == "success")) | sort_by(.createdAt) | .[-1] | .databaseId')
+              # Search the last 10 completed builds (any conclusion except null/in-progress)
+              RUNID=$(gh run list --repo gitpod-io/gitpod --branch main --workflow build.yml --limit 10 --json createdAt,conclusion,databaseId --jq 'map(select(.conclusion != null)) | sort_by(.createdAt) | .[-1] | .databaseId')
               if [ "$RUNID" == "" ]; then
-                echo no successful build found on main branch in the last 10 commits, see https://github.com/gitpod-io/gitpod/actions/workflows/build.yml for details | tee -a $GITHUB_STEP_SUMMARY
+                echo no completed build found on main branch in the last 10 commits, see https://github.com/gitpod-io/gitpod/actions/workflows/build.yml for details | tee -a $GITHUB_STEP_SUMMARY
                 # if we got here, it means in the last 10 builds on main, there wasn't a success, and then we'll keep getting this message
                 # to fix, manually trigger the tests with the latest main-gha asset till we get a success
                 # you might have to fix or disable flakey tests to do this

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -107,7 +107,7 @@ jobs:
               echo "Using version $MAIN_VERSION" | tee -a $GITHUB_STEP_SUMMARY
 
               {
-                  echo "version=$("$MAIN_VERSION")"
+                  echo "version=$MAIN_VERSION"
               } >> $GITHUB_OUTPUT
           fi
           if [[ '${{ inputs.image_repo_base }}' != '' ]]; then

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -102,8 +102,12 @@ jobs:
                 exit 1
               fi
 
+              echo "Using RUNID $RUNID" | tee -a $GITHUB_STEP_SUMMARY
+              MAIN_VERSION=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep "leeway build --cache remote -Dversion=" | grep 'main-gha.[0-9]*' -o | head -n 1)
+              echo "Using version $MAIN_VERSION" | tee -a $GITHUB_STEP_SUMMARY
+
               {
-                  echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha.[0-9]*' -o | head -n 1)"
+                  echo "version=$("$MAIN_VERSION")"
               } >> $GITHUB_OUTPUT
           fi
           if [[ '${{ inputs.image_repo_base }}' != '' ]]; then


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The main-gha version scrape is getting confused because it's using the version from our dev image, which includes main-gha, etc.

The string we match on looks like:
> Build Gitpod    Leeway Build    2025-03-21T14:08:38.2792412Z + leeway build --cache remote -Dversion=main-gha.31974 --docker-build-options network=host --max-concurrent-tasks 1 -DlocalAppVersion=main-gha.31974 -DpublishToNPM=true -DnpmPublishTrigger=1742566118278 -DpublishToJBMarketplace=true -DimageRepoBase=eu.gcr.io/gitpod-core-dev/build --report report.html

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes n/a

## How to test
<!-- Provide steps to test this PR -->
[This](https://github.com/gitpod-io/gitpod/actions/runs/14000217940/job/39204920564) run found an installer. Previously, we were not finding an installer in GCR, so the tests would fail (and are failing) on main (unless we specify an explicit version).

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
