### PR TITLE
Add Claude Code for Gitpod and Gitpod Classic

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -320,7 +320,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh |
     && bash -c ". $HOME/.nvm/nvm.sh \
     && nvm install v${NODE_VERSION} \
     && nvm alias default v${NODE_VERSION} \
-    && npm install -g typescript yarn pnpm node-gyp"
+    && npm install -g typescript yarn pnpm node-gyp @anthropic-ai/claude-code"
 
 ENV PATH=$PATH:/root/.aws-iam:/root/.terraform:/workspace/bin
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -293,7 +293,7 @@ RUN mkdir -p ~/.terraform \
     && printf "terraform -install-autocomplete 2> /dev/null\n" >>~/.bashrc
 
 ## Java
-ENV JAVA_VERSION=11.0.23.fx-zulu
+ENV JAVA_VERSION=11.0.27.fx-zulu
 RUN curl -fsSL "https://get.sdkman.io" | bash \
     && bash -c ". /root/.sdkman/bin/sdkman-init.sh \
     && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /root/.sdkman/etc/config \
@@ -301,7 +301,7 @@ RUN curl -fsSL "https://get.sdkman.io" | bash \
     && sdk install java ${JAVA_VERSION} \
     && sdk default java ${JAVA_VERSION} \
     && sdk install gradle \
-    && sdk install maven \
+    && sdk install maven 3.9.10 \
     && sdk flush archives \
     && sdk flush temp \
     && mkdir /root/.m2 \

--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     steps:
       - uses: actions/checkout@v4
       - name: Setup Environment
@@ -188,7 +188,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
       env:
         DB_HOST: "mysql"
         DB_PORT: "23306"
@@ -521,7 +521,7 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -131,7 +131,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -23,7 +23,7 @@ jobs:
   update-jetbrains:
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     needs: [ create-runner ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -39,7 +39,7 @@ jobs:
       gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   jetbrains-smoke-test-linux:
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     steps:

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -99,7 +99,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}
       count: ${{ steps.set-matrix.outputs.count }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -166,7 +166,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
     steps:
       - uses: actions/checkout@v4
       - name: Integration Test

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -80,6 +80,13 @@ tasks:
     init: |
       ./components/gitpod-protocol/go/scripts/generate-config.sh
       leeway exec --filter-type go -v -- go mod verify
+  - name: claude code
+    command: |
+      if [[ ! -z "${CLAUDE_JSON}" ]]; then
+        echo "Skipping setup for Claude Code. Setup a CLAUDE_JSON variable to reuse Claude Code in workspaces."
+        exit 0
+      fi
+      echo $CLAUDE_JSON > ~/.claude.json
 vscode:
   extensions:
     - EditorConfig.EditorConfig

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.32852
+image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:
@@ -82,11 +82,11 @@ tasks:
       leeway exec --filter-type go -v -- go mod verify
   - name: claude code
     command: |
-      if [[ ! -z "${CLAUDE_JSON}" ]]; then
+      if [[ -z "${CLAUDE_JSON}" ]]; then
         echo "Skipping setup for Claude Code. Setup a CLAUDE_JSON variable to reuse Claude Code in workspaces."
-        exit 0
+      else
+        echo $CLAUDE_JSON > ~/.claude.json
       fi
-      echo $CLAUDE_JSON > ~/.claude.json
 vscode:
   extensions:
     - EditorConfig.EditorConfig

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+# Claude Context for Gitpod
+
+This file provides essential context for AI assistants working on the Gitpod codebase.
+
+## Project Overview
+
+Gitpod is a cloud development environment platform that provides automated, ready-to-code development environments for any Git repository. The platform consists of multiple interconnected services and components that work together to deliver seamless developer experiences.
+
+## Memory Bank Structure
+
+This repository maintains comprehensive documentation in the `memory-bank/` directory:
+
+### Core Documentation
+- **[Project Brief](memory-bank/projectbrief.md)** - Foundation document defining core requirements and goals
+- **[Product Context](memory-bank/productContext.md)** - Why this project exists and problems it solves
+- **[System Patterns](memory-bank/systemPatterns.md)** - System architecture and key technical decisions
+- **[Tech Context](memory-bank/techContext.md)** - Technologies used and development setup
+- **[Active Context](memory-bank/activeContext.md)** - Current work focus and recent changes
+- **[Progress](memory-bank/progress.md)** - What works, what's left to build, and current status
+
+### Component Documentation
+The `memory-bank/components/` directory contains detailed documentation for each service and component in the Gitpod platform. Start with **[components.md](memory-bank/components.md)** for an overview.
+
+## Working with This Codebase
+
+1. **Start by reading the memory bank** - Always begin by reviewing the core documentation files above to understand the current state and context
+2. **Component-specific work** - Refer to the relevant component documentation in `memory-bank/components/`
+3. **Architecture decisions** - Check `memory-bank/systemPatterns.md` for established patterns and conventions
+4. **Current focus** - Review `memory-bank/activeContext.md` for ongoing work and priorities
+
+## Key Characteristics
+
+- **Multi-service architecture** - Gitpod consists of dozens of interconnected services
+- **Kubernetes-native** - Designed to run on Kubernetes with cloud-native patterns
+- **Developer experience focus** - Every decision prioritizes developer productivity and experience
+- **Workspace lifecycle management** - Complex orchestration of development environments
+- **Security and isolation** - Strong emphasis on secure, isolated development environments
+
+## Important Notes
+
+- This is a production system serving thousands of developers
+- Changes should be thoroughly tested and follow established patterns
+- Security considerations are paramount given the multi-tenant nature
+- Performance and scalability are critical concerns
+- The codebase spans multiple languages (Go, TypeScript, Java) and technologies
+
+Always refer to the memory bank documentation for the most current and detailed information about any aspect of the system.

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -127,7 +127,7 @@ USER gitpod
 ARG GITPOD_NODE_VERSION=22.15.1
 RUN bash -c ". .nvm/nvm.sh \
     && nvm install $GITPOD_NODE_VERSION \
-    && npm install -g typescript yarn"
+    && npm install -g typescript yarn @anthropic-ai/claude-code"
 ENV PATH=/home/gitpod/.nvm/versions/node/v${GITPOD_NODE_VERSION}/bin:$PATH
 
 ## Register leeway autocompletion in bashrc

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,7 +4,7 @@
 
 FROM gitpod/workspace-gitpod-dev:latest
 
-ENV TRIGGER_REBUILD 42
+ENV TRIGGER_REBUILD 43
 
 USER root
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Add support for Claude Code in this repo for Gitpod Classic and Gitpod.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
n/a

## How to test
<!-- Provide steps to test this PR -->
1. If you've never used `claude`, run it once, that'll generate a configuration file at `~/.claude.json`
2. Copy the configuration file to Gitpod Classic and Gitpod as a variable and secret file, respectively. 
   * ℹ️  Before you copy, empty the history and cachedChangelog fields to reduce length (Gitpod is limited to 4096)
   * For Gitpod Classic, create a User Variable called CLAUDE_JSON, and paste the file contents
   * For Gitpod, create a File Secret called CLAUDE_JSON, with a location of `/root/.claude.json`
4. Run a Gitpod Classic workspace from this PR, and then try using Claude, it should just work (a task configures Claude on workspace start to use the variable)
5. Run a Gitpod environment from this PR, and then try using Claude, it should just work (assuming you setup the File secret correctly, Gitpod will persist the secret file here for you)

### Test results

<img width="1913" alt="image" src="https://github.com/user-attachments/assets/4861e2bf-1b94-4c97-b967-973028ce0384" />

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
