### PR TITLE
[supervisor] Drop feature flag supervisor_terminal_no_deadline_exceeded

### DIFF
--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -29,7 +29,6 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -337,10 +336,9 @@ func Run(options ...RunOption) {
 		}
 	}
 
-	terminalNoDeadlineExceeded := watchTerminalNoDeadlineExceeded(ctx, exps, host)
 	willShutdownCtx, fireWillShutdown := context.WithCancel(ctx)
 	termMux := terminal.NewMux()
-	termMuxSrv := terminal.NewMuxTerminalService(termMux, terminalNoDeadlineExceeded)
+	termMuxSrv := terminal.NewMuxTerminalService(termMux)
 	termMuxSrv.DefaultWorkdir = cfg.RepoRoot
 	if cfg.WorkspaceRoot != "" {
 		termMuxSrv.DefaultWorkdirProvider = func() string {
@@ -582,36 +580,6 @@ func getIDENotReadyShutdownDuration(ctx context.Context, exps experiments.Client
 		}
 		return true, duration
 	}
-}
-
-func watchTerminalNoDeadlineExceeded(ctx context.Context, exps experiments.Client, gitpodHost string) *atomic.Bool {
-	newBool := func(v bool) *atomic.Bool {
-		r := atomic.Bool{}
-		r.Store(v)
-		return &r
-	}
-	if exps == nil {
-		return newBool(false)
-	}
-
-	value := exps.GetBoolValue(ctx, "supervisor_terminal_no_deadline_exceeded", false, experiments.Attributes{GitpodHost: gitpodHost})
-	result := newBool(value)
-
-	go (func() {
-		t := time.NewTicker(30 * time.Second)
-
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case <-t.C:
-				value := exps.GetBoolValue(ctx, "supervisor_terminal_no_deadline_exceeded", false, experiments.Attributes{GitpodHost: gitpodHost})
-				result.Store(value)
-			}
-		}
-	})()
-
-	return result
 }
 
 func isShallowRepository(rootDir string) bool {

--- a/components/supervisor/pkg/supervisor/tasks_test.go
+++ b/components/supervisor/pkg/supervisor/tasks_test.go
@@ -10,7 +10,6 @@ import (
 	"os"
 	"strconv"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -21,12 +20,6 @@ import (
 	"github.com/gitpod-io/gitpod/supervisor/api"
 	"github.com/gitpod-io/gitpod/supervisor/pkg/terminal"
 )
-
-func newBool(b bool) *atomic.Bool {
-	result := atomic.Bool{}
-	result.Store(b)
-	return &result
-}
 
 var (
 	skipCommand = "echo \"skip\""
@@ -223,7 +216,7 @@ func TestTaskManager(t *testing.T) {
 			}
 
 			var (
-				terminalService = terminal.NewMuxTerminalService(terminal.NewMux(), newBool(true))
+				terminalService = terminal.NewMuxTerminalService(terminal.NewMux())
 				contentState    = NewInMemoryContentState("")
 				reporter        = testHeadlessTaskProgressReporter{}
 				taskManager     = newTasksManager(&Config{

--- a/components/supervisor/pkg/terminal/service.go
+++ b/components/supervisor/pkg/terminal/service.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -27,7 +26,7 @@ import (
 )
 
 // NewMuxTerminalService creates a new terminal service.
-func NewMuxTerminalService(m *Mux, terminalNoDeadlineExceeded *atomic.Bool) *MuxTerminalService {
+func NewMuxTerminalService(m *Mux) *MuxTerminalService {
 	shell := os.Getenv("SHELL")
 	if shell == "" {
 		shell = "/bin/bash"
@@ -37,8 +36,6 @@ func NewMuxTerminalService(m *Mux, terminalNoDeadlineExceeded *atomic.Bool) *Mux
 		DefaultWorkdir: "/workspace",
 		DefaultShell:   shell,
 		Env:            os.Environ(),
-
-		terminalNoDeadlineExceeded: terminalNoDeadlineExceeded,
 	}
 }
 
@@ -55,8 +52,6 @@ type MuxTerminalService struct {
 	Env                []string
 	DefaultCreds       *syscall.Credential
 	DefaultAmbientCaps []uintptr
-
-	terminalNoDeadlineExceeded *atomic.Bool
 
 	api.UnimplementedTerminalServiceServer
 }
@@ -291,10 +286,7 @@ func (srv *MuxTerminalService) Listen(req *api.ListenTerminalRequest, resp api.T
 			err = resp.Send(message)
 		case err = <-errchan:
 		case <-resp.Context().Done():
-			if srv.terminalNoDeadlineExceeded.Load() {
-				return nil
-			}
-			return status.Error(codes.DeadlineExceeded, resp.Context().Err().Error())
+			return nil
 		}
 		if err == io.EOF {
 			// EOF isn't really an error here

--- a/components/supervisor/pkg/terminal/terminal_test.go
+++ b/components/supervisor/pkg/terminal/terminal_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -21,12 +20,6 @@ import (
 
 	"github.com/gitpod-io/gitpod/supervisor/api"
 )
-
-func newBool(b bool) *atomic.Bool {
-	result := atomic.Bool{}
-	result.Store(b)
-	return &result
-}
 
 func TestTitle(t *testing.T) {
 	t.Skip("skipping flakey tests")
@@ -66,7 +59,7 @@ func TestTitle(t *testing.T) {
 			}
 			defer os.RemoveAll(tmpWorkdir)
 
-			terminalService := NewMuxTerminalService(mux, newBool(true))
+			terminalService := NewMuxTerminalService(mux)
 			terminalService.DefaultWorkdir = tmpWorkdir
 
 			term, err := terminalService.OpenWithOptions(ctx, &api.OpenTerminalRequest{}, TermOptions{
@@ -204,7 +197,7 @@ func TestAnnotations(t *testing.T) {
 			mux := NewMux()
 			defer mux.Close(ctx)
 
-			terminalService := NewMuxTerminalService(mux, newBool(true))
+			terminalService := NewMuxTerminalService(mux)
 			var err error
 			if test.Opts == nil {
 				_, err = terminalService.Open(ctx, test.Req)
@@ -255,7 +248,7 @@ func TestTerminals(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.Desc, func(t *testing.T) {
-			terminalService := NewMuxTerminalService(NewMux(), newBool(true))
+			terminalService := NewMuxTerminalService(NewMux())
 			resp, err := terminalService.Open(context.Background(), &api.OpenTerminalRequest{})
 			if err != nil {
 				t.Fatal(err)
@@ -336,7 +329,7 @@ func TestWorkDirProvider(t *testing.T) {
 	mux := NewMux()
 	defer mux.Close(ctx)
 
-	terminalService := NewMuxTerminalService(mux, newBool(true))
+	terminalService := NewMuxTerminalService(mux)
 
 	type AssertWorkDirTest struct {
 		expectedWorkDir string


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
Related: CLC-1332

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
