### PR TITLE
[code] update code image layers

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -12,7 +12,7 @@
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
-          "{{.Repository}}/ide/code-codehelper:commit-175fb0bebdc172d8af798007d86db475c38ecf07"
+          "{{.Repository}}/ide/code-codehelper:commit-301f1b73da68f23b17e0516e3e4969c56bf434a3"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",


### PR DESCRIPTION
## Description
This PR updates the VS Code Browser image layers to the most recent installer version.

## How to test

Test if changes are working.

i.e.
- `code-helper` it can start browser code with extensions installed
- `gitpod-web-extension` extension functionalities are working well
- `code` is not expected it to be changed

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-code-images</li>
	<li><b>🔗 URL</b> - <a href="https://ide-code-images.preview.gitpod-dev.com/workspaces" target="_blank">ide-code-images.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-code-images-gha.32915</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ide-code-images%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment