### PR TITLE
Fixes preview creation after https://github.com/gitpod-io/gitpod/pull/20833

### DIFF
--- a/dev/preview/infrastructure/modules/gce/vm.tf
+++ b/dev/preview/infrastructure/modules/gce/vm.tf
@@ -77,7 +77,8 @@ resource "google_compute_address" "static-preview-ip" {
 locals {
   vm_name = "preview-${var.preview_name}"
   bootstrap_script = templatefile("${path.module}/../../scripts/bootstrap-k3s.sh", {
-    vm_name = local.vm_name
+    vm_name      = local.vm_name
+    preview_name = var.preview_name
   })
 
   trustmanager_script = file("${path.module}/../../scripts/install-trustmanager.sh")

--- a/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
+++ b/dev/preview/infrastructure/scripts/bootstrap-k3s.sh
@@ -12,6 +12,7 @@ export SERVICE_DNS_IP
 /usr/local/bin/install-k3s.sh \
   --token "1234" \
   --node-ip "$SERVICE_DNS_IP" \
+  --tls-san "${preview_name}.preview.gitpod-dev.com" \
   --node-label "cloud.google.com/gke-nodepool=control-plane-pool" \
   --container-runtime-endpoint=/var/run/containerd/containerd.sock \
   --write-kubeconfig-mode 444 \

--- a/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
+++ b/dev/preview/workflow/preview/deploy-monitoring-satellite.sh
@@ -97,4 +97,6 @@ echo "Patching grafana deployment"
 kubectl \
     --kubeconfig "${PREVIEW_K3S_KUBE_PATH}" \
     --context "${PREVIEW_K3S_KUBE_CONTEXT}" \
-    patch deployments.apps -n monitoring-satellite grafana --type=json -p="[{'op': 'remove', 'path': '/spec/template/spec/nodeSelector'}]"
+    patch deployments.apps -n monitoring-satellite grafana --type=json \
+    -p='[{"op": "test", "path": "/spec/template/spec/nodeSelector"}, {"op": "remove", "path": "/spec/template/spec/nodeSelector"}]' \
+    2>/dev/null || true


### PR DESCRIPTION
## Description
Fixes for https://github.com/gitpod-io/gitpod/pull/20833:
 - add `--tls-san` for k3s setup
 - fix usage of `kubectl patch` for newer server version


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
 - run `leeway run dev:preview` and see it working :heavy_check_mark:  
![image](https://github.com/user-attachments/assets/e9afc045-a2c4-47af-8390-04a6f11e2dd5)
   - also, workspace starts :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
