### PR TITLE
[common-go] continue on hashConfig errors

### DIFF
--- a/components/common-go/watch/file.go
+++ b/components/common-go/watch/file.go
@@ -85,7 +85,7 @@ func File(ctx context.Context, path string, onChange func()) error {
 
 				currentHash, err := hashConfig(path)
 				if err != nil {
-					log.WithError(err).Warn("Cannot check if config has changed")
+					log.WithError(err).WithField("event", event.Name).Warn("Cannot check if config has changed")
 					return
 				}
 

--- a/components/common-go/watch/file.go
+++ b/components/common-go/watch/file.go
@@ -86,7 +86,7 @@ func File(ctx context.Context, path string, onChange func()) error {
 				currentHash, err := hashConfig(path)
 				if err != nil {
 					log.WithError(err).WithField("event", event.Name).Warn("Cannot check if config has changed")
-					return
+					continue
 				}
 
 				// no change


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We used to return and stop watching a file if the hashConfig function returned an error. Now we log the error (including the event name) so we can later try again on subsequent fsnotify events.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1304

## How to test
<!-- Provide steps to test this PR -->
Update the `image-pull-secret` in this preview environment, and assert that file watcher picks up the new value in the [logs](https://cloudlogging.app.goo.gl/CzKjqLUfizYmBNbq7). 

In the below picture, you'll see 3 entries, 1 for the initial start and 2 where I changed the secret value path via: `kubectl patch secret image-pull-secret --patch '{"data":{".dockerconfigjson":"'$(cat patch.json | base64 -w 0)'"}}'`

<img width="1504" alt="image" src="https://github.com/user-attachments/assets/9cc0813e-32d5-49f3-b443-60e630a66186" />

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - kylos101-clc-1304</li>
	<li><b>🔗 URL</b> - <a href="https://kylos101-clc-1304.preview.gitpod-dev.com/workspaces" target="_blank">kylos101-clc-1304.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - kylos101-CLC-1304-gha.32194</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-kylos101-clc-1304%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
