### PR TITLE
[server] Fix permission issue for collaborators in listenForPrebuildUpdates

### DIFF
--- a/components/server/src/workspace/gitpod-server-impl.ts
+++ b/components/server/src/workspace/gitpod-server-impl.ts
@@ -268,7 +268,11 @@ export class GitpodServerImpl implements GitpodServerWithTracing, Disposable {
                     subjectId: SubjectId.fromUserId(userId),
                 },
                 async () => {
-                    const organizations = await this.getTeams(ctx ?? {});
+                    const { rows: organizations } = await this.organizationService.listOrganizations(
+                        userId,
+                        { limit: 10 },
+                        "member",
+                    );
                     for (const organization of organizations) {
                         const hasPermission = await this.auth.hasPermissionOnOrganization(
                             userId,


### PR DESCRIPTION
## Description
We still establish a websocket connection in some cases. For collaborators, this generates this noisy error because we fail to register a listener for every org the user is member of.
This PR fixes this error by using the appropriate service method instead of an outdated one.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1323

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
