### PR TITLE
[VS Code Browser] Update stable code to `1.101.2`

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,7 +8,7 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-25a0a64070cf41d36fba83149a8c445040cc6509",
+        "image": "{{.Repository}}/ide/code:commit-fe29f3040155d94e7dc864784fba21fd07b1859f",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
           "{{.Repository}}/ide/gitpod-code-web:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
@@ -20,6 +20,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "1.101.1",
+            "image": "{{.Repository}}/ide/code:commit-25a0a64070cf41d36fba83149a8c445040cc6509",
+            "imageLayers": [
+              "{{.Repository}}/ide/gitpod-code-web:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
+              "{{.Repository}}/ide/code-codehelper:commit-c5a55dd02ababa6e40372e6f9aa03ae62afa30d6"
+            ]
+          },
           {
             "version": "1.100.2",
             "image": "{{.Repository}}/ide/code:commit-175fb0bebdc172d8af798007d86db475c38ecf07",


### PR DESCRIPTION
## Description
Update code to `1.101.2`

## How to test

Should be tested already in build PR, double check:

- [x] New version is pinnable
- [x] Stable version is updated and it can start workspace with it

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - ide-code-release</li>
	<li><b>🔗 URL</b> - <a href="https://ide-code-release.preview.gitpod-dev.com/workspaces" target="_blank">ide-code-release.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - ide-code-release-gha.33312</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-ide-code-release%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment