### PR TITLE
[VS Code Browser] Update stable code to `1.100.2`

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,11 +8,11 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-e62d71dde81f736d8a4c6b07c5483e5caed40d7b",
+        "image": "{{.Repository}}/ide/code:commit-246f56d562b502a46f1a4dce02a5406bda7dfa28",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-e62d71dde81f736d8a4c6b07c5483e5caed40d7b",
-          "{{.Repository}}/ide/code-codehelper:commit-6385d6f4c904ce2b8d298c5f8c115090aa5f6488"
+          "{{.Repository}}/ide/code-codehelper:commit-e04327e0e2d9fe0db5c75931638dbe04eecc2534"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",
@@ -20,6 +20,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "1.99.3",
+            "image": "{{.Repository}}/ide/code:commit-e62d71dde81f736d8a4c6b07c5483e5caed40d7b",
+            "imageLayers": [
+              "{{.Repository}}/ide/gitpod-code-web:commit-e62d71dde81f736d8a4c6b07c5483e5caed40d7b",
+              "{{.Repository}}/ide/code-codehelper:commit-6385d6f4c904ce2b8d298c5f8c115090aa5f6488"
+            ]
+          },
           {
             "version": "1.98.2",
             "image": "{{.Repository}}/ide/code:commit-211281858c4e2b08062afeb58078c3f54b366ccc",


### PR DESCRIPTION
## Description
Update code to `1.100.2`

## How to test

Should be tested already in build PR, double check:

- [ ] New version is pinnable
- [ ] Stable version is updated and it can start workspace with it

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-code-release</li>
	<li><b>🔗 URL</b> - <a href="https://ide-code-release.preview.gitpod-dev.com/workspaces" target="_blank">ide-code-release.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-code-release-gha.32823</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ide-code-release%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment