### PR TITLE
[gitpod-protocol] handle host:port:token for getGitpodImageAuth

### DIFF
--- a/components/gitpod-protocol/src/protocol.spec.ts
+++ b/components/gitpod-protocol/src/protocol.spec.ts
@@ -182,7 +182,7 @@ class TestEnvVar {
         const envVars: EnvVarWithValue[] = [
             {
                 name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
-                value: "justhost,hostonly:,:credonly,:::,",
+                value: "justhost,hostonly:,:credonly,:::,:,",
             },
         ];
         const result = EnvVar.getGitpodImageAuth(envVars);
@@ -199,7 +199,7 @@ class TestEnvVar {
         ];
         const result = EnvVar.getGitpodImageAuth(envVars);
         expect(result.size).to.equal(2);
-        expect(result.get("my-registry.foo.net ")).to.equal(" Zm9vOmJhcg==");
+        expect(result.get("my-registry.foo.net")).to.equal("Zm9vOmJhcg==");
         expect(result.get("my-registry2.bar.com")).to.equal("YWJjOmRlZg==");
     }
 }

--- a/components/gitpod-protocol/src/protocol.spec.ts
+++ b/components/gitpod-protocol/src/protocol.spec.ts
@@ -6,7 +6,7 @@
 
 import { suite, test } from "@testdeck/mocha";
 import * as chai from "chai";
-import { SSHPublicKeyValue } from ".";
+import { SSHPublicKeyValue, EnvVar, EnvVarWithValue } from ".";
 
 const expect = chai.expect;
 
@@ -94,4 +94,120 @@ class TestSSHPublicKeyValue {
         ).to.throw("Key is invalid");
     }
 }
-module.exports = new TestSSHPublicKeyValue(); // Only to circumvent no usage warning :-/
+
+@suite
+class TestEnvVar {
+    @test
+    public testGetGitpodImageAuth_empty() {
+        const result = EnvVar.getGitpodImageAuth([]);
+        expect(result.size).to.equal(0);
+    }
+
+    @test
+    public testGetGitpodImageAuth_noRelevantVar() {
+        const envVars: EnvVarWithValue[] = [{ name: "OTHER_VAR", value: "some_value" }];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(0);
+    }
+
+    @test
+    public testGetGitpodImageAuth_singleEntryNoPort() {
+        const envVars: EnvVarWithValue[] = [
+            {
+                name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
+                value: "my-registry.foo.net:Zm9vOmJhcg==",
+            },
+        ];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(1);
+        expect(result.get("my-registry.foo.net")).to.equal("Zm9vOmJhcg==");
+    }
+
+    @test
+    public testGetGitpodImageAuth_singleEntryWithPort() {
+        const envVars: EnvVarWithValue[] = [
+            {
+                name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
+                value: "my-registry.foo.net:5000:Zm9vOmJhcg==",
+            },
+        ];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(1);
+        expect(result.get("my-registry.foo.net:5000")).to.equal("Zm9vOmJhcg==");
+    }
+
+    @test
+    public testGetGitpodImageAuth_multipleEntries() {
+        const envVars: EnvVarWithValue[] = [
+            {
+                name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
+                value: "my-registry.foo.net:Zm9vOmJhcg==,my-registry2.bar.com:YWJjOmRlZg==",
+            },
+        ];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(2);
+        expect(result.get("my-registry.foo.net")).to.equal("Zm9vOmJhcg==");
+        expect(result.get("my-registry2.bar.com")).to.equal("YWJjOmRlZg==");
+    }
+
+    @test
+    public testGetGitpodImageAuth_multipleEntriesWithPortAndMalformed() {
+        const envVars: EnvVarWithValue[] = [
+            {
+                name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
+                value: "my-registry.foo.net:5000:Zm9vOmJhcg==,my-registry2.bar.com:YWJjOmRlZg==,invalidEntry,another.host:anothercred",
+            },
+        ];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(3);
+        expect(result.get("my-registry2.bar.com")).to.equal("YWJjOmRlZg==");
+        expect(result.get("another.host")).to.equal("anothercred");
+        expect(result.get("my-registry.foo.net:5000")).to.equal("Zm9vOmJhcg==");
+    }
+
+    @test
+    public testGetGitpodImageAuth_emptyValue() {
+        const envVars: EnvVarWithValue[] = [
+            {
+                name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
+                value: "",
+            },
+        ];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(0);
+    }
+
+    @test
+    public testGetGitpodImageAuth_malformedEntries() {
+        const envVars: EnvVarWithValue[] = [
+            {
+                name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
+                value: "justhost,hostonly:,:credonly,:::,",
+            },
+        ];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(0);
+    }
+
+    @test
+    public testGetGitpodImageAuth_entriesWithSpaces() {
+        const envVars: EnvVarWithValue[] = [
+            {
+                name: EnvVar.GITPOD_IMAGE_AUTH_ENV_VAR_NAME,
+                value: " my-registry.foo.net : Zm9vOmJhcg== ,  my-registry2.bar.com:YWJjOmRlZg==  ",
+            },
+        ];
+        const result = EnvVar.getGitpodImageAuth(envVars);
+        expect(result.size).to.equal(2);
+        expect(result.get("my-registry.foo.net ")).to.equal(" Zm9vOmJhcg==");
+        expect(result.get("my-registry2.bar.com")).to.equal("YWJjOmRlZg==");
+    }
+}
+
+// Exporting both test suites
+const testSSHPublicKeyValue = new TestSSHPublicKeyValue();
+const testEnvVar = new TestEnvVar();
+module.exports = {
+    testSSHPublicKeyValue,
+    testEnvVar,
+};

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -293,11 +293,30 @@ export namespace EnvVar {
             return res;
         }
 
-        (imageAuth.value || "")
-            .split(",")
-            .map((e) => e.trim().split(":"))
-            .filter((e) => e.length == 2)
-            .forEach((e) => res.set(e[0], e[1]));
+        (imageAuth.value || "").split(",").forEach((entry) => {
+            const parts = entry.trim().split(":");
+            if (parts.length === 2) {
+                // host:token
+                const host = parts[0];
+                const token = parts[1];
+                if (host && token && host.length > 0 && token.length > 0) {
+                    res.set(host, token);
+                }
+            } else if (parts.length === 3) {
+                // host:port:token
+                const hostWithPort = `${parts[0]}:${parts[1]}`;
+                const token = parts[2];
+                if (hostWithPort && token && hostWithPort.length > 0 && token.length > 0) {
+                    res.set(hostWithPort, token);
+                }
+            }
+        });
+
+        // (imageAuth.value || "")
+        //     .split(",")
+        //     .map((e) => e.trim().split(":"))
+        //     .filter((e) => e.length == 2)
+        //     .forEach((e) => res.set(e[0], e[1]));
         return res;
     }
 }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -307,7 +307,8 @@ export namespace EnvVar {
             .split(",")
             .map((e) => e.trim().split(":"))
             .forEach((parts) => {
-                getHost(parts) !== "" ? res.set(getHost(parts), parts[parts.length - 1]) : null;
+                const host = getHost(parts);
+                host !== "" ? res.set(host, parts[parts.length - 1]) : null;
             });
 
         return res;

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -293,21 +293,22 @@ export namespace EnvVar {
             return res;
         }
 
-        (imageAuth.value || "").split(",").forEach((entry) => {
-            const parts = entry.trim().split(":");
-            if (parts.length === 2) {
-                const [host, token] = parts;
-                if (host && token) {
-                    res.set(host, token);
-                }
-            } else if (parts.length === 3) {
-                const [host, port, token] = parts;
-                const hostWithPort = `${host}:${port}`;
-                if (hostWithPort && token) {
-                    res.set(hostWithPort, token);
-                }
+        // Returns a host value, which can include port, if token also has length.
+        const getHost = (parts: string[]): string => {
+            if (parts.length === 2 && parts[0] && parts[1]) {
+                return parts[0];
+            } else if (parts.length === 3 && parts[0] && parts[1] && parts[2]) {
+                return `${parts[0]}:${parts[1]}`;
             }
-        });
+            return "";
+        };
+
+        (imageAuth.value || "")
+            .split(",")
+            .map((e) => e.trim().split(":"))
+            .forEach((parts) => {
+                getHost(parts) !== "" ? res.set(getHost(parts), parts[parts.length - 1]) : null;
+            });
 
         return res;
     }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -296,17 +296,14 @@ export namespace EnvVar {
         (imageAuth.value || "").split(",").forEach((entry) => {
             const parts = entry.trim().split(":");
             if (parts.length === 2) {
-                // host:token
-                const host = parts[0];
-                const token = parts[1];
-                if (host && token && host.length > 0 && token.length > 0) {
+                const [host, token] = parts;
+                if (host && token) {
                     res.set(host, token);
                 }
             } else if (parts.length === 3) {
-                // host:port:token
-                const hostWithPort = `${parts[0]}:${parts[1]}`;
-                const token = parts[2];
-                if (hostWithPort && token && hostWithPort.length > 0 && token.length > 0) {
+                const [host, port, token] = parts;
+                const hostWithPort = `${host}:${port}`;
+                if (hostWithPort && token) {
                     res.set(hostWithPort, token);
                 }
             }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -307,12 +307,7 @@ export namespace EnvVar {
 
         (imageAuth.value || "")
             .split(",")
-            .map((e) =>
-                e
-                    .trim()
-                    .split(":")
-                    .map((part) => part.trim()),
-            )
+            .map((e) => e.split(":").map((part) => part.trim()))
             .forEach((parts) => {
                 const parsed = parse(parts);
                 if (parsed) {

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -312,11 +312,6 @@ export namespace EnvVar {
             }
         });
 
-        // (imageAuth.value || "")
-        //     .split(",")
-        //     .map((e) => e.trim().split(":"))
-        //     .filter((e) => e.length == 2)
-        //     .forEach((e) => res.set(e[0], e[1]));
         return res;
     }
 }

--- a/components/gitpod-protocol/src/protocol.ts
+++ b/components/gitpod-protocol/src/protocol.ts
@@ -293,22 +293,31 @@ export namespace EnvVar {
             return res;
         }
 
-        // Returns a host value, which can include port, if token also has length.
-        const getHost = (parts: string[]): string => {
-            if (parts.length === 2 && parts[0] && parts[1]) {
-                return parts[0];
-            } else if (parts.length === 3 && parts[0] && parts[1] && parts[2]) {
-                return `${parts[0]}:${parts[1]}`;
+        const parse = (parts: string[]): { host: string; auth: string } | undefined => {
+            if (parts.some((e) => e === "")) {
+                return undefined;
             }
-            return "";
+            if (parts.length === 2) {
+                return { host: parts[0], auth: parts[1] };
+            } else if (parts.length === 3) {
+                return { host: `${parts[0]}:${parts[1]}`, auth: parts[2] };
+            }
+            return undefined;
         };
 
         (imageAuth.value || "")
             .split(",")
-            .map((e) => e.trim().split(":"))
+            .map((e) =>
+                e
+                    .trim()
+                    .split(":")
+                    .map((part) => part.trim()),
+            )
             .forEach((parts) => {
-                const host = getHost(parts);
-                host !== "" ? res.set(host, parts[parts.length - 1]) : null;
+                const parsed = parse(parts);
+                if (parsed) {
+                    res.set(parsed.host, parsed.auth);
+                }
             });
 
         return res;

--- a/components/image-builder-bob/pkg/proxy/auth.go
+++ b/components/image-builder-bob/pkg/proxy/auth.go
@@ -53,21 +53,30 @@ func (a MapAuthorizer) Authorize(host string) (user, pass string, err error) {
 	}()
 
 	// Strip any port from the host if present
-	host = strings.Split(host, ":")[0]
+	hostSlice := strings.Split(host, ":")
+	portStrippedHost := hostSlice[0]
+	var port string
+	if len(hostSlice) > 1 {
+		port = hostSlice[1]
+	}
 
 	explicitHostMatcher := func() (authConfig, bool) {
-		res, ok := a[host]
+		eval := host
+		if port == "443" {
+			eval = portStrippedHost
+		}
+		res, ok := a[eval]
 		return res, ok
 	}
 	ecrHostMatcher := func() (authConfig, bool) {
-		if isECRRegistry(host) {
+		if isECRRegistry(portStrippedHost) {
 			res, ok := a[DummyECRRegistryDomain]
 			return res, ok
 		}
 		return authConfig{}, false
 	}
 	dockerHubHostMatcher := func() (authConfig, bool) {
-		if isDockerHubRegistry(host) {
+		if isDockerHubRegistry(portStrippedHost) {
 			res, ok := a["docker.io"]
 			return res, ok
 		}

--- a/components/image-builder-bob/pkg/proxy/auth_test.go
+++ b/components/image-builder-bob/pkg/proxy/auth_test.go
@@ -32,7 +32,7 @@ func TestAuthorize(t *testing.T) {
 			},
 		},
 		{
-			name:        "docker auth format - valid credentials - host with port",
+			name:        "docker auth format - valid credentials - host with :443 port",
 			constructor: NewAuthorizerFromDockerEnvVar,
 			input:       `{"auths": {"registry.example.com": {"auth": "dXNlcjpwYXNz"}}}`, // base64(user:pass)
 			testHost:    "registry.example.com:443",
@@ -108,6 +108,26 @@ func TestAuthorize(t *testing.T) {
 			expected: expectation{
 				user: "",
 				pass: "",
+			},
+		},
+		{
+			name:        "Docker Hub",
+			constructor: NewAuthorizerFromEnvVar,
+			input:       `{"docker.io": {"auth": "dXNlcjpwYXNz"}}`,
+			testHost:    "registry-1.docker.io",
+			expected: expectation{
+				user: "user",
+				pass: "pass",
+			},
+		},
+		{
+			name:        "docker auth format - valid credentials - host with :5000 port",
+			constructor: NewAuthorizerFromDockerEnvVar,
+			input:       `{"auths": {"registry.example.com:5000": {"auth": "dXNlcjpwYXNz"}}}`, // base64(user:pass)
+			testHost:    "registry.example.com:5000",
+			expected: expectation{
+				user: "user",
+				pass: "pass",
 			},
 		},
 	}

--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -383,12 +383,14 @@ func (a AllowedAuthFor) additionalAuth(domain string) *Authentication {
 	dec, err := base64.StdEncoding.DecodeString(ath)
 	if err == nil {
 		segs := strings.Split(string(dec), ":")
-		if len(segs) > 1 {
-			res.Username = segs[0]
-			res.Password = strings.Join(segs[1:], ":")
+		numSegs := len(segs)
+
+		if numSegs > 1 {
+			res.Username = strings.Join(segs[:numSegs-1], ":")
+			res.Password = segs[numSegs-1]
 		}
 	} else {
-		log.Errorf("failed getting additional auth")
+		log.WithError(err).Warn("failed to decode base64 auth string in additionalAuth")
 	}
 	return res
 }

--- a/components/image-builder-mk3/pkg/auth/auth.go
+++ b/components/image-builder-mk3/pkg/auth/auth.go
@@ -390,7 +390,7 @@ func (a AllowedAuthFor) additionalAuth(domain string) *Authentication {
 			res.Password = segs[numSegs-1]
 		}
 	} else {
-		log.WithError(err).Warn("failed to decode base64 auth string in additionalAuth")
+		log.Errorf("failed getting additional auth")
 	}
 	return res
 }

--- a/components/image-builder-mk3/pkg/auth/auth_test.go
+++ b/components/image-builder-mk3/pkg/auth/auth_test.go
@@ -5,6 +5,7 @@
 package auth
 
 import (
+	"encoding/base64"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -26,6 +27,101 @@ func TestIsECRRegistry(t *testing.T) {
 
 			if diff := cmp.Diff(test.Expectation, act); diff != "" {
 				t.Errorf("isECRRegistry() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestAdditionalAuth(t *testing.T) {
+	tests := []struct {
+		name          string
+		domain        string
+		additionalMap map[string]string
+		expectedAuth  *Authentication
+	}{
+		{
+			name:   "standard host:token",
+			domain: "myregistry.com",
+			additionalMap: map[string]string{
+				"myregistry.com": base64.StdEncoding.EncodeToString([]byte("myregistry.com:mytoken")),
+			},
+			expectedAuth: &Authentication{
+				Username: "myregistry.com",
+				Password: "mytoken",
+				Auth:     base64.StdEncoding.EncodeToString([]byte("myregistry.com:mytoken")),
+			},
+		},
+		{
+			name:   "buggy host:port:token",
+			domain: "myregistry.com:5000",
+			additionalMap: map[string]string{
+				"myregistry.com:5000": base64.StdEncoding.EncodeToString([]byte("myregistry.com:5000:mytoken")),
+			},
+			expectedAuth: &Authentication{
+				Username: "myregistry.com:5000",
+				Password: "mytoken",
+				Auth:     base64.StdEncoding.EncodeToString([]byte("myregistry.com:5000:mytoken")),
+			},
+		},
+		{
+			name:   "only username, no password/token (single segment)",
+			domain: "useronly.com",
+			additionalMap: map[string]string{
+				"useronly.com": base64.StdEncoding.EncodeToString([]byte("justauser")),
+			},
+			expectedAuth: &Authentication{
+				Auth: base64.StdEncoding.EncodeToString([]byte("justauser")),
+			},
+		},
+		{
+			name:   "empty auth string",
+			domain: "emptyauth.com",
+			additionalMap: map[string]string{
+				"emptyauth.com": base64.StdEncoding.EncodeToString([]byte("")),
+			},
+			expectedAuth: &Authentication{
+				Auth: base64.StdEncoding.EncodeToString([]byte("")),
+			},
+		},
+		{
+			name:          "domain not in map",
+			domain:        "notfound.com",
+			additionalMap: map[string]string{"someother.com": base64.StdEncoding.EncodeToString([]byte("someauth"))},
+			expectedAuth:  nil,
+		},
+		{
+			name:   "invalid base64 string",
+			domain: "invalidbase64.com",
+			additionalMap: map[string]string{
+				"invalidbase64.com": "!!!INVALID_BASE64!!!",
+			},
+			expectedAuth: &Authentication{
+				Auth: "!!!INVALID_BASE64!!!",
+			},
+		},
+		{
+			name:   "standard host:token where username in cred is different from domain key",
+			domain: "docker.io",
+			additionalMap: map[string]string{
+				"docker.io": base64.StdEncoding.EncodeToString([]byte("user1:pass1")),
+			},
+			expectedAuth: &Authentication{
+				Username: "user1",
+				Password: "pass1",
+				Auth:     base64.StdEncoding.EncodeToString([]byte("user1:pass1")),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			aaf := AllowedAuthFor{
+				Additional: tt.additionalMap,
+			}
+			actualAuth := aaf.additionalAuth(tt.domain)
+
+			if diff := cmp.Diff(tt.expectedAuth, actualAuth); diff != "" {
+				t.Errorf("additionalAuth() mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/components/supervisor/pkg/supervisor/docker.go
+++ b/components/supervisor/pkg/supervisor/docker.go
@@ -325,7 +325,7 @@ func insertCredentialsIntoConfig(imageAuth string) (int, error) {
 			registryIdentifier = parts[0] + ":" + parts[1]
 			token = parts[2]
 		default:
-			log.Warnf("authentication: skipping malformed credential entry (parts count %d not 2 or 3): '%s'", len(parts), hostCredentialsEntry)
+			log.Warnf("authentication: skipping credential (parts count %d not 2 or 3): '%s'", len(parts), hostCredentialsEntry)
 			continue
 		}
 		registryKey := registryIdentifier

--- a/components/supervisor/pkg/supervisor/docker.go
+++ b/components/supervisor/pkg/supervisor/docker.go
@@ -325,7 +325,6 @@ func insertCredentialsIntoConfig(imageAuth string) (int, error) {
 			host = parts[0] + ":" + parts[1]
 			token = parts[2]
 		default:
-			log.Warnf("authentication: skipping credential (parts count %d not 2 or 3): '%s'", len(parts), hostCredentialsEntry)
 			continue
 		}
 

--- a/components/supervisor/pkg/supervisor/docker.go
+++ b/components/supervisor/pkg/supervisor/docker.go
@@ -314,26 +314,26 @@ func insertCredentialsIntoConfig(imageAuth string) (int, error) {
 	authenticationPerHost := strings.Split(imageAuth, ",")
 	for _, hostCredentialsEntry := range authenticationPerHost {
 		parts := strings.SplitN(hostCredentialsEntry, ":", 3)
-		var registryIdentifier string
+		var host string
 		var token string
 
 		switch len(parts) {
 		case 2:
-			registryIdentifier = parts[0]
+			host = parts[0]
 			token = parts[1]
 		case 3:
-			registryIdentifier = parts[0] + ":" + parts[1]
+			host = parts[0] + ":" + parts[1]
 			token = parts[2]
 		default:
 			log.Warnf("authentication: skipping credential (parts count %d not 2 or 3): '%s'", len(parts), hostCredentialsEntry)
 			continue
 		}
-		registryKey := registryIdentifier
-		if registryIdentifier == "docker.io" || strings.HasSuffix(registryIdentifier, ".docker.io") {
-			registryKey = "https://index.docker.io/v1/"
+
+		if host == "docker.io" || strings.HasSuffix(host, ".docker.io") {
+			host = "https://index.docker.io/v1/"
 		}
 
-		authConfig.Auths[registryKey] = RegistryAuth{
+		authConfig.Auths[host] = RegistryAuth{
 			Auth: token,
 		}
 	}

--- a/components/supervisor/pkg/supervisor/docker.go
+++ b/components/supervisor/pkg/supervisor/docker.go
@@ -337,9 +337,7 @@ func insertCredentialsIntoConfig(imageAuth string) (int, error) {
 			Auth: token,
 		}
 	}
-
 	if len(authConfig.Auths) == 0 {
-		log.Warn("authentication: no valid credentials found after parsing all entries")
 		return 0, nil
 	}
 

--- a/components/supervisor/pkg/supervisor/docker_test.go
+++ b/components/supervisor/pkg/supervisor/docker_test.go
@@ -223,7 +223,7 @@ func TestInsertCredentialsIntoConfig_Parsing(t *testing.T) {
 				"reg2.com:6000": {"auth": "token2"},
 				"https://index.docker.io/v1/": {"auth": "token3"}
 			}`,
-			expectedCount: 4,
+			expectedCount: 3,
 		},
 		{
 			name:              "empty imageAuth string",
@@ -346,7 +346,7 @@ func TestInsertCredentialsIntoConfig_Parsing(t *testing.T) {
 			}
 
 			if len(expectedAuthsMap) == 0 {
-				if resultConfig.Auths != nil && len(resultConfig.Auths) != 0 {
+				if len(resultConfig.Auths) != 0 {
 					t.Errorf("Expected empty auths, but got: %v", resultConfig.Auths)
 				}
 			} else {

--- a/components/supervisor/pkg/supervisor/docker_test.go
+++ b/components/supervisor/pkg/supervisor/docker_test.go
@@ -173,3 +173,187 @@ func TestInsertRegistryAuth(t *testing.T) {
 		})
 	}
 }
+
+// tests the parsing logic of insertCredentialsIntoConfig
+func TestInsertCredentialsIntoConfig_Parsing(t *testing.T) {
+	tests := []struct {
+		name              string
+		imageAuthInput    string
+		expectedAuthsJSON string
+		expectedCount     int
+		expectError       bool
+	}{
+		{
+			name:           "simple host and token",
+			imageAuthInput: "myregistry.com:secrettoken",
+			expectedAuthsJSON: `{
+				"myregistry.com": {"auth": "secrettoken"}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:           "docker.io host and token",
+			imageAuthInput: "docker.io:dockertoken",
+			expectedAuthsJSON: `{
+				"https://index.docker.io/v1/": {"auth": "dockertoken"}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:           "subdomain of docker.io and token",
+			imageAuthInput: "sub.docker.io:subdockertoken",
+			expectedAuthsJSON: `{
+				"https://index.docker.io/v1/": {"auth": "subdockertoken"}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:           "host with port and token",
+			imageAuthInput: "myregistry.com:5000:supersecret",
+			expectedAuthsJSON: `{
+				"myregistry.com:5000": {"auth": "supersecret"}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:           "multiple credentials, some with port",
+			imageAuthInput: "reg1.com:token1,reg2.com:6000:token2,docker.io:token3",
+			expectedAuthsJSON: `{
+				"reg1.com": {"auth": "token1"},
+				"reg2.com:6000": {"auth": "token2"},
+				"https://index.docker.io/v1/": {"auth": "token3"}
+			}`,
+			expectedCount: 4,
+		},
+		{
+			name:              "empty imageAuth string",
+			imageAuthInput:    "",
+			expectedAuthsJSON: `{}`,
+			expectedCount:     0,
+		},
+		{
+			name:           "credential with empty token part",
+			imageAuthInput: "myregistry.com:",
+			expectedAuthsJSON: `{
+				"myregistry.com": {"auth": ""}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:           "credential with empty host part",
+			imageAuthInput: ":mytoken",
+			expectedAuthsJSON: `{
+				"": {"auth": "mytoken"}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:           "credential with only a colon",
+			imageAuthInput: ":",
+			expectedAuthsJSON: `{
+				"": {"auth": ""}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:              "single invalid credential (no colon)",
+			imageAuthInput:    "myregistry.com",
+			expectedAuthsJSON: `{}`,
+			expectedCount:     0,
+		},
+		{
+			name:           "mixed valid and invalid credentials",
+			imageAuthInput: "reg1.com:token1,invalidreg,reg2.com:token2",
+			expectedAuthsJSON: `{
+				"reg1.com": {"auth": "token1"},
+				"reg2.com": {"auth": "token2"}
+			}`,
+			expectedCount: 2,
+		},
+		{
+			name:           "input with leading/trailing spaces for the whole string",
+			imageAuthInput: "  myregistry.com:spacedtoken  ",
+			expectedAuthsJSON: `{
+				"myregistry.com": {"auth": "spacedtoken"}
+			}`,
+			expectedCount: 1,
+		},
+		{
+			name:           "input with spaces around comma separator creating leading space in host",
+			imageAuthInput: "reg1.com:token1 , reg2.com:token2",
+			expectedAuthsJSON: `{
+				"reg1.com": {"auth": "token1 "},
+				" reg2.com": {"auth": "token2"}
+			}`,
+			expectedCount: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tmpDir, err := os.MkdirTemp("", "docker-auth-test-")
+			if err != nil {
+				t.Fatalf("Failed to create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tmpDir)
+
+			originalHome := os.Getenv("HOME")
+			os.Setenv("HOME", tmpDir)
+			defer os.Setenv("HOME", originalHome)
+
+			count, err := insertCredentialsIntoConfig(tc.imageAuthInput)
+
+			if tc.expectError {
+				if err == nil {
+					t.Errorf("Expected an error, but got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("insertCredentialsIntoConfig() returned an unexpected error: %v", err)
+			}
+
+			if count != tc.expectedCount {
+				t.Errorf("Expected count %d, got %d", tc.expectedCount, count)
+			}
+
+			configPath := filepath.Join(tmpDir, ".docker", "config.json")
+
+			var expectedAuthsMap map[string]RegistryAuth
+			if err := json.Unmarshal([]byte(tc.expectedAuthsJSON), &expectedAuthsMap); err != nil {
+				t.Fatalf("Failed to unmarshal expectedAuthsJSON for tc '%s': %v. JSON: %s", tc.name, err, tc.expectedAuthsJSON)
+			}
+
+			_, statErr := os.Stat(configPath)
+			if os.IsNotExist(statErr) {
+				if len(expectedAuthsMap) == 0 && tc.expectedCount == 0 {
+					return
+				}
+				t.Fatalf("Config file %s does not exist, but expected auths (count: %d, map: %s)", configPath, tc.expectedCount, tc.expectedAuthsJSON)
+			}
+			if statErr != nil && !os.IsNotExist(statErr) {
+				t.Fatalf("Error stating config file %s: %v", configPath, statErr)
+			}
+
+			configBytes, readErr := os.ReadFile(configPath)
+			if readErr != nil {
+				t.Fatalf("Failed to read docker config file %s: %v. Expected auths: %s", configPath, readErr, tc.expectedAuthsJSON)
+			}
+
+			var resultConfig DockerConfig
+			if err := json.Unmarshal(configBytes, &resultConfig); err != nil {
+				t.Fatalf("Failed to unmarshal result config: %v. Content: %s", err, string(configBytes))
+			}
+
+			if len(expectedAuthsMap) == 0 {
+				if resultConfig.Auths != nil && len(resultConfig.Auths) != 0 {
+					t.Errorf("Expected empty auths, but got: %v", resultConfig.Auths)
+				}
+			} else {
+				if diff := cmp.Diff(expectedAuthsMap, resultConfig.Auths); diff != "" {
+					t.Errorf("Unexpected auths map in config.json (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Be able to consume GITPOD_IMAGE_AUTH, where it is `host:<token>` or `host:port:<token>`.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #16237
Fixes CLC-1364

## How to test
<!-- Provide steps to test this PR -->
See unit tests

[Preview](https://kylos101-s2pzmioah6s.preview.gitpod-dev.com/workspaces)

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
