### PR TITLE
[gha] Fix IDE integration tests

### DIFF
--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -72,7 +72,7 @@ jobs:
               fi
 
               {
-                  echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha.[0-9]*' -o | head -n 1)"
+                  echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha\.[0-9]*' -o | head -n 1)"
                   echo "name=ide-integration-test-${{ github.run_id }}-${{ github.run_attempt }}"
               } >> $GITHUB_OUTPUT
           fi

--- a/components/ide/gha-update-image/lib/common.ts
+++ b/components/ide/gha-update-image/lib/common.ts
@@ -121,7 +121,7 @@ const getInstallerVersion = async (version: string | undefined) => {
         }
     }
     const installationVersion =
-        await $`echo '${tagInfo}' | awk '{ print $2 }' | grep -o 'main-gha.[0-9]*' | cut -d'/' -f3`
+        await $`echo '${tagInfo}' | awk '{ print $2 }' | grep -o 'main-gha\\.[0-9]*' | cut -d'/' -f3`
             .text()
             .catch((e) => {
                 throw new Error("Failed to parse installer version from git tag: " + e);


### PR DESCRIPTION
Tool: gitpod/catfood.gitpod.cloud

## Description
<!-- Describe your changes in detail -->

Fix IDE integration tests on main

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=ide
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
