### PR TITLE
[registry facade] Don't retry requests with error messages that were successful

### DIFF
--- a/components/blobserve/pkg/blobserve/refstore_test.go
+++ b/components/blobserve/pkg/blobserve/refstore_test.go
@@ -118,7 +118,7 @@ func TestBlobFor(t *testing.T) {
 				refDescriptor: provideDescriptor,
 			},
 			Expectation: Expectation{
-				Error: "cannot fetch manifest: " + hashManifest + " not found",
+				Error: "failed to fetch manifest: " + hashManifest + " not found",
 			},
 		},
 		{


### PR DESCRIPTION
## Description
Follow up to https://github.com/gitpod-io/gitpod/pull/20880: That PR re-tried _all_ requests, even if it was a 404.

This PR introduces a `retryableError` function that excludes non-retryable errors from being retried, fixing this test.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1419

## How to test
 - test are green :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
