### PR TITLE
[registry-facade] Properly retry fetching mainfests/config as well

### DIFF
--- a/components/registry-facade/pkg/registry/manifest_test.go
+++ b/components/registry-facade/pkg/registry/manifest_test.go
@@ -7,14 +7,23 @@ package registry
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
+	"strings"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/remotes"
 	"github.com/opencontainers/go-digest"
 	"github.com/opencontainers/image-spec/specs-go"
 	ociv1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 func TestDownloadManifest(t *testing.T) {
@@ -139,4 +148,154 @@ func (fbs *misbehavingStore) Writer(ctx context.Context, opts ...content.WriterO
 // If the content is not present, ErrNotFound will be returned.
 func (fbs *misbehavingStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
 	return content.Info{}, fmt.Errorf("you wish")
+}
+
+// manifestFailingReader is a reader that fails after a certain point.
+type manifestFailingReader struct {
+	reader         io.Reader
+	failAfterBytes int
+	failError      error
+	bytesRead      int
+}
+
+func (fr *manifestFailingReader) Read(p []byte) (n int, err error) {
+	if fr.bytesRead >= fr.failAfterBytes {
+		return 0, fr.failError
+	}
+	n, err = fr.reader.Read(p)
+	if err != nil {
+		return n, err
+	}
+	fr.bytesRead += n
+	if fr.bytesRead >= fr.failAfterBytes {
+		// Return the error, but also the bytes read in this call.
+		return n, fr.failError
+	}
+	return n, nil
+}
+
+func (fr *manifestFailingReader) Close() error {
+	return nil
+}
+
+type mockFetcher struct {
+	// How many times Fetch should fail before succeeding.
+	failCount int
+	// The error to return on failure.
+	failError error
+
+	// Internal counter for calls.
+	callCount int
+	// The data to return on success.
+	successData string
+
+	// Whether to use a reader that fails mid-stream on the first call.
+	failReaderOnFirstCall bool
+	// The number of bytes to read successfully before the reader fails.
+	failAfterBytes int
+}
+
+func (m *mockFetcher) Fetch(ctx context.Context, desc ociv1.Descriptor) (io.ReadCloser, error) {
+	m.callCount++
+	if m.callCount <= m.failCount {
+		return nil, m.failError
+	}
+
+	if m.failReaderOnFirstCall && m.callCount == 1 {
+		return &manifestFailingReader{
+			reader:         strings.NewReader(m.successData),
+			failAfterBytes: m.failAfterBytes,
+			failError:      m.failError,
+		}, nil
+	}
+
+	return io.NopCloser(strings.NewReader(m.successData)), nil
+}
+
+func TestDownloadManifest_RetryOnReadAll(t *testing.T) {
+	// Arrange
+	mockFetcher := &mockFetcher{
+		failCount:             0, // Fetch succeeds immediately
+		failReaderOnFirstCall: true,
+		failAfterBytes:        5,
+		failError:             syscall.EPIPE,
+		successData:           `{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json"}`,
+	}
+
+	fetcherFunc := func() (remotes.Fetcher, error) {
+		return mockFetcher, nil
+	}
+
+	// Use short backoff for testing
+	originalBackoff := fetcherBackoffParams
+	fetcherBackoffParams = wait.Backoff{
+		Duration: 1 * time.Millisecond,
+		Steps:    3,
+	}
+	defer func() { fetcherBackoffParams = originalBackoff }()
+
+	// Act
+	_, _, err := DownloadManifest(context.Background(), fetcherFunc, ociv1.Descriptor{MediaType: ociv1.MediaTypeImageManifest})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockFetcher.callCount, "Expected Fetch to be called twice (1st succeeds, read fails, 2nd succeeds)")
+}
+
+func TestDownloadConfig_RetryOnReadAll(t *testing.T) {
+	// Arrange
+	mockFetcher := &mockFetcher{
+		failCount:             0, // Fetch succeeds immediately
+		failReaderOnFirstCall: true,
+		failAfterBytes:        5,
+		failError:             syscall.EPIPE,
+		successData:           `{"architecture": "amd64", "os": "linux"}`,
+	}
+
+	fetcherFunc := func() (remotes.Fetcher, error) {
+		return mockFetcher, nil
+	}
+
+	// Use short backoff for testing
+	originalBackoff := fetcherBackoffParams
+	fetcherBackoffParams = wait.Backoff{
+		Duration: 1 * time.Millisecond,
+		Steps:    3,
+	}
+	defer func() { fetcherBackoffParams = originalBackoff }()
+
+	// Act
+	_, err := DownloadConfig(context.Background(), fetcherFunc, "ref", ociv1.Descriptor{MediaType: ociv1.MediaTypeImageConfig})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 2, mockFetcher.callCount, "Expected Fetch to be called twice (1st succeeds, read fails, 2nd succeeds)")
+}
+
+func TestDownloadManifest_RetryOnFetch(t *testing.T) {
+	// Arrange
+	mockFetcher := &mockFetcher{
+		failCount:   2,
+		failError:   errors.New("transient network error"),
+		successData: `{"schemaVersion": 2, "mediaType": "application/vnd.oci.image.manifest.v1+json"}`,
+	}
+
+	fetcherFunc := func() (remotes.Fetcher, error) {
+		return mockFetcher, nil
+	}
+
+	// Use short backoff for testing
+	originalBackoff := fetcherBackoffParams
+	fetcherBackoffParams = wait.Backoff{
+		Duration: 1 * time.Millisecond,
+		Steps:    3,
+	}
+	defer func() { fetcherBackoffParams = originalBackoff }()
+
+	// Act
+	_, _, err := DownloadManifest(context.Background(), fetcherFunc, ociv1.Descriptor{MediaType: ociv1.MediaTypeImageManifest})
+
+	// Assert
+	require.NoError(t, err)
+	assert.Equal(t, 3, mockFetcher.callCount, "Expected Fetch to be called 3 times (2 failures + 1 success)")
 }


### PR DESCRIPTION
## Description
Turns out that similarly to https://github.com/gitpod-io/gitpod/pull/20879 we have a retry mechanism in place, but it does capture [this scenario](https://linear.app/gitpod/issue/CLC-1365/registry-facade-sometimes-cannot-downloadconfig-for-ecr-for-private#comment-77bba8f3):
> And they happen because if io.ReadAll(rc) fails, we do not re-try in any way because:
>
> rc is a httpReadSeeker, so does not only read a body, but might also do new range requests
>
> containerds dockerFetcher does [uses ](https://github.com/containerd/containerd/blob/v1.6.36/remotes/docker/fetcher.go#L70)http.DefaultClient for subsequent requests, instead of the one we pass into the dockerResolver [here](https://github.com/gitpod-io/gitpod/blob/76781bf32218c46d064e85ac8dd39e454218c8af/components/registry-facade/cmd/run.go#L89-L107) 😬 :facepalm-picard: 
>
> So the solution to all of those is to implement a retry around the io.ReadAll and .Fetch(...).


## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1365

Related: CLC-195, CLC-1279

## How to test
 - tests are green: :heavy_check_mark: 
 - start [a workspace](https://gpl-1365-rf23ba3a1ae.preview.gitpod-dev.com/new#https://github.com/geropl/bel): :heavy_check_mark: 
 - start [an image build](https://gpl-1365-rf23ba3a1ae.preview.gitpod-dev.com/new#https://github.com/geropl/gitpod-test-repo/tree/gpl/docker-build-30s]: :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
