### PR TITLE
[server, bridge] Bind metrics apps to "127.0.0.1" instead of "localhost"

### DIFF
--- a/components/server/src/server.ts
+++ b/components/server/src/server.ts
@@ -365,7 +365,7 @@ export class Server {
         this.httpServer = httpServer;
 
         if (this.monitoringApp) {
-            this.monitoringHttpServer = this.monitoringApp.listen(MONITORING_PORT, "localhost", () => {
+            this.monitoringHttpServer = this.monitoringApp.listen(MONITORING_PORT, "127.0.0.1", () => {
                 log.info(
                     `monitoring app listening on port: ${(<AddressInfo>this.monitoringHttpServer!.address()).port}`,
                 );

--- a/components/ws-manager-bridge/src/main.ts
+++ b/components/ws-manager-bridge/src/main.ts
@@ -48,8 +48,8 @@ export const start = async (container: Container) => {
             res.send(await mergedRegistry.metrics());
         });
         const metricsPort = 9500;
-        const metricsHttpServer = metricsApp.listen(metricsPort, "localhost", () => {
-            log.info(`prometheus metrics server running on: localhost:${metricsPort}`);
+        const metricsHttpServer = metricsApp.listen(metricsPort, "127.0.0.1", () => {
+            log.info(`prometheus metrics server running on: 127.0.0.1:${metricsPort}`);
         });
 
         const debugApp = container.get<DebugApp>(DebugApp);


### PR DESCRIPTION
## Description
This helps aligning the behavior of bridge and server with other containers.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1271

## How to test
 - `kubectl -n monitoring-satellite port-forward grafana-5fd57658b4-2fzlh 3000 &`
 - open that port
 - check that `gitpod_version_info` is exported :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
