### PR TITLE
[registry-facade] add image spec to logs

### DIFF
--- a/components/registry-facade/pkg/registry/manifest.go
+++ b/components/registry-facade/pkg/registry/manifest.go
@@ -114,7 +114,7 @@ func (mh *manifestHandler) getManifest(w http.ResponseWriter, r *http.Request) {
 	span, ctx := opentracing.StartSpanFromContext(r.Context(), "getManifest")
 	logFields := log.OWI("", "", mh.Name)
 	logFields["tag"] = mh.Tag
-	logFields["spec"] = mh.Spec
+	logFields["spec"] = log.TrustedValueWrap{Value: mh.Spec}
 	err := func() error {
 		log.WithFields(logFields).Debug("get manifest")
 		tracing.LogMessageSafe(span, "spec", mh.Spec)
@@ -265,7 +265,7 @@ func (mh *manifestHandler) getManifest(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	if err != nil {
-		log.WithError(err).WithField("spec", mh.Spec).Error("cannot get manifest")
+		log.WithError(err).WithField("spec", log.TrustedValueWrap{Value: mh.Spec}).Error("cannot get manifest")
 		respondWithError(w, err)
 	}
 	tracing.FinishSpan(span, &err)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

[registry-facade] add image spec to logs

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1315

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
