### PR TITLE
New Gitpod Classic notification

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -131,6 +131,21 @@ const INVALID_BILLING_ADDRESS = (stripePortalUrl: string | undefined) => {
     } as Notification;
 };
 
+const GITPOD_CLASSIC_SUNSET = {
+    id: "gitpod-classic-sunset",
+    type: "info" as AlertType,
+    preventDismiss: true, // This makes it so users can't dismiss the notification
+    message: (
+        <span className="text-md">
+            <b>Gitpod Classic is sunsetting fall 2025.</b>{" "}
+            <a className="text-kumquat-ripe font-bold" href="https://app.gitpod.io" target="_blank" rel="noreferrer">
+                Try the new Gitpod
+            </a>{" "}
+            now (hosted compute coming soon)
+        </span>
+    ),
+} as Notification;
+
 export function AppNotifications() {
     const [topNotification, setTopNotification] = useState<Notification | undefined>(undefined);
     const { user, loading } = useUserLoader();
@@ -145,6 +160,10 @@ export function AppNotifications() {
         const updateNotifications = async () => {
             const notifications = [];
             if (!loading) {
+                if (isGitpodIo()) {
+                    notifications.push(GITPOD_CLASSIC_SUNSET);
+                }
+
                 if (
                     isGitpodIo() &&
                     (!user?.profile?.acceptedPrivacyPolicyDate ||
@@ -167,6 +186,7 @@ export function AppNotifications() {
 
             if (!ignore) {
                 const dismissedNotifications = getDismissedNotifications();
+                // Since the sunset notification has preventDismiss: true, it won't be affected by dismissedNotifications
                 const topNotification = notifications.find((n) => !dismissedNotifications.includes(n.id));
                 setTopNotification(topNotification);
             }
@@ -197,7 +217,7 @@ export function AppNotifications() {
         <div className="app-container pt-2">
             <Alert
                 type={topNotification.type}
-                closable={true}
+                closable={topNotification.id !== "gitpod-classic-sunset"} // Only show close button if it's not the sunset notification
                 onClose={() => {
                     if (!topNotification.preventDismiss) {
                         dismissNotification();

--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -138,7 +138,7 @@ const GITPOD_CLASSIC_SUNSET = {
     message: (
         <span className="text-md">
             <b>Gitpod Classic is sunsetting fall 2025.</b>{" "}
-            <a className="text-kumquat-ripe font-bold" href="https://app.gitpod.io" target="_blank" rel="noreferrer">
+            <a className="text-kumquat-base font-bold" href="https://app.gitpod.io" target="_blank" rel="noreferrer">
                 Try the new Gitpod
             </a>{" "}
             now (hosted compute coming soon)
@@ -186,7 +186,6 @@ export function AppNotifications() {
 
             if (!ignore) {
                 const dismissedNotifications = getDismissedNotifications();
-                // Since the sunset notification has preventDismiss: true, it won't be affected by dismissedNotifications
                 const topNotification = notifications.find((n) => !dismissedNotifications.includes(n.id));
                 setTopNotification(topNotification);
             }

--- a/components/dashboard/src/Login.tsx
+++ b/components/dashboard/src/Login.tsx
@@ -330,6 +330,14 @@ const RightProductDescriptionPanel = () => {
                         Automated, standardized development environments hosted by us in Gitpod’s infrastructure. Users
                         who joined before October 1, 2024 on non-Enterprise plans are considered Gitpod Classic users.
                     </p>
+
+                    <p className="text-pk-content-secondary mb-2">
+                        Gitpod Classic is sunsetting fall 2025.{" "}
+                        <a className="gp-link font-bold" href="https://app.gitpod.io" target="_blank" rel="noreferrer">
+                            Try the new Gitpod
+                        </a>{" "}
+                        now (hosted compute coming soon).
+                    </p>
                 </div>
                 <img src={GitpodClassicCard} alt="Gitpod Classic" className="w-full" />
             </div>


### PR DESCRIPTION
Introduce a sticky notification informing users about the sunset plans of Gitpod Classic in fall 2025, encouraging them to try the new Gitpod which will also have Gitpod-hosted compute soon :tada:

Related: [Internal conversation](https://gitpod.slack.com/archives/C046Z4BBP2N/p1743110347939789)

/hold