### PR TITLE
[db] Fix collation drift with old installations

### DIFF
--- a/components/gitpod-db/src/typeorm/migration/1750344728596-FixCollationMismatch.ts
+++ b/components/gitpod-db/src/typeorm/migration/1750344728596-FixCollationMismatch.ts
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2025 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FixCollationMismatch1750344728596 implements MigrationInterface {
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        const versionRow = await queryRunner.query(`SELECT VERSION() as version`);
+        const version = versionRow[0].version;
+
+        // MySQL docs: https://dev.mysql.com/blog-archive/mysql-8-0-collations-migrating-from-older-collations/
+        // 5.7 default: utf8mb4_general_ci
+        // 8.0 default: utf8mb4_0900_ai_ci
+        let collation: string;
+        if (version.startsWith("5.7")) {
+            collation = "utf8mb4_general_ci";
+        } else {
+            // Assume MySQL 8.0+ for all other versions
+            collation = "utf8mb4_0900_ai_ci";
+        }
+
+        const dbNameRow = await queryRunner.query(`SELECT DATABASE() as dbName`);
+        const dbName = dbNameRow[0].dbName;
+
+        await queryRunner.query(`ALTER DATABASE ${dbName} CHARACTER SET utf8mb4 COLLATE ${collation};`);
+
+        await queryRunner.query(`ALTER TABLE d_b_org_env_var DEFAULT CHARACTER SET utf8mb4 COLLATE ${collation};`);
+        await queryRunner.query(`ALTER TABLE d_b_org_env_var CONVERT TO CHARACTER SET utf8mb4 COLLATE ${collation};`);
+
+        await queryRunner.query(
+            `ALTER TABLE d_b_workspace_instance_metrics DEFAULT CHARACTER SET utf8mb4 COLLATE ${collation};`,
+        );
+        await queryRunner.query(
+            `ALTER TABLE d_b_workspace_instance_metrics CONVERT TO CHARACTER SET utf8mb4 COLLATE ${collation};`,
+        );
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        // This migration is not reversible as it changes the database collation.
+    }
+}


### PR DESCRIPTION
## Description
Fixes an issue where in very old installations we have a case of COLLATION drift in two tables.

This PR fixes the issue by:
1. explicitly setting the default COLLATION (depending on MySQL version)
2. `CONVERT ... COLLATE` (depending on MySQL version)

We did extensive testing on a) data consistency and b) runtime impact of the migrations which is negligible (<8s). :heavy_check_mark: 

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1303
Fixes CLC-1439

## How to test
 1. see here for the test protocol, and verify it invalidates all concerns :heavy_check_mark: 
 2. smoke test:
   - [start a workspace in the preview](https://gpl-1303-f055bb08b3c.preview.gitpod-dev.com/new#https://github.com/geropl/bel)
   - once running, visit /org-admin and notice the workspaces list at the bottom shows your workspace :heavy_check_mark:
 3. CI tests are :green_circle: : :heavy_check_mark: 

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
