### PR TITLE
[registry-facade] Do retry if copying a blob fails mid way

### DIFF
--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -18,11 +18,13 @@ Building a comprehensive knowledge base of the Gitpod codebase and architecture 
 - Documented 33 service components and 11 API components
 - Enhanced API component documentation with code generation information
 - Implemented server readiness probe with database, SpiceDB, and Redis connectivity checks
+- **Improved `registry-facade` resilience by implementing a comprehensive retry mechanism for blob retrieval, addressing transient network errors.**
 
 ## Next Steps
 
-1. **Component Interactions**: Understand inter-component communication
-2. **Development Environment**: Configure local development setup
+1. **Monitor `registry-facade`:** Observe the component's behavior with the new retry logic to ensure it correctly handles the previously identified network issues.
+2. **Component Interactions**: Understand inter-component communication
+3. **Development Environment**: Configure local development setup
 3. **Build System**: Gain experience with in-tree and Leeway builds
 4. **Component Builds**: Practice building different component types
 5. **Initial Tasks**: Identify specific improvement areas

--- a/memory-bank/components/registry-facade.md
+++ b/memory-bank/components/registry-facade.md
@@ -33,6 +33,12 @@ The component acts as an "image layer smuggler," inserting layers into container
 - `cmd/run.go`: Implements the main registry service
 - `cmd/setup.go`: Handles service setup and configuration
 - `pkg/registry/`: Core registry implementation
+- `blob.go`: Handles blob retrieval from various sources (local store, IPFS, upstream registries). Contains a resilient retry mechanism to handle transient network errors during both connection and data transfer phases.
+
+## Key Implementation Details
+
+### Blob Retrieval Retry Logic
+The `retrieveFromSource` function in `pkg/registry/blob.go` implements an exponential backoff retry mechanism that wraps the entire blob retrieval process. This ensures that transient network errors, such as `TLS handshake timeout` or `connection reset`, that occur during either the initial connection (`GetBlob`) or the data streaming (`io.CopyBuffer`) are retried. This makes the service more resilient to intermittent network issues when fetching blobs from upstream sources like S3.
 
 ## Dependencies
 

--- a/memory-bank/progress.md
+++ b/memory-bank/progress.md
@@ -68,6 +68,12 @@ No specific blockers identified yet.
 
 ## Recent Progress
 
+### 6/6/2025
+- Investigated `registry-facade` 500 errors (CLC-195).
+- Analyzed logs and identified TLS handshake timeouts as a root cause.
+- Implemented a more resilient retry mechanism in `pkg/registry/blob.go` to handle transient network errors during blob retrieval.
+- Updated `registry-facade` component documentation.
+
 ### 3/17/2025
 - Implemented server readiness probe with database, SpiceDB, and Redis checks
 - Created PRD document for the implementation


### PR DESCRIPTION
## Description
We do retries when doing HTTP requests. But if an error occurs while copying the response body, we did not re-establish the connection so far. This PR justs does this, as well as extending the backoff time span to ~10s instead of 1s, to be able to cover intermittent network problems.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1416

## How to test
 - new tests are green: :heavy_check_mark: 
 - start [a workspace](https://gpl-195-registry-err.preview.gitpod-dev.com/new#https://github.com/geropl/bel) :heavy_check_mark: 
 - start an image build: :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
