### PR TITLE
[JetBrains] Improve ports listener leaking

### DIFF
--- a/components/ide/jetbrains/backend-plugin/build.gradle-stable.kts
+++ b/components/ide/jetbrains/backend-plugin/build.gradle-stable.kts
@@ -38,6 +38,7 @@ project(":") {
         if (properties("platformType") == "RD") {
             print("Rider: exclude unnecessary files")
             sourceSets["main"].kotlin.exclude("**/GitpodForceUpdateMavenProjectsActivity.kt")
+            sourceSets["main"].kotlin.exclude("**/GitpodPortForwardingServiceImpl.kt")
             sourceSets["main"].kotlin.exclude("**/maven.xml")
         }
     }

--- a/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodRiderPortForwardingService.kt
+++ b/components/ide/jetbrains/backend-plugin/src/main/kotlin/io/gitpod/jetbrains/remote/optional/GitpodRiderPortForwardingService.kt
@@ -1,18 +1,18 @@
-// Copyright (c) 2024 Gitpod GmbH. All rights reserved.
+// Copyright (c) 2025 Gitpod GmbH. All rights reserved.
 // Licensed under the GNU Affero General Public License (AGPL).
 // See License.AGPL.txt in the project root for license information.
 
-package io.gitpod.jetbrains.remote
+package io.gitpod.jetbrains.remote.optional
 
 import com.jetbrains.rd.util.lifetime.Lifetime
 import com.jetbrains.rd.util.threading.coroutines.launch
+import io.gitpod.jetbrains.remote.AbstractGitpodPortForwardingService
 import kotlinx.coroutines.CoroutineScope
-import fleet.util.async.throttleLatest
 import kotlinx.coroutines.flow.Flow
 
 @Suppress("UnstableApiUsage")
-class GitpodPortForwardingServiceImpl : AbstractGitpodPortForwardingService() {
+class GitpodRiderPortForwardingService : AbstractGitpodPortForwardingService() {
     override fun runJob(lifetime: Lifetime, block: suspend CoroutineScope.() -> Unit) = lifetime.launch { block() }
 
-    override suspend fun <T> applyThrottling(flow: Flow<T>): Flow<T> = flow.throttleLatest(1000)
+    override suspend fun <T> applyThrottling(flow: Flow<T>): Flow<T> = flow
 }

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-latest/META-INF/extensions.xml
@@ -6,5 +6,8 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
+                            serviceImplementation="io.gitpod.jetbrains.remote.GitpodPortForwardingServiceImpl"
+                            client="controller" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-rider/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-rider/META-INF/plugin.xml
@@ -50,6 +50,9 @@
                      description="Disable the forced update of Maven projects when IDE opens."
                      restartRequired="true"/>
 
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
+                            serviceImplementation="io.gitpod.jetbrains.remote.optional.GitpodRiderPortForwardingService"
+                            client="controller" preload="true" />
 
         <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodIgnoredPortsForNotificationService"
                             serviceImplementation="io.gitpod.jetbrains.remote.internal.GitpodIgnoredPortsForNotificationServiceImpl"

--- a/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources-stable/META-INF/extensions.xml
@@ -6,5 +6,8 @@
 <!--suppress PluginXmlValidity -->
 <idea-plugin>
     <extensions defaultExtensionNs="com.intellij">
+        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
+                            serviceImplementation="io.gitpod.jetbrains.remote.GitpodPortForwardingServiceImpl"
+                            client="controller" preload="true"/>
     </extensions>
 </idea-plugin>

--- a/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
+++ b/components/ide/jetbrains/backend-plugin/src/main/resources/META-INF/plugin.xml
@@ -55,9 +55,6 @@
                             preload="true"/>
 
 
-        <applicationService serviceInterface="io.gitpod.jetbrains.remote.GitpodPortForwardingService"
-                            serviceImplementation="io.gitpod.jetbrains.remote.GitpodPortForwardingServiceImpl"
-                            client="controller" preload="true"/>
         <gateway.customization.performance id="gitpodMetricsControl" order="before cpuControl"
                                            implementation="io.gitpod.jetbrains.remote.GitpodMetricControlProvider"/>
     </extensions>

--- a/dev/preview/workflow/preview/patch-ide-configmap.js
+++ b/dev/preview/workflow/preview/patch-ide-configmap.js
@@ -12,6 +12,8 @@ function replaceImage(image) {
 const imagesBuildFromMain = [
     "jb-backend-plugin:commit-2d67254d5aa110bc2c76cd807b85b272e3d54d97-latest",
     "jb-backend-plugin:commit-4c69ad0670cc4cfbf43910e1db700ad90acd5ac6",
+    "jb-backend-plugin:commit-8cdc2a1a45c66ac9e003a97af8c57fad42d923f6-rider",
+    "jb-backend-plugin:commit-8cdc2a1a45c66ac9e003a97af8c57fad42d923f6-rider-latest",
 ];
 
 // TODO(hw): remove me
@@ -39,6 +41,11 @@ for (let ide in json.ideOptions.options) {
 
     // TODO(hw): remove me
     if (["intellij"].includes(ide)) {
+        json.ideOptions.options[ide].pluginImage = replaceImage2(json.ideOptions.options[ide].pluginImage);
+        json.ideOptions.options[ide].imageLayers = json.ideOptions.options[ide].imageLayers.map(replaceImage2);
+    }
+
+    if (["rider"].includes(ide)) {
         json.ideOptions.options[ide].pluginImage = replaceImage2(json.ideOptions.options[ide].pluginImage);
         json.ideOptions.options[ide].imageLayers = json.ideOptions.options[ide].imageLayers.map(replaceImage2);
     }

--- a/install/installer/pkg/components/ide-service/ide_config_configmap.go
+++ b/install/installer/pkg/components/ide-service/ide_config_configmap.go
@@ -75,10 +75,12 @@ func GenerateIDEConfigmap(ctx *common.RenderContext) (*ide_config.IDEConfig, err
 		CodeHelperImage:                ctx.ImageName(ctx.Config.Repository, ide.CodeHelperIDEImage, ctx.VersionManifest.Components.Workspace.CodeHelperImage.Version),
 		CodeWebExtensionImage:          ctx.ImageName(ctx.Config.Repository, ide.CodeWebExtensionImage, ctx.VersionManifest.Components.Workspace.CodeWebExtensionImage.Version),
 
-		JetBrainsPluginImage:            ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginImage.Version),
-		JetBrainsPluginLatestImage:      ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginLatestImage.Version),
-		JetBrainsPluginRiderImage:       ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginRiderImage.Version),
-		JetBrainsPluginLatestRiderImage: ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginLatestRiderImage.Version),
+		JetBrainsPluginImage:       ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginImage.Version),
+		JetBrainsPluginLatestImage: ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsBackendPluginLatestImage.Version),
+
+		// Pin Rider's backend-plugin version as we don't plan to upgrade Rider yet
+		JetBrainsPluginRiderImage:       ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-8cdc2a1a45c66ac9e003a97af8c57fad42d923f6-rider"),
+		JetBrainsPluginLatestRiderImage: ctx.ImageName(ctx.Config.Repository, ide.JetBrainsBackendPluginImage, "commit-8cdc2a1a45c66ac9e003a97af8c57fad42d923f6-rider-latest"),
 		JetBrainsLauncherImage:          ctx.ImageName(ctx.Config.Repository, ide.JetBrainsLauncherImage, ctx.VersionManifest.Components.Workspace.DesktopIdeImages.JetBrainsLauncherImage.Version),
 		ResolvedJBImageLatest: JBImages{
 			IntelliJ:  resolveLatestImage(ide.IntelliJDesktopIDEImage, "latest", ctx.VersionManifest.Components.Workspace.DesktopIdeImages.IntelliJLatestImage),


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
- Start workspace with **stable IntelliJ IDEA** https://github.com/gitpod-samples/spring-petclinic
- Make sure it's working like before

**Integration tests**
- The only failed one is because of indexing, which should be fine https://github.com/gitpod-io/gitpod/actions/runs/15673024601/job/44150433554?pr=20872

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-jb-ports</li>
	<li><b>🔗 URL</b> - <a href="https://hw-jb-ports.preview.gitpod-dev.com/workspaces" target="_blank">hw-jb-ports.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-jb-ports-gha.32980</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-jb-ports%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [x] with-integration-tests=jetbrains
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
