### PR TITLE
[ws-manager-mk2] do cleanup of failed workspace with unknown status

### DIFF
--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -440,10 +440,12 @@ func (r *WorkspaceReconciler) extractFailure(ctx context.Context, ws *workspacev
 				if !ws.IsHeadless() {
 					return fmt.Sprintf("container %s completed; containers of a workspace pod are not supposed to do that", cs.Name), nil
 				}
-			} else if !isPodBeingDeleted(pod) && terminationState.ExitCode != containerUnknownExitCode {
+			} else if !isPodBeingDeleted(pod) && terminationState.ExitCode == containerUnknownExitCode {
+				return fmt.Sprintf("workspace container %s terminated for an unknown reason: (%s) %s", cs.Name, terminationState.Reason, terminationState.Message), nil
+			} else if !isPodBeingDeleted(pod) {
 				// if a container is terminated and it wasn't because of either:
 				//  - regular shutdown
-				//  - the exit code "UNKNOWN" (which might be caused by an intermittent issue and is handled in extractStatusFromPod)
+				//  - the exit code "UNKNOWN" (which might be caused by an intermittent issue
 				//  - another known error
 				// then we report it as UNKNOWN
 				phase := workspacev1.WorkspacePhaseUnknown


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
[ws-manager-mk2] do cleanup of failed workspace with unknown status

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1372

## How to test
<!-- Provide steps to test this PR -->

1. start a workspace in preview env
2. ssh in to workspace node
3. restart the node
4. you will observe the workspace are cleanup after reboot, and you can also see logs `workspace container xxxx terminated for an unknown reason` in ws-manager-mk2 pod

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-clc-1372</li>
	<li><b>🔗 URL</b> - <a href="https://pd-clc-1372.preview.gitpod-dev.com/workspaces" target="_blank">pd-clc-1372.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-CLC-1372-gha.32691</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-clc-1372%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
