### PR TITLE
[supervisor] Don't emit DeadlineExceeded if client closes connection

### DIFF
--- a/components/supervisor/pkg/supervisor/tasks_test.go
+++ b/components/supervisor/pkg/supervisor/tasks_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -20,6 +21,12 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/terminal"
 )
+
+func newBool(b bool) *atomic.Bool {
+	result := atomic.Bool{}
+	result.Store(b)
+	return &result
+}
 
 var (
 	skipCommand = "echo \"skip\""
@@ -216,7 +223,7 @@ func TestTaskManager(t *testing.T) {
 			}
 
 			var (
-				terminalService = terminal.NewMuxTerminalService(terminal.NewMux())
+				terminalService = terminal.NewMuxTerminalService(terminal.NewMux(), newBool(true))
 				contentState    = NewInMemoryContentState("")
 				reporter        = testHeadlessTaskProgressReporter{}
 				taskManager     = newTasksManager(&Config{

--- a/components/supervisor/pkg/terminal/terminal_test.go
+++ b/components/supervisor/pkg/terminal/terminal_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -20,6 +21,12 @@ import (
 
 	"github.com/gitpod-io/gitpod/supervisor/api"
 )
+
+func newBool(b bool) *atomic.Bool {
+	result := atomic.Bool{}
+	result.Store(b)
+	return &result
+}
 
 func TestTitle(t *testing.T) {
 	t.Skip("skipping flakey tests")
@@ -59,7 +66,7 @@ func TestTitle(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpWorkdir)
 
-			terminalService := NewMuxTerminalService(mux)
+			terminalService := NewMuxTerminalService(mux, newBool(true))
 			terminalService.DefaultWorkdir = tmpWorkdir
 
 			term, err := terminalService.OpenWithOptions(ctx, &api.OpenTerminalRequest{}, TermOptions{
@@ -197,7 +204,7 @@ func TestAnnotations(t *testing.T) {
 			mux := NewMux()
 			defer mux.Close(ctx)
 
-			terminalService := NewMuxTerminalService(mux)
+			terminalService := NewMuxTerminalService(mux, newBool(true))
 			var err error
 			if test.Opts == nil {
 				_, err = terminalService.Open(ctx, test.Req)
@@ -248,7 +255,7 @@ func TestTerminals(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			terminalService := NewMuxTerminalService(NewMux())
+			terminalService := NewMuxTerminalService(NewMux(), newBool(true))
 			resp, err := terminalService.Open(context.Background(), &api.OpenTerminalRequest{})
 			if err != nil {
 				t.Fatal(err)
@@ -329,7 +336,7 @@ func TestWorkDirProvider(t *testing.T) {
 	mux := NewMux()
 	defer mux.Close(ctx)
 
-	terminalService := NewMuxTerminalService(mux)
+	terminalService := NewMuxTerminalService(mux, newBool(true))
 
 	type AssertWorkDirTest struct {
 		expectedWorkDir string


### PR DESCRIPTION
## Description
Reduce grpc error noise by returning `Ok` instead of `DeadlineExceeded` when a client terminates `TerminalService.Listen`.

Behind feature flag `supervisor_terminal_no_deadline_exceeded`

## Related Issue(s)
Related: CLC-1332

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
