### PR TITLE
[installer] Avoid https://tldr.fail

### DIFF
--- a/install/installer/pkg/common/common.go
+++ b/install/installer/pkg/common/common.go
@@ -122,6 +122,11 @@ func DefaultEnv(cfg *config.Config) []corev1.EnvVar {
 			}},
 			{Name: "KUBE_DOMAIN", Value: "svc.cluster.local"},
 			{Name: "LOG_LEVEL", Value: strings.ToLower(logLevel)},
+			// TODO(gpl): This is our bandaid for https:://tldr.fail, until we upgrade from Go 1.23 to 1.24
+			// See these issues for details:
+			//  - https://linear.app/gitpod/issue/CLC-1264/investigate-public-api-server-connectivity-issues-during-sso-login#comment-f2daa302
+			//  - https://linear.app/gitpod/issue/CLC-1067/go-upgrade-from-123x-to-124x-once-available for details
+			{Name: "GODEBUG", Value: "tlskyber=0"},
 		},
 		ProxyEnv(cfg),
 	)


### PR DESCRIPTION
## Description
See CLC-1264

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1264

## How to test
 - use a firewall/server/proxy that is subject to https://tldr.fail
 - use it to gate/server content Gitpod needs access to (SCM, IDP)
 - see that it still works

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
