### PR TITLE
[gha] Correct installer tag finding for IDE integration tests

### DIFF
--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -72,7 +72,6 @@ jobs:
               fi
 
               {
-                  echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha\.[0-9]*' -o | head -n 1)"
                   echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'Build Gitpod' | grep 'Tag the release' | grep 'main-gha\.[0-9]*' -o | head -n 1)"
                   echo "name=ide-integration-test-${{ github.run_id }}-${{ github.run_attempt }}"
               } >> $GITHUB_OUTPUT

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -73,6 +73,7 @@ jobs:
 
               {
                   echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'main-gha\.[0-9]*' -o | head -n 1)"
+                  echo "version=$(gh run view "$RUNID" --log -R gitpod-io/gitpod | grep 'Build Gitpod' | grep 'Tag the release' | grep 'main-gha\.[0-9]*' -o | head -n 1)"
                   echo "name=ide-integration-test-${{ github.run_id }}-${{ github.run_attempt }}"
               } >> $GITHUB_OUTPUT
           fi

--- a/components/ide/gha-update-image/lib/common.ts
+++ b/components/ide/gha-update-image/lib/common.ts
@@ -121,7 +121,7 @@ const getInstallerVersion = async (version: string | undefined) => {
         }
     }
     const installationVersion =
-        await $`echo '${tagInfo}' | awk '{ print $2 }' | grep -o 'main-gha\\.[0-9]*' | cut -d'/' -f3`
+        await $`echo '${tagInfo}' | awk '{ print $2 }' | grep -o 'main-gha.[0-9]*' | cut -d'/' -f3`
             .text()
             .catch((e) => {
                 throw new Error("Failed to parse installer version from git tag: " + e);


### PR DESCRIPTION
Tool: gitpod/catfood.gitpod.cloud

## Description
<!-- Describe your changes in detail -->
Revert changes that breaks main and trigger IDE integration tests in branch

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-gha-2</li>
	<li><b>🔗 URL</b> - <a href="https://hw-gha-2.preview.gitpod-dev.com/workspaces" target="_blank">hw-gha-2.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-gha-2-gha.32002</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-gha-2%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=ide
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
