### PR TITLE
[server] Allow org env vars in repos that don't have projects

### DIFF
--- a/components/server/src/user/env-var-service.ts
+++ b/components/server/src/user/env-var-service.ts
@@ -317,6 +317,8 @@ export class EnvVarService {
         }
         if (projectId) {
             await this.auth.checkPermissionOnProject(requestorId, "read_env_var", projectId);
+        }
+        if (organizationId) {
             await this.auth.checkPermissionOnOrganization(requestorId, "read_env_var", organizationId);
         }
 
@@ -337,9 +339,7 @@ export class EnvVarService {
         }
 
         // 2. then org env vars (if applicable)
-        if (projectId) {
-            // !!! Important: Only apply the org env vars if the workspace is part of a project
-            // This is to prevent leaking org env vars to workspaces randomly started in an organization (safety feature)
+        if (organizationId) {
             const orgEnvVars =
                 (await ApplicationError.notFoundToUndefined(this.listOrgEnvVars(requestorId, organizationId))) || [];
             const withValues: OrgEnvVarWithValue[] = await this.orgDB.getOrgEnvironmentVariableValues(orgEnvVars);


### PR DESCRIPTION
## Description
Enables the use case of collaborators allowing to use projects with a private default workspace image configured on the org-level. This is enabled by the optional `enableDockerdAuthentication` that was implemented in #20586 - shortly _after_ org-level-env vars was implemented in #20538.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1319

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
