### PR TITLE
[VS Code Browser] Build stable code `1.100.0`

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -7,8 +7,8 @@ defaultArgs:
   publishToNPM: true
   publishToJBMarketplace: true
   localAppVersion: unknown
-  codeCommit: ec2e536434cea064d6864b259015fefdaa07a74b
-  codeVersion: 1.99.3
+  codeCommit: 364780d2582153e210bd46c0246c5fc8bad1d4e0
+  codeVersion: 1.100.0
   codeQuality: stable
   codeWebExtensionCommit: 3953e8160fffa97dd4a4509542b4bf7ff9b704cd
   xtermCommit: d547d4ff4590b66c3ea24342fc62e3afcf6b77bc


### PR DESCRIPTION
## Description

Build code version `1.100.0` (`364780d2582153e210bd46c0246c5fc8bad1d4e0`)

## How to test

- Switch to VS Code Browser Insiders in settings.
- Start a workspace.
- Test the following:
  - [ ] terminals are preserved and resized properly between window reloads
  - [ ] WebViews are working
  - [ ] extension host process: check language smartness and debugging
  - [ ] extension management (installing/uninstalling)
  - [ ] install the [VIM extension](https://open-vsx.org/extension/vscodevim/vim) to test web extensions
  - that user data is synced across workspaces as well as on workspace restarts, especially for extensions
    - [ ] extensions from `.gitpod.yml` are not installed as sync
    - [ ] extensions installed as sync are actually synced to all new workspaces
  - [ ] settings should not contain any mentions of MS telemetry
  - [ ] WebSockets and workers are properly proxied
    - [ ] diff editor should be operable
    - [ ] trigger reconnection with `window.WebSocket.disconnectWorkspace()`, check that old WebSockets are closed and new opened of the same amount
  - [ ] workspace specific commands should work, i.e. <kbd>F1</kbd> → type <kbd>Gitpod</kbd>
  - [ ] that a PR view is preloaded when opening a PR URL
  - [ ] test `gp open` and `gp preview`
  - [ ] test open in VS Code Desktop, check `gp open` and `gp preview` in task/user terminals
  - [ ] telemetry data like `vscode_extension_gallery` is collected in [Segment](https://app.segment.com/gitpod/sources/staging_trusted/debugger)

### Preview status
gitpod:summary

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment
- [x] /werft with-large-vm