### PR TITLE
[ops] add Slack alert for GitpodImageBuilderMk3InternalErrors

### DIFF
--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -62,3 +62,15 @@ spec:
         expr: |
           kube_deployment_status_replicas_unavailable{deployment="image-builder-mk3", cluster!~"ephemeral.*"} > 0
         for: 10m
+      - alert: GitpodImageBuilderMk3InternalErrors
+        labels:
+          severity: error
+          dedicated: included
+        annotations:
+          # runbook is 404 for now
+          runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuilderMk3InternalErrors.md
+          summary: image-builder-mk3 is returning unexpected internal errors
+          description: 'Check the logs for image-builder-mk3 to inspect the high rate: {{ printf "%.2f" $value }}'
+        expr: |
+          sum by() (rate(grpc_server_handled_total{service="image-builder-mk3", grpc_code=~"Internal", grpc_method="Build"}[1h])) > 0.001
+        for: 1h

--- a/operations/observability/mixins/workspace/rules/central/image-builder.yaml
+++ b/operations/observability/mixins/workspace/rules/central/image-builder.yaml
@@ -64,8 +64,9 @@ spec:
         for: 10m
       - alert: GitpodImageBuilderMk3InternalErrors
         labels:
-          severity: error
+          severity: warning
           dedicated: included
+          team: engine
         annotations:
           # runbook is 404 for now
           runbook_url: https://github.com/gitpod-io/runbooks/blob/main/runbooks/GitpodImageBuilderMk3InternalErrors.md


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Alert in Slack when the internal errors for build are too high, these land in #team-enterprise-alerts.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1305

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
