### PR TITLE
[server] Fix custom CA

### DIFF
--- a/install/installer/pkg/common/certificate.go
+++ b/install/installer/pkg/common/certificate.go
@@ -8,6 +8,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+const CUSTOM_CA_MOUNT_PATH = "/etc/ssl/certs/ca-certificates.crt"
+
 func CAVolume() corev1.Volume {
 	return corev1.Volume{
 		Name: "ca-certificates",
@@ -22,7 +24,7 @@ func CAVolume() corev1.Volume {
 func CAVolumeMount() corev1.VolumeMount {
 	return corev1.VolumeMount{
 		Name:      "ca-certificates",
-		MountPath: "/etc/ssl/certs/ca-certificates.crt",
+		MountPath: CUSTOM_CA_MOUNT_PATH,
 		SubPath:   "ca-certificates.crt",
 		ReadOnly:  true,
 	}

--- a/install/installer/pkg/components/server/deployment.go
+++ b/install/installer/pkg/components/server/deployment.go
@@ -102,6 +102,11 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 				Name:  "WSMAN_CFG_MANAGERS",
 				Value: wsmanCfgManager,
 			},
+			// Required for node.js to pick up custom CAs
+			{
+				Name:  "NODE_EXTRA_CA_CERTS",
+				Value: common.CUSTOM_CA_MOUNT_PATH,
+			},
 		},
 	)
 

--- a/install/installer/pkg/components/ws-manager-bridge/deployment.go
+++ b/install/installer/pkg/components/ws-manager-bridge/deployment.go
@@ -87,10 +87,17 @@ func deployment(ctx *common.RenderContext) ([]runtime.Object, error) {
 		common.AnalyticsEnv(&ctx.Config),
 		common.DatabaseEnv(&ctx.Config),
 		common.ConfigcatEnv(ctx),
-		[]corev1.EnvVar{{
-			Name:  "WSMAN_BRIDGE_CONFIGPATH",
-			Value: "/config/ws-manager-bridge.json",
-		}},
+		[]corev1.EnvVar{
+			{
+				Name:  "WSMAN_BRIDGE_CONFIGPATH",
+				Value: "/config/ws-manager-bridge.json",
+			},
+			// Required for node.js to pick up custom CAs
+			{
+				Name:  "NODE_EXTRA_CA_CERTS",
+				Value: common.CUSTOM_CA_MOUNT_PATH,
+			},
+		},
 	))
 
 	_ = ctx.WithExperimental(func(cfg *experimental.Config) error {


### PR DESCRIPTION
## Description
Configure NODE_EXTRA_CA_CERTS env var to point to the CA certificate bundle file.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1317

## How to test
 - we applied via `kubectl set env deployment/server NODE_EXTRA_CA_CERTS=/etc/ssl/certs/ca-certificates.crt` which fixed the issue in a Dedicated installation
 - to verify it still works, [start one in the preview](https://gpl-test-ca.preview.gitpod-dev.com/new#https://github.com/geropl/bel)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
