### PR TITLE
[code] update code image layers

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,11 +8,11 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-4483885bb11ab66b7906e81952af47ec0be6db09",
+        "image": "{{.Repository}}/ide/code:commit-e62d71dde81f736d8a4c6b07c5483e5caed40d7b",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
-          "{{.Repository}}/ide/gitpod-code-web:commit-89f0bc5aa6682e507c40d3eaa2df68b6984c8b98",
-          "{{.Repository}}/ide/code-codehelper:commit-6a6052fe11cde3c702ced508c32538b274216779"
+          "{{.Repository}}/ide/gitpod-code-web:commit-e62d71dde81f736d8a4c6b07c5483e5caed40d7b",
+          "{{.Repository}}/ide/code-codehelper:commit-6385d6f4c904ce2b8d298c5f8c115090aa5f6488"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",


### PR DESCRIPTION
## Description
This PR updates the VS Code Browser image layers to the most recent installer version.

## How to test

Test if changes are working.

i.e.
- `code-helper` it can start browser code with extensions installed
- `gitpod-web-extension` extension functionalities are working well
- `code` is not expected it to be changed

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-code-images</li>
	<li><b>🔗 URL</b> - <a href="https://ide-code-images.preview.gitpod-dev.com/workspaces" target="_blank">ide-code-images.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-code-images-gha.32720</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ide-code-images%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment