### PR TITLE
[JetBrains] Attach tasks with `exec` to properly handle terminal resize

### DIFF
--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodTerminalService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/AbstractGitpodTerminalService.kt
@@ -172,7 +172,7 @@ abstract class AbstractGitpodTerminalService(project: Project) : Disposable {
 
     private fun createAttachedSharedTerminal(title: String, supervisorTerminal: TerminalOuterClass.Terminal) {
         val shellTerminalWidget = createSharedTerminal(supervisorTerminal.alias, title)
-        shellTerminalWidget.executeCommand("gp tasks attach ${supervisorTerminal.alias}")
+        shellTerminalWidget.executeCommand("exec gp tasks attach ${supervisorTerminal.alias}")
         closeTerminalWidgetWhenClientGetsClosed(supervisorTerminal, shellTerminalWidget)
         exitTaskWhenTerminalWidgetGetsClosed(supervisorTerminal, shellTerminalWidget)
         listenForTaskTerminationAndTitleChanges(supervisorTerminal, shellTerminalWidget)


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1308

## How to test
<!-- Provide steps to test this PR -->

- Create a workspace in preview env with https://github.com/gitpod-samples/spring-petclinic + stable IntelliJ IDEA 
- Resize the terminal should make content adjusts as well

![Apr-28-2025 16-45-42](https://github.com/user-attachments/assets/60fa5d25-8b1f-4c62-a26a-1cf8c2d0541b)

**Integration tests**
✔️  Passed https://github.com/gitpod-io/gitpod/actions/runs/14701968868/job/41254054356?pr=20778

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-terminal</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-terminal.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-terminal.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-terminal-gha.32335</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-terminal%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
