### PR TITLE
Create SBOMs and scan for vulnerablities

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -309,35 +309,79 @@ jobs:
           GITHUB_USER: roboquat
           GITHUB_EMAIL: roboquat@gitpod.io
           VERSION: ${{ needs.configuration.outputs.version }}
-
-  trivy-scan:
-    name: "Scan Images for Vulnerabilities"
-    needs:
-      - configuration
-      - build-gitpod
-      - create-runner
-    runs-on: ${{ needs.create-runner.outputs.label }}
-    container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Environment
-        uses: ./.github/actions/setup-environment
-        with:
-          identity_provider: ${{ github.ref == 'refs/heads/main' && secrets.CORE_DEV_PROVIDER || secrets.DEV_PREVIEW_PROVIDER }}
-          service_account: ${{ github.ref == 'refs/heads/main' && secrets.CORE_DEV_SA || secrets.DEV_PREVIEW_SA }}
-          leeway_segment_key: ${{ secrets.LEEWAY_SEGMENT_KEY }}
-      - name: Scan Images for Vulnerabilities
+      - name: Scan for Vulnerabilities
+        id: scan
         shell: bash
         env:
-          INSTALLER_IMAGE_BASE_REPO: ${{needs.configuration.outputs.image_repo_base}}
-        run: |
-          ./scripts/trivy/trivy-scan-images.sh ${{ needs.configuration.outputs.version }} CRITICAL
-          exit $?
+          NODE_OPTIONS: "--max_old_space_size=4096"
+          JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
+          VERSION: ${{needs.configuration.outputs.version}}
+          PR_NO_CACHE: ${{needs.configuration.outputs.build_no_cache}}
+          PR_NO_TEST: ${{needs.configuration.outputs.build_no_test}}
+          NPM_AUTH_TOKEN: "${{ secrets.NPM_AUTH_TOKEN }}"
+          PUBLISH_TO_NPM: ${{ needs.configuration.outputs.publish_to_npm == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
+          JB_MARKETPLACE_PUBLISH_TOKEN: "${{ secrets.JB_MARKETPLACE_PUBLISH_TOKEN }}"
+          PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
+          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+          LEEWAY_REMOTE_CACHE_BUCKET: ${{needs.configuration.outputs.leeway_cache_bucket}}
+          IMAGE_REPO_BASE: ${{needs.configuration.outputs.image_repo_base}}/build
 
+          # SCM tokens for integration tests
+          GITPOD_TEST_TOKEN_BITBUCKET: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET }}"
+          GITPOD_TEST_TOKEN_BITBUCKET_SERVER: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET_SERVER }}"
+          GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE }}"
+          GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ }}"
+          GITPOD_TEST_TOKEN_GITHUB: "${{ secrets.GITPOD_TEST_TOKEN_GITHUB }}"
+          GITPOD_TEST_TOKEN_GITLAB: "${{ secrets.GITPOD_TEST_TOKEN_GITLAB }}"
+          GITPOD_TEST_TOKEN_AZURE_DEVOPS: "${{ secrets.GITPOD_TEST_TOKEN_AZURE_DEVOPS }}"
+        run: |
+          [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
+          [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""
+          [[ "${PUBLISH_TO_NPM}" = 'true' ]] && NPM_PUBLISH_TRIGGER=$(date +%s%3N) || NPM_PUBLISH_TRIGGER="false"
+
+          sboms_dir=$(mktemp -d)
+          CI= leeway sbom export --with-dependencies --output-dir "$sboms_dir" \
+            -Dversion=$VERSION \
+            --docker-build-options network=host \
+            --max-concurrent-tasks 1 \
+            -DlocalAppVersion=$VERSION \
+            -DpublishToNPM="${PUBLISH_TO_NPM}" \
+            -DnpmPublishTrigger="${NPM_PUBLISH_TRIGGER}" \
+            -DpublishToJBMarketplace="${PUBLISH_TO_JBPM}" \
+            -DimageRepoBase=$IMAGE_REPO_BASE
+
+          scans_dir=$(mktemp -d)
+          CI= leeway sbom scan --with-dependencies --output-dir "$scans_dir" \
+            -Dversion=$VERSION \
+            --docker-build-options network=host \
+            --max-concurrent-tasks 1 \
+            -DlocalAppVersion=$VERSION \
+            -DpublishToNPM="${PUBLISH_TO_NPM}" \
+            -DnpmPublishTrigger="${NPM_PUBLISH_TRIGGER}" \
+            -DpublishToJBMarketplace="${PUBLISH_TO_JBPM}" \
+            -DimageRepoBase=$IMAGE_REPO_BASE
+
+          {
+            echo "leeway_sboms_dir=$sboms_dir"
+            echo "leeway_vulnerability_reports_dir=$scans_dir"
+          } >> $GITHUB_OUTPUT
+
+          cat "$scans_dir/vulnerability-summary.md" >> $GITHUB_STEP_SUMMARY
+      - name: Upload SBOMs
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: sboms
+          path: ${{ steps.scan.outputs.leeway_sboms_dir }}
+      - name: Upload vulnerability reports
+        uses: actions/upload-artifact@v4
+        if: success()
+        with:
+          name: vulnerability-reports
+          path: ${{ steps.scan.outputs.leeway_vulnerability_reports_dir }}
   install-app:
     runs-on: ${{ needs.create-runner.outputs.label }}
-    needs: [ configuration, build-gitpod, trivy-scan, create-runner ]
+    needs: [ configuration, build-gitpod, create-runner ]
     if: ${{ needs.configuration.outputs.is_main_branch == 'true' }}
     strategy:
       fail-fast: false
@@ -375,7 +419,6 @@ jobs:
       - configuration
       - build-previewctl
       - build-gitpod
-      - trivy-scan
       - infrastructure
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
@@ -523,7 +566,6 @@ jobs:
       - build-previewctl
       - infrastructure
       - build-gitpod
-      - trivy-scan
       - install-app
       - install
       - monitoring

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -329,27 +329,11 @@ jobs:
         id: scan
         shell: bash
         env:
-          NODE_OPTIONS: "--max_old_space_size=4096"
-          JAVA_HOME: /home/gitpod/.sdkman/candidates/java/current
           VERSION: ${{needs.configuration.outputs.version}}
-          PR_NO_CACHE: ${{needs.configuration.outputs.build_no_cache}}
-          PR_NO_TEST: ${{needs.configuration.outputs.build_no_test}}
-          NPM_AUTH_TOKEN: "${{ secrets.NPM_AUTH_TOKEN }}"
           PUBLISH_TO_NPM: ${{ needs.configuration.outputs.publish_to_npm == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
-          JB_MARKETPLACE_PUBLISH_TOKEN: "${{ secrets.JB_MARKETPLACE_PUBLISH_TOKEN }}"
           PUBLISH_TO_JBPM: ${{ needs.configuration.outputs.publish_to_jbmp == 'true'  || needs.configuration.outputs.is_main_branch == 'true' }}
-          CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
           LEEWAY_REMOTE_CACHE_BUCKET: ${{needs.configuration.outputs.leeway_cache_bucket}}
           IMAGE_REPO_BASE: ${{needs.configuration.outputs.image_repo_base}}/build
-
-          # SCM tokens for integration tests
-          GITPOD_TEST_TOKEN_BITBUCKET: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET }}"
-          GITPOD_TEST_TOKEN_BITBUCKET_SERVER: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET_SERVER }}"
-          GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET_SERVER_WRITE }}"
-          GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ: "${{ secrets.GITPOD_TEST_TOKEN_BITBUCKET_SERVER_READ }}"
-          GITPOD_TEST_TOKEN_GITHUB: "${{ secrets.GITPOD_TEST_TOKEN_GITHUB }}"
-          GITPOD_TEST_TOKEN_GITLAB: "${{ secrets.GITPOD_TEST_TOKEN_GITLAB }}"
-          GITPOD_TEST_TOKEN_AZURE_DEVOPS: "${{ secrets.GITPOD_TEST_TOKEN_AZURE_DEVOPS }}"
         run: |
           [[ "$PR_NO_CACHE" = "true" ]] && CACHE="none"       || CACHE="remote"
           [[ "$PR_NO_TEST"  = "true" ]] && TEST="--dont-test" || TEST=""

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,17 @@ on:
         type: string
         description: "Whether to recreate the VM"
         default: "false"
+      simulate_scheduled_run:
+        required: false
+        type: boolean
+        description: "Simulate a scheduled run"
+        default: false
+  schedule:
+    # Run at midnight UTC every day
+    # Purpose: This scheduled run performs regular vulnerability scans of the codebase
+    # and sends notifications to Slack when new critical vulnerabilities are found.
+    # The scan results are used to maintain security standards and address issues promptly.
+    - cron: '0 0 * * *'
 
 jobs:
   create-runner:
@@ -36,6 +47,7 @@ jobs:
       cancel-in-progress: true
     outputs:
       is_main_branch: ${{ (github.head_ref || github.ref) == 'refs/heads/main' }}
+      is_scheduled_run: ${{ github.event_name == 'schedule' || inputs.simulate_scheduled_run == true }}
       version: ${{ steps.branches.outputs.sanitized-branch-name }}-gha.${{github.run_number}}
       preview_enable: ${{ contains( steps.pr-details.outputs.pr_body, '[x] /werft with-preview') || (steps.output.outputs.with_integration_tests != '') }}
       preview_name: ${{ github.head_ref || github.ref_name }}
@@ -98,7 +110,8 @@ jobs:
     name: Build previewctl
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
-      (needs.configuration.outputs.preview_enable == 'true')
+      (needs.configuration.outputs.preview_enable == 'true') &&
+      (needs.configuration.outputs.is_scheduled_run != 'true')
     needs: [ configuration, create-runner ]
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-previewctl
@@ -126,7 +139,8 @@ jobs:
     if: |
       (needs.configuration.outputs.pr_no_diff_skip != 'true') &&
       (needs.configuration.outputs.preview_enable == 'true') &&
-      (needs.configuration.outputs.is_main_branch != 'true')
+      (needs.configuration.outputs.is_main_branch != 'true') &&
+      (needs.configuration.outputs.is_scheduled_run != 'true')
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
@@ -154,6 +168,8 @@ jobs:
     name: Build Gitpod
     needs: [ configuration, create-runner ]
     runs-on: ${{ needs.create-runner.outputs.label }}
+    outputs:
+      affected_packages: ${{ steps.check_vulnerabilities.outputs.affected_packages }}
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-build-gitpod
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
@@ -299,7 +315,7 @@ jobs:
 
           exit $RESULT
       - name: Tag the release
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/main' && needs.configuration.outputs.is_scheduled_run != 'true'
         run: |
           git config --global user.name $GITHUB_USER
           git config --global user.email $GITHUB_EMAIL
@@ -359,7 +375,7 @@ jobs:
             -DpublishToNPM="${PUBLISH_TO_NPM}" \
             -DnpmPublishTrigger="${NPM_PUBLISH_TRIGGER}" \
             -DpublishToJBMarketplace="${PUBLISH_TO_JBPM}" \
-            -DimageRepoBase=$IMAGE_REPO_BASE
+            -DimageRepoBase=$IMAGE_REPO_BASE || RESULT=$?
 
           {
             echo "leeway_sboms_dir=$sboms_dir"
@@ -367,22 +383,41 @@ jobs:
           } >> $GITHUB_OUTPUT
 
           cat "$scans_dir/vulnerability-summary.md" >> $GITHUB_STEP_SUMMARY
+
+          exit $RESULT
+      - name: Check for Critical Vulnerabilities
+        if: needs.configuration.outputs.is_scheduled_run == 'true'
+        id: check_vulnerabilities
+        shell: bash
+        run: |
+          # Parse vulnerability-stats.json from the scans directory
+          CRITICAL_PACKAGES=$(jq -r '.[] | select(.critical > 0) | "\(.name): \(.critical) critical vulnerabilities"' "${{ steps.scan.outputs.leeway_vulnerability_reports_dir }}/vulnerability-stats.json")
+
+          # If there are critical packages, list them and fail the build
+          if [ -n "$CRITICAL_PACKAGES" ]; then
+            echo "::error::Critical vulnerabilities found in the following packages:"
+            echo "$CRITICAL_PACKAGES" | tee -a $GITHUB_STEP_SUMMARY
+            echo "affected_packages<<EOF" >> $GITHUB_OUTPUT
+            echo "$CRITICAL_PACKAGES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+            exit 1
+          else
+            echo "No critical vulnerabilities found."
+          fi
       - name: Upload SBOMs
         uses: actions/upload-artifact@v4
-        if: success()
         with:
           name: sboms
           path: ${{ steps.scan.outputs.leeway_sboms_dir }}
       - name: Upload vulnerability reports
         uses: actions/upload-artifact@v4
-        if: success()
         with:
           name: vulnerability-reports
           path: ${{ steps.scan.outputs.leeway_vulnerability_reports_dir }}
   install-app:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [ configuration, build-gitpod, create-runner ]
-    if: ${{ needs.configuration.outputs.is_main_branch == 'true' }}
+    if: ${{ needs.configuration.outputs.is_main_branch == 'true' && needs.configuration.outputs.is_scheduled_run != 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -421,6 +456,7 @@ jobs:
       - build-gitpod
       - infrastructure
       - create-runner
+    if: needs.configuration.outputs.is_scheduled_run != 'true'
     runs-on: ${{ needs.create-runner.outputs.label }}
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
@@ -471,7 +507,7 @@ jobs:
     name: "Install Monitoring Satellite"
     needs: [ infrastructure, build-previewctl, create-runner ]
     runs-on: ${{ needs.create-runner.outputs.label }}
-    if: needs.configuration.outputs.with_monitoring == 'true'
+    if: needs.configuration.outputs.with_monitoring == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-monitoring
       cancel-in-progress: true
@@ -502,7 +538,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
-    if: needs.configuration.outputs.with_integration_tests != ''
+    if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test
       cancel-in-progress: true
@@ -532,7 +568,7 @@ jobs:
       - configuration
       - build-gitpod
       - create-runner
-    if: needs.configuration.outputs.is_main_branch == 'true'
+    if: needs.configuration.outputs.is_main_branch == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     uses: ./.github/workflows/workspace-integration-tests.yml
     with:
       version: ${{ needs.configuration.outputs.version }}
@@ -544,7 +580,7 @@ jobs:
       - configuration
       - build-gitpod
       - create-runner
-    if: needs.configuration.outputs.is_main_branch == 'true'
+    if: needs.configuration.outputs.is_main_branch == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     uses: ./.github/workflows/code-updates.yml
     secrets: inherit
 
@@ -554,9 +590,30 @@ jobs:
       - configuration
       - build-gitpod
       - create-runner
-    if: needs.configuration.outputs.is_main_branch == 'true'
+    if: needs.configuration.outputs.is_main_branch == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     uses: ./.github/workflows/jetbrains-updates.yml
     secrets: inherit
+
+  notify-scheduled-failure:
+    name: "Notify on scheduled run failure"
+    if: needs.configuration.outputs.is_scheduled_run == 'true' && failure()
+    needs:
+      - configuration
+      - build-gitpod
+      - workspace-integration-tests-main
+      - ide-code-updates
+      - ide-jb-updates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.WORKSPACE_SLACK_WEBHOOK }}
+          SLACK_ICON_EMOJI: ":x:"
+          SLACK_USERNAME: "Scheduled Build"
+          SLACK_COLOR: "danger"
+          SLACK_MESSAGE: "⚠️ Security Alert: Daily vulnerability scan detected critical vulnerabilities in the following packages:\n${{ needs.build-gitpod.outputs.affected_packages }}"
+          SLACK_FOOTER: "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Workflow Logs>"
 
   delete-runner:
     if: always()
@@ -570,6 +627,7 @@ jobs:
       - install
       - monitoring
       - integration-test
+      - notify-scheduled-failure
     uses: gitpod-io/gce-github-runner/.github/workflows/delete-vm.yml@main
     secrets:
       gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -340,7 +340,7 @@ jobs:
           [[ "${PUBLISH_TO_NPM}" = 'true' ]] && NPM_PUBLISH_TRIGGER=$(date +%s%3N) || NPM_PUBLISH_TRIGGER="false"
 
           sboms_dir=$(mktemp -d)
-          CI= leeway sbom export --with-dependencies --output-dir "$sboms_dir" \
+          CI= leeway sbom export components:needs-vuln-scan --with-dependencies --output-dir "$sboms_dir" \
             -Dversion=$VERSION \
             --docker-build-options network=host \
             --max-concurrent-tasks 1 \
@@ -351,7 +351,7 @@ jobs:
             -DimageRepoBase=$IMAGE_REPO_BASE
 
           scans_dir=$(mktemp -d)
-          CI= leeway sbom scan --with-dependencies --output-dir "$scans_dir" \
+          CI= leeway sbom scan components:needs-vuln-scan --with-dependencies --output-dir "$scans_dir" \
             -Dversion=$VERSION \
             --docker-build-options network=host \
             --max-concurrent-tasks 1 \

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     steps:
       - uses: actions/checkout@v4
       - name: Setup Environment
@@ -188,7 +188,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
       env:
         DB_HOST: "mysql"
         DB_PORT: "23306"
@@ -537,7 +537,7 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -131,7 +131,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -23,7 +23,7 @@ jobs:
   update-jetbrains:
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     needs: [ create-runner ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -39,7 +39,7 @@ jobs:
       gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   jetbrains-smoke-test-linux:
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     steps:

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -99,7 +99,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}
       count: ${{ steps.set-matrix.outputs.count }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -166,7 +166,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
     steps:
       - uses: actions/checkout@v4
       - name: Integration Test

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32399
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32507
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -33,6 +33,18 @@ provenance:
   slsa: true
 sbom:
   enabled: true
+  ignoreVulnerabilities:
+    - vulnerability: GHSA-fx4w-v43j-vc45
+      reason: |
+        This vulnerability in TypeORM's findOne / findOneOrFail functions can improperly interpret a crafted JSON object
+        and concatenate it into raw SQL, potentially allowing SQL injection attacks.
+
+        In Gitpod’s usage, TypeORM is not exposed to arbitrary user input. For example, DB migrations run preset queries;
+        the server/bridge code does not hand raw JSON from external sources to findOne. Therefore, there is no path for
+        injecting malicious JSON into a query, rendering the vulnerability non-exploitable.
+    - vulnerability: GHSA-2jcg-qqmg-46q6
+      reason: |
+        This is a false positive. See https://github.com/browserify/resolve/issues/303
 environmentManifest:
   - name: "go"
     command: ["sh", "-c", "go version | sed s/arm/amd/"]

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -31,6 +31,8 @@ defaultArgs:
 provenance:
   enabled: true
   slsa: true
+sbom:
+  enabled: true
 environmentManifest:
   - name: "go"
     command: ["sh", "-c", "go version | sed s/arm/amd/"]

--- a/components/BUILD.yaml
+++ b/components/BUILD.yaml
@@ -9,6 +9,7 @@ packages:
       - version
     deps:
       - :all-docker
+      - :needs-vuln-scan
       - :docker-versions
       - :publish-api
       - dev:all-app
@@ -95,6 +96,33 @@ packages:
         - ["sh", "-c", "echo \"version: ${version}\" >> versions.yaml"]
         - ["sh", "-c", "dev-version-manifest--app/version-manifest >> versions.yaml"]
         - ["sh", "-c", "rm -r components* dev-*"]
+  - name: needs-vuln-scan
+    type: generic
+    deps:
+      - components/blobserve:docker
+      - components/content-service:docker
+      - components/dashboard:docker
+      - components/docker-up:docker
+      - components/ee/agent-smith:docker
+      - components/gitpod-db:docker
+      - components/ide-metrics:docker
+      - components/ide-proxy:docker
+      - components/ide-service:docker
+      - components/image-builder-bob:docker
+      - components/image-builder-mk3:docker
+      - components/node-labeler:docker
+      - components/openvsx-proxy:docker
+      - components/proxy:docker
+      - components/public-api-server:docker
+      - components/registry-facade:docker
+      - components/server:docker
+      - components/service-waiter:docker
+      - components/supervisor:docker
+      - components/workspacekit:docker
+      - components/ws-daemon:docker
+      - components/ws-manager-bridge:docker
+      - components/ws-manager-mk2:docker
+      - components/ws-proxy:docker
   - name: publish-api
     type: generic
     deps:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

This PR improves our vulnerability detection by implementing daily scans and optimizing the scanning process.

## Changes

- **Daily Vulnerability Scanning**: Added scheduled workflow (midnight UTC) with Slack notifications for critical findings
- **Optimized Scanning**: Created `needs-vuln-scan` target to focus on relevant packages only
- **Vulnerability Management**: Added ignore rules with documentation for false positives
- **SBOM Integration**: Enabled SBOM generation and artifact uploads
- **Dev Environment**: Updated development image and related workflows

The implementation replaces direct Trivy scanning with Leeway's built-in SBOM capabilities for better build system integration. When vulnerabilities are detected, the workflow automatically notifies us on Slack.


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/CLC-1339/sbom-vuln-scanning-on-gitpod-iogitpod

## How to test
<!-- Provide steps to test this PR -->
Run the workflow with "simulate scheduled" enabled. If you remove the ignore rules, you get a Slack message like this: https://gitpod.slack.com/archives/C07270E825R/p1746699798336559

![image](https://github.com/user-attachments/assets/0fad9445-494a-4ad7-b93f-66443ca75fc2)




#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
