### PR TITLE
Update GitHub CLI to v2.74.1 and parameterize version

### DIFF
--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -195,8 +195,9 @@ RUN sudo install-packages shellcheck \
     && sudo python3 -m pip install pre-commit
 
 # gh (Github CLI) binary:
-RUN cd /usr/bin && curl -fsSL https://github.com/cli/cli/releases/download/v2.35.0/gh_2.35.0_linux_amd64.tar.gz \
-    | sudo tar xzv --strip-components=2 gh_2.35.0_linux_amd64/bin/gh
+ARG GH_VERSION="2.74.1"
+RUN cd /usr/bin && curl -fsSL https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz \
+    | sudo tar xzv --strip-components=2 gh_${GH_VERSION}_linux_amd64/bin/gh
 
 # Install observability-related binaries
 ARG PROM_VERSION="2.36.0"


### PR DESCRIPTION
## Summary
• Upgrades GitHub CLI from v2.35.0 to v2.74.1 for latest features and bug fixes
• Introduces ARG GH_VERSION parameter for easier version management in future updates

Related: CLC-1425

🤖 Generated with [Claude Code](https://claude.ai/code)