### PR TITLE
Update dev/image tag to latest build

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+FROM eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     steps:
       - uses: actions/checkout@v4
       - name: Setup Environment
@@ -188,7 +188,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
       env:
         DB_HOST: "mysql"
         DB_PORT: "23306"
@@ -521,7 +521,7 @@ jobs:
       - create-runner
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-environment

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -131,7 +131,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -23,7 +23,7 @@ jobs:
   update-jetbrains:
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     needs: [ create-runner ]
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -39,7 +39,7 @@ jobs:
       gcp_credentials: ${{ secrets.SELF_HOSTED_GITHUB_RUNNER_GCP_CREDENTIALS }}
   jetbrains-smoke-test-linux:
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     steps:

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -99,7 +99,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
       volumes:
         - /var/tmp:/var/tmp
         - /tmp:/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}
       count: ${{ steps.set-matrix.outputs.count }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ needs.create-runner.outputs.label }}
     needs: [create-runner]
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     outputs:
       name: ${{ steps.configuration.outputs.name }}
       version: ${{ steps.configuration.outputs.version }}
@@ -166,7 +166,7 @@ jobs:
     needs: [configuration, infrastructure, create-runner]
     runs-on: ${{ needs.create-runner.outputs.label }}
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
     steps:
       - uses: actions/checkout@v4
       - name: Integration Test

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:kylos101-add-claude-code-gha.33073
+image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-1425-int-test-gha.33103
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:


### PR DESCRIPTION
## Summary
• Updates all dev-environment image references to use newly built tag `gpl-1425-int-test-gha.33103`.
• Ensures consistency across all CI/CD workflows and development environments with updated GitHub CLI v2.74.1

Blocked by: https://github.com/gitpod-io/gitpod/pull/20898
Fixes CLC-1425

🤖 Generated with [Claude Code](https://claude.ai/code)