### PR TITLE
[JetBrains] Improve port forwarding logic

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodPortForwardingService.kt
@@ -13,6 +13,7 @@ import com.intellij.util.application
 import com.jetbrains.rd.platform.codeWithMe.portForwarding.*
 import com.jetbrains.rd.util.URI
 import com.jetbrains.rd.util.lifetime.Lifetime
+import com.jetbrains.rd.util.lifetime.LifetimeDefinition
 import io.gitpod.supervisor.api.Status
 import io.gitpod.supervisor.api.Status.PortsStatus
 import io.gitpod.supervisor.api.StatusServiceGrpc
@@ -23,17 +24,33 @@ import kotlinx.coroutines.future.asDeferred
 import org.apache.http.client.utils.URIBuilder
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ConcurrentHashMap
+import kotlinx.coroutines.sync.Semaphore
+import kotlinx.coroutines.sync.withPermit
 
 @Suppress("UnstableApiUsage")
 abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService {
     companion object {
         const val FORWARDED_PORT_LABEL = "ForwardedByGitpod"
         const val EXPOSED_PORT_LABEL = "ExposedByGitpod"
+        private const val MAX_CONCURRENT_OPERATIONS = 10
+        private const val BATCH_SIZE = 10
+        private const val BATCH_DELAY = 100L
+        private const val DEBOUNCE_DELAY = 500L
     }
 
     private val perClientPortForwardingManager = service<PerClientPortForwardingManager>()
     private val ignoredPortsForNotificationService = service<GitpodIgnoredPortsForNotificationService>()
     private val lifetime = Lifetime.Eternal.createNested()
+
+    // Store current observed ports and their lifetime references
+    private val portLifetimes = ConcurrentHashMap<Int, LifetimeDefinition>()
+
+    // Debounce job for port updates
+    private var debounceJob: Job? = null
+
+    // Semaphore to limit concurrent operations
+    private val operationSemaphore = Semaphore(MAX_CONCURRENT_OPERATIONS)
 
     init { start() }
 
@@ -58,7 +75,6 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
                     is InterruptedException, is CancellationException -> {
                         cancel("gitpod: Stopped observing ports list due to an expected interruption.")
                     }
-
                     else -> {
                         thisLogger().warn(
                             "gitpod: Got an error while trying to get ports list from Supervisor. " +
@@ -86,7 +102,17 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
             }
 
             override fun onNext(response: Status.PortsStatusResponse) {
-                application.invokeLater { syncPortsListWithClient(response) }
+                debounceJob?.cancel()
+                debounceJob = runJob(lifetime) {
+                    delay(DEBOUNCE_DELAY)
+                    try {
+                        syncPortsListWithClient(response)
+                    } catch (e: Exception) {
+                        thisLogger().error("gitpod: Error during port observation", e)
+                    } finally {
+                        debounceJob = null
+                    }
+                }
             }
 
             override fun onCompleted() {
@@ -114,6 +140,9 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
         val servedPorts = portsList.filter { it.served }
         val exposedPorts = servedPorts.filter { it.exposed?.url?.isNotBlank() ?: false }
         val portsNumbersFromNonServedPorts = portsList.filter { !it.served }.map { it.localPort }
+
+        val allPortsToKeep = mutableSetOf<Int>()
+
         val servedPortsToStartForwarding = servedPorts.filter {
             perClientPortForwardingManager.getPorts(it.localPort).none { p -> p.labels.contains(FORWARDED_PORT_LABEL) }
         }
@@ -127,27 +156,91 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
             .map { it.hostPortNumber }
             .filter { portsNumbersFromNonServedPorts.contains(it) || !portsNumbersFromPortsList.contains(it) }
 
-        servedPortsToStartForwarding.forEach { startForwarding(it) }
+        runJob(lifetime) {
+            processPortsInBatches(servedPortsToStartForwarding) { port ->
+                operationSemaphore.withPermit {
+                    startForwarding(port)
+                    allPortsToKeep.add(port.localPort)
+                }
+            }
 
-        exposedPortsToStartExposingOnClient.forEach { startExposingOnClient(it) }
+            processPortsInBatches(exposedPortsToStartExposingOnClient) { port ->
+                operationSemaphore.withPermit {
+                    startExposingOnClient(port)
+                    allPortsToKeep.add(port.localPort)
+                }
+            }
 
-        forwardedPortsToStopForwarding.forEach { stopForwarding(it) }
+            processPortsInBatches(forwardedPortsToStopForwarding) { port ->
+                operationSemaphore.withPermit { stopForwarding(port) }
+            }
 
-        exposedPortsToStopExposingOnClient.forEach { stopExposingOnClient(it) }
+            processPortsInBatches(exposedPortsToStopExposingOnClient) { port ->
+                operationSemaphore.withPermit { stopExposingOnClient(port) }
+            }
 
-        portsList.forEach { updatePortsPresentation(it) }
+            processPortsInBatches(portsList) { port ->
+                application.invokeLater {
+                    updatePortsPresentation(port)
+                    allPortsToKeep.add(port.localPort)
+                }
+            }
+
+            cleanupUnusedLifetimes(allPortsToKeep)
+        }
+    }
+
+    private suspend fun <T> processPortsInBatches(ports: List<T>, action: suspend (T) -> Unit) {
+        ports.chunked(BATCH_SIZE).forEach { batch ->
+            try {
+                batch.forEach { port ->
+                    try {
+                        withTimeout(5000) { // Add timeout to prevent hanging operations
+                            action(port)
+                        }
+                    } catch (e: Exception) {
+                        thisLogger().warn("gitpod: Error processing port in batch", e)
+                    }
+                }
+                delay(BATCH_DELAY)
+            } catch (e: Exception) {
+                thisLogger().error("gitpod: Error processing batch", e)
+                delay(BATCH_DELAY * 2) // Double delay on error
+            }
+        }
+    }
+
+    private fun cleanupUnusedLifetimes(portsToKeep: Set<Int>) {
+        portLifetimes.keys.filter { !portsToKeep.contains(it) }.forEach { port ->
+            portLifetimes[port]?.let { lifetime ->
+                thisLogger().debug("gitpod: Terminating lifetime for port $port")
+                lifetime.terminate()
+                portLifetimes.remove(port)
+            }
+        }
     }
 
     private fun startForwarding(portStatus: PortsStatus) {
-        if (isLocalPortForwardingDisabled()) {
-            return
-        }
+        if (isLocalPortForwardingDisabled()) return
+
+        val portLifetime = getOrCreatePortLifetime(portStatus.localPort)
+
         try {
-            perClientPortForwardingManager.forwardPort(
+            thisLogger().debug("gitpod: Starting forwarding for port ${portStatus.localPort}")
+            val port = perClientPortForwardingManager.forwardPort(
                 portStatus.localPort,
                 PortType.TCP,
                 setOf(FORWARDED_PORT_LABEL),
             )
+
+            portLifetime.onTerminationOrNow {
+                thisLogger().debug("gitpod: Cleaning up port ${portStatus.localPort} due to lifetime termination")
+                try {
+                    perClientPortForwardingManager.removePort(port)
+                } catch (e: Exception) {
+                    thisLogger().warn("gitpod: Failed to remove port on lifetime termination", e)
+                }
+            }
         } catch (throwable: Throwable) {
             if (throwable !is PortAlreadyForwardedException) {
                 thisLogger().warn("gitpod: Caught an exception while forwarding port: ${throwable.message}")
@@ -156,62 +249,113 @@ abstract class AbstractGitpodPortForwardingService : GitpodPortForwardingService
     }
 
     private fun stopForwarding(hostPort: Int) {
-        perClientPortForwardingManager.getPorts(hostPort)
+        thisLogger().debug("gitpod: Stopping forwarding for port $hostPort")
+        val portsToRemove = perClientPortForwardingManager.getPorts(hostPort)
             .filter { it.labels.contains(FORWARDED_PORT_LABEL) }
-            .forEach { perClientPortForwardingManager.removePort(it) }
+
+        terminatePortLifetime(hostPort)
+
+        portsToRemove.forEach {
+            try {
+                perClientPortForwardingManager.removePort(it)
+            } catch (e: Exception) {
+                thisLogger().warn("gitpod: Failed to remove forwarded port $hostPort", e)
+            }
+        }
     }
 
     private fun startExposingOnClient(portStatus: PortsStatus) {
-        perClientPortForwardingManager.exposePort(
+        val portLifetime = getOrCreatePortLifetime(portStatus.localPort)
+
+        thisLogger().debug("gitpod: Starting exposing for port ${portStatus.localPort}")
+        val port = perClientPortForwardingManager.exposePort(
             portStatus.localPort,
             portStatus.exposed.url,
             setOf(EXPOSED_PORT_LABEL),
         )
+
+        portLifetime.onTerminationOrNow {
+            thisLogger().debug("gitpod: Cleaning up exposed port ${portStatus.localPort} due to lifetime termination")
+            try {
+                perClientPortForwardingManager.removePort(port)
+            } catch (e: Exception) {
+                thisLogger().warn("gitpod: Failed to remove exposed port on lifetime termination", e)
+            }
+        }
     }
 
     private fun stopExposingOnClient(hostPort: Int) {
-        perClientPortForwardingManager.getPorts(hostPort)
+        thisLogger().debug("gitpod: Stopping exposing for port $hostPort")
+        val portsToRemove = perClientPortForwardingManager.getPorts(hostPort)
             .filter { it.labels.contains(EXPOSED_PORT_LABEL) }
-            .forEach { perClientPortForwardingManager.removePort(it) }
+
+        terminatePortLifetime(hostPort)
+
+        portsToRemove.forEach {
+            try {
+                perClientPortForwardingManager.removePort(it)
+            } catch (e: Exception) {
+                thisLogger().warn("gitpod: Failed to remove exposed port $hostPort", e)
+            }
+        }
+    }
+
+    private fun getOrCreatePortLifetime(port: Int): Lifetime =
+        portLifetimes.computeIfAbsent(port) {
+            thisLogger().debug("gitpod: Creating new lifetime for port $port")
+            lifetime.createNested()
+        }
+
+    private fun terminatePortLifetime(port: Int) {
+        portLifetimes[port]?.let { portLifetime ->
+            thisLogger().debug("gitpod: Terminating lifetime for port $port")
+            portLifetime.terminate()
+            portLifetimes.remove(port)
+        }
     }
 
     private fun updatePortsPresentation(portStatus: PortsStatus) {
         perClientPortForwardingManager.getPorts(portStatus.localPort).forEach {
-            if (it.configuration.isForwardedPort()) {
-                it.presentation.name = portStatus.name
-                it.presentation.description = portStatus.description
-                it.presentation.tooltip = "Forwarded"
-                it.presentation.icon = RowIcon(AllIcons.Actions.Commit)
-            } else if (it.configuration.isExposedPort()) {
-                val isPubliclyExposed = (portStatus.exposed.visibility == Status.PortVisibility.public_visibility)
-
-                it.presentation.name = portStatus.name
-                it.presentation.description = portStatus.description
-                it.presentation.tooltip = "Exposed (${if (isPubliclyExposed) "Public" else "Private"})"
-                it.presentation.icon = if (isPubliclyExposed) {
-                    RowIcon(AllIcons.Actions.Commit)
-                } else {
-                    RowIcon(AllIcons.Actions.Commit, AllIcons.Diff.Lock)
+            when {
+                it.configuration.isForwardedPort() -> {
+                    it.presentation.name = portStatus.name
+                    it.presentation.description = portStatus.description
+                    it.presentation.tooltip = "Forwarded"
+                    it.presentation.icon = RowIcon(AllIcons.Actions.Commit)
+                }
+                it.configuration.isExposedPort() -> {
+                    val isPubliclyExposed = (portStatus.exposed.visibility == Status.PortVisibility.public_visibility)
+                    it.presentation.name = portStatus.name
+                    it.presentation.description = portStatus.description
+                    it.presentation.tooltip = "Exposed (${if (isPubliclyExposed) "Public" else "Private"})"
+                    it.presentation.icon = if (isPubliclyExposed) {
+                        RowIcon(AllIcons.Actions.Commit)
+                    } else {
+                        RowIcon(AllIcons.Actions.Commit, AllIcons.Diff.Lock)
+                    }
                 }
             }
         }
     }
 
-    override fun getLocalHostUriFromHostPort(hostPort: Int): Optional<URI> {
-        val forwardedPort = perClientPortForwardingManager.getPorts(hostPort).firstOrNull {
-            it.configuration.isForwardedPort()
-        } ?: return Optional.empty()
-
-        (forwardedPort.configuration as PortConfiguration.PerClientTcpForwarding).clientPortState.let {
-            return if (it is ClientPortState.Assigned) {
-                Optional.of(URIBuilder().setScheme("http").setHost(it.clientInterface).setPort(it.clientPort).build())
-            } else {
-                Optional.empty()
-            }
-        }
-    }
+    override fun getLocalHostUriFromHostPort(hostPort: Int): Optional<URI> =
+        perClientPortForwardingManager.getPorts(hostPort)
+            .firstOrNull { it.configuration.isForwardedPort() }
+            ?.let { forwardedPort ->
+                (forwardedPort.configuration as PortConfiguration.PerClientTcpForwarding)
+                    .clientPortState
+                    .let {
+                        if (it is ClientPortState.Assigned) {
+                            Optional.of(URIBuilder().setScheme("http").setHost(it.clientInterface).setPort(it.clientPort).build())
+                        } else {
+                            Optional.empty()
+                        }
+                    }
+            } ?: Optional.empty()
 
     override fun dispose() {
+        portLifetimes.values.forEach { it.terminate() }
+        portLifetimes.clear()
         lifetime.terminate()
     }
 }


### PR DESCRIPTION
Tool: gitpod/catfood.gitpod.cloud

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Open a workspace in preview environment with context https://github.com/mustard-mh/test/tree/hw/logs-ports
- It should work well without issues if you access the ports configured in `.gitpod.yml`
- It should work well when you trying to open / close new ports (which will trigger workspace ports updates)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-fix</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-fix.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-fix.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-fix-gha.32028</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-fix%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
