### PR TITLE
Add Ona banner notification

### DIFF
--- a/components/dashboard/src/AppNotifications.tsx
+++ b/components/dashboard/src/AppNotifications.tsx
@@ -134,8 +134,8 @@ const GITPOD_CLASSIC_SUNSET = {
     type: "info" as AlertType,
     preventDismiss: true, // This makes it so users can't dismiss the notification
     message: (
-        <span className="text-md text-white font-semibold">
-            Meet <img src={onaWordmark} alt="Ona" className="inline items-center h-4 w-auto" draggable="false" /> | the
+        <span className="text-md text-white font-semibold items-center justify-center">
+            Meet <img src={onaWordmark} alt="Ona" className="inline align-middle w-12 mb-0.5" draggable="false" /> | the
             privacy-first software engineering agent |{" "}
             <a href="https://ona.com/" target="_blank" rel="noreferrer" className="underline hover:no-underline">
                 Get early access


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->



<img width="981" alt="image" src="https://github.com/user-attachments/assets/4cde96dc-9164-4e81-bb51-34d23bf7193d" />




## Related Issue(s)
<!-- List the issue(s) this PR solves -->

Part of GRO-887

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
