### PR TITLE
Remove obsolete node labels for ws-daemon and registry-facade readiness

### DIFF
--- a/components/ws-manager-mk2/controllers/create.go
+++ b/components/ws-manager-mk2/controllers/create.go
@@ -339,14 +339,6 @@ func createDefiniteWorkspacePod(sctx *startWorkspaceContext) (*corev1.Pod, error
 			Key:      "gitpod.io/workload_workspace_" + workloadType,
 			Operator: corev1.NodeSelectorOpExists,
 		},
-		{
-			Key:      "gitpod.io/ws-daemon_ready_ns_" + sctx.Config.Namespace,
-			Operator: corev1.NodeSelectorOpExists,
-		},
-		{
-			Key:      "gitpod.io/registry-facade_ready_ns_" + sctx.Config.Namespace,
-			Operator: corev1.NodeSelectorOpExists,
-		},
 	}
 
 	affinity := &corev1.Affinity{

--- a/memory-bank/components/node-labeler.md
+++ b/memory-bank/components/node-labeler.md
@@ -77,12 +77,12 @@ The Node-Labeler component integrates with:
 
 ## Usage Patterns
 
-### Node Label Management
-The component adds the following labels to nodes:
-- `gitpod.io/registry-facade_ready_ns_<namespace>`: Indicates registry-facade is ready
-- `gitpod.io/ws-daemon_ready_ns_<namespace>`: Indicates ws-daemon is ready
+### Node Taint Management
+The component manages node taints to control workspace scheduling:
+- `gitpod.io/registry-facade-not-ready`: Added when registry-facade is not ready
+- `gitpod.io/ws-daemon-not-ready`: Added when ws-daemon is not ready
 
-These labels are used by the workspace scheduler to ensure workspaces are only scheduled on nodes with the required services.
+These taints prevent workspace pods from being scheduled on nodes where required services are not available.
 
 ### Cluster-Autoscaler Annotation Management
 The component adds or removes the following annotation:


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Removes the node labels `gitpod.io/ws-daemon_ready_ns_*` and `gitpod.io/registry-facade_ready_ns_*` as they are no longer necessary since workspace scheduling now relies on taints instead of positive labels.

Changes:
- ws-manager-mk2: Remove NodeSelectorRequirements for obsolete labels
- node-labeler: Remove label constants and management logic while preserving taint functionality
- Documentation: Update to reflect taint-based scheduling approach

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1326

## How to test
<!-- Provide steps to test this PR -->
Build a GCP packer images that applies taints on new nodes, but not labels, and assert workspaces can start.

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
