### PR TITLE
Redact args in the logs of audit log service

### DIFF
--- a/components/server/src/audit/AuditLogService.ts
+++ b/components/server/src/audit/AuditLogService.ts
@@ -53,7 +53,16 @@ export class AuditLogService {
             action: method,
             args: argsScrubbed,
         };
-        log.info("audit", new TrustedValue(logEntry));
+        // The args param contains workspace IDs and other sensitive data. Since
+        // it's quite hard to detect them, best way is to simply not log it at
+        // all. It's still part of the audit database but does not appear in the
+        // component logs.
+        const logEntryForLogging = {
+            ...logEntry,
+            args: ["[redacted]"],
+        };
+
+        log.info("audit", new TrustedValue(logEntryForLogging));
         await this.dbAuditLog.recordAuditLog(logEntry);
     }
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The args param contains workspace IDs and other sensitive data. Since it's quite hard to detect them, best way is to simply not log it at all. It's still part of the audit database but does not appear in the component logs.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/CLC-666/scrubbing-audit-log-writes-workspaceids-in-plain-text


#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
