### PR TITLE
[ws-manager-mk2] always update workspace pod ip

### DIFF
--- a/components/ws-manager-mk2/controllers/status.go
+++ b/components/ws-manager-mk2/controllers/status.go
@@ -109,12 +109,11 @@ func (r *WorkspaceReconciler) updateWorkspaceStatus(ctx context.Context, workspa
 	if workspace.Status.Runtime.HostIP == "" && pod.Status.HostIP != "" {
 		workspace.Status.Runtime.HostIP = pod.Status.HostIP
 	}
-	if workspace.Status.Runtime.PodIP == "" && pod.Status.PodIP != "" {
-		workspace.Status.Runtime.PodIP = pod.Status.PodIP
-	}
 	if workspace.Status.Runtime.PodName == "" && pod.Name != "" {
 		workspace.Status.Runtime.PodName = pod.Name
 	}
+
+	workspace.Status.Runtime.PodIP = pod.Status.PodIP
 
 	// Check if the node has disappeared. If so, ws-daemon has also disappeared and we need to
 	// mark the workspace backup as failed if it didn't complete disposal yet.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
We should always synchronize the IP addresses, even if they have been set before.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Related to CLC-1368

## How to test
<!-- Provide steps to test this PR -->
1. start a workspace in preview env
2. reboot the node
3. use kubectl to get workspace crd info, the runtime->podIP should be cleanup

<img width="1456" alt="image" src="https://github.com/user-attachments/assets/44ab1e60-6902-4f86-a047-302fb886650d" />


## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-ws-sync-ip</li>
	<li><b>🔗 URL</b> - <a href="https://pd-ws-sync-ip.preview.gitpod-dev.com/workspaces" target="_blank">pd-ws-sync-ip.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-ws-sync-ip-gha.32701</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-ws-sync-ip%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [ ] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
