### PR TITLE
feat(dashboard): Update header layout and start page branding

### DIFF
--- a/components/dashboard/src/menu/Menu.tsx
+++ b/components/dashboard/src/menu/Menu.tsx
@@ -88,7 +88,7 @@ export default function Menu() {
                         <div className="hidden md:flex items-center">
                             <div className="h-6 w-px bg-gray-300 dark:bg-gray-600 mx-2" />
                             <UserMenu user={user} className="" onFeedback={handleFeedbackFormClick} />
-                            <div className="pl-2">
+                            <div className="pl-4">
                                 <OrgPagesNav />
                             </div>
                         </div>
@@ -108,13 +108,10 @@ export default function Menu() {
                                 )}
                                 {!isDataOps && (
                                     <li>
-                                        <a
-                                            href="/"
-                                            className="flex items-center gap-x-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
-                                        >
+                                        <div className="flex items-center gap-x-1 text-sm text-pk-content-secondary">
                                             <ProductLogo className="h-4 w-auto" />
                                             <span>Gitpod Classic</span>
-                                        </a>
+                                        </div>
                                     </li>
                                 )}
                             </ul>
@@ -122,13 +119,10 @@ export default function Menu() {
                         {/* Right side items - Mobile Only */}
                         <div className="flex items-center space-x-3 md:hidden">
                             {!isDataOps && (
-                                <a
-                                    href="/"
-                                    className="flex items-center gap-x-1 text-sm text-gray-500 dark:text-gray-400 hover:text-gray-900 dark:hover:text-white"
-                                >
+                                <div className="flex items-center gap-x-1 text-sm text-pk-content-secondary">
                                     <ProductLogo className="h-4 w-auto" />
                                     <span>Gitpod Classic</span>
-                                </a>
+                                </div>
                             )}
                         </div>
                     </div>
@@ -183,7 +177,7 @@ const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, onFeedbac
     const { data: installationConfig, isLoading: isInstallationConfigLoading } = useInstallationConfiguration();
     const isGitpodIo = isInstallationConfigLoading ? false : !installationConfig?.isDedicatedInstallation;
 
-    const extraSection = useMemo(() => {
+    const adminSection = useMemo(() => {
         const items: ContextMenuEntry[] = [];
 
         if (withAdminLink && user?.rolesOrPermissions?.includes(RoleOrPermission.ADMIN)) {
@@ -202,7 +196,7 @@ const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, onFeedbac
     }, [user?.rolesOrPermissions, withAdminLink]);
 
     const menuEntries = useMemo(() => {
-        const baseEntries: ContextMenuEntry[] = [
+        const entries: ContextMenuEntry[] = [
             {
                 title: (user && (getPrimaryEmail(user) || user?.name)) || "User",
                 customFontStyle: "text-gray-400",
@@ -228,22 +222,22 @@ const UserMenu: FC<UserMenuProps> = ({ user, className, withAdminLink, onFeedbac
         ];
 
         if (isGitpodIo) {
-            baseEntries.push({
+            entries.push({
                 title: "Feedback",
                 onClick: onFeedback,
                 separator: true,
             });
         }
 
-        baseEntries.push(...extraSection);
+        entries.push(...adminSection);
 
-        baseEntries.push({
+        entries.push({
             title: "Log out",
             href: gitpodHostUrl.asApiLogout().toString(),
         });
 
-        return baseEntries;
-    }, [extraSection, user, isGitpodIo, onFeedback]);
+        return entries;
+    }, [adminSection, user, isGitpodIo, onFeedback]);
 
     return (
         <div

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -108,7 +108,7 @@ export function StartPage(props: StartPageProps) {
                         error || phase === StartPhase.Stopped || phase === StartPhase.IdeReady ? "" : "animate-bounce"
                     }`}
                 />
-                {!isDataOps && <span className="block mt-2 text-gray-600 dark:text-gray-400">Gitpod Classic</span>}
+                {!isDataOps && <span className="block mt-2 text-pk-content-secondary">Gitpod Classic</span>}
                 <Heading2 className="mt-8">{title}</Heading2>
                 {typeof phase === "number" && phase < StartPhase.IdeReady && (
                     <ProgressBar phase={phase} error={!!error} />

--- a/components/dashboard/src/start/StartPage.tsx
+++ b/components/dashboard/src/start/StartPage.tsx
@@ -14,6 +14,7 @@ import { VerifyModal } from "./VerifyModal";
 import { useWorkspaceDefaultImageQuery } from "../data/workspaces/default-workspace-image-query";
 import { GetWorkspaceDefaultImageResponse_Source } from "@gitpod/public-api/lib/gitpod/v1/workspace_pb";
 import { ProductLogo } from "../components/ProductLogo";
+import { useIsDataOps } from "../data/featureflag-query";
 
 export enum StartPhase {
     Checking = 0,
@@ -96,6 +97,8 @@ export function StartPage(props: StartPageProps) {
     const { phase, error, workspaceId } = props;
     let title = props.title || getPhaseTitle(phase, error);
     useDocumentTitle("Starting");
+    const isDataOps = useIsDataOps();
+
     return (
         <div className="w-screen h-screen align-middle">
             <div className="flex flex-col mx-auto items-center text-center h-screen">
@@ -105,6 +108,7 @@ export function StartPage(props: StartPageProps) {
                         error || phase === StartPhase.Stopped || phase === StartPhase.IdeReady ? "" : "animate-bounce"
                     }`}
                 />
+                {!isDataOps && <span className="block mt-2 text-gray-600 dark:text-gray-400">Gitpod Classic</span>}
                 <Heading2 className="mt-8">{title}</Heading2>
                 {typeof phase === "number" && phase < StartPhase.IdeReady && (
                     <ProgressBar phase={phase} error={!!error} />


### PR DESCRIPTION
## Description

This PR refactors the main application header Menu for improved responsiveness and updates the workspace start page with conditional UI elements.

Fixes GRO-808

| Menu header | Starting page |
|--------|--------|
| <img width="1154" alt="image" src="https://github.com/user-attachments/assets/8f7bf059-c1cd-4e6b-91c1-cc0bdc6249d3" /> | <img width="565" alt="image" src="https://github.com/user-attachments/assets/35f933f4-d5ff-4622-a5e4-fbd1e261a922" /> | 

## How to test
<!-- Provide steps to test this PR -->

*   Verify header layout on different screen sizes (desktop and mobile).
*   Test with relevant customer feature flag enabled and disabled to check conditional UI elements.
*   Check visibility of conditional branding in header and on start page.
*   Verify "Feedback" link visibility in the user menu dropdown under appropriate conditions.
*   Confirm "Admin" link visibility for admin users.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - siddhant-gcd2d94cdf1</li>
	<li><b>🔗 URL</b> - <a href="https://siddhant-gcd2d94cdf1.preview.gitpod-dev.com/workspaces" target="_blank">siddhant-gcd2d94cdf1.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - siddhant-gro-808-gitpod-classic-needs-to-be-visibly-marked-as-gitpod-classic-gha.32219</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-siddhant-gcd2d94cdf1%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
