### PR TITLE
WIP: Hw/jb eap upgrade

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -293,7 +293,7 @@ RUN mkdir -p ~/.terraform \
     && printf "terraform -install-autocomplete 2> /dev/null\n" >>~/.bashrc
 
 ## Java
-ENV JAVA_VERSION=11.0.27.fx-zulu
+ENV JAVA_VERSION=21.0.3.fx-zulu
 RUN curl -fsSL "https://get.sdkman.io" | bash \
     && bash -c ". /root/.sdkman/bin/sdkman-init.sh \
     && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /root/.sdkman/etc/config \

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -58,6 +58,7 @@ tasks:
       exit 0
   - name: Java
     command: |
+      java --version
       if [ -z "$RUN_GRADLE_TASK" ]; then
         read -r -p "Press enter to continue Java gradle task"
       fi

--- a/components/ide/jetbrains/backend-plugin/BUILD.yaml
+++ b/components/ide/jetbrains/backend-plugin/BUILD.yaml
@@ -149,11 +149,19 @@ packages:
       - JB_QUALIFIER=stable-rider
       # Force skip plugin verification for Rider
       - NO_VERIFY_JB_PLUGIN=true
+      - SDKMAN_DIR=/home/gitpod/.sdkman
     config:
       commands:
-        - ["rm", "-rf", "src/main/kotlin/io/gitpod/jetbrains/remote/GitpodMetricControlProvider.kt"]
-        - ["mv", "build.gradle-stable.kts", "build.gradle.kts"]
-        - ["./build.sh", "${__git_commit}"]
+        - - "bash"
+          - "-c"
+          - >
+            >
+            echo java=11.0.27.fx-zulu > .sdkmanrc
+            && source "$SDKMAN_DIR/bin/sdkman-init.sh"
+            && sdk env install
+            && rm -rf src/main/kotlin/io/gitpod/jetbrains/remote/GitpodMetricControlProvider.kt
+            && mv build.gradle-stable.kts build.gradle.kts
+            && ./build.sh ${__git_commit}
   - name: plugin-latest-rider
     type: generic
     argdeps:

--- a/components/ide/jetbrains/backend-plugin/gradle-latest.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-latest.properties
@@ -2,10 +2,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=252.18003
+pluginSinceBuild=252.23309
 pluginUntilBuild=252.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
 pluginVerifierIdeVersions=2025.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/updates/updates.xml or exec `./gradlew printProductsReleases`
-platformVersion=252.18003.27
+platformVersion=252.23309.22

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -123,6 +123,17 @@ RUN install-packages netcat
 
 USER gitpod
 
+# Set up SDKMAN for gitpod user and ensure Java 21.0.3.fx-zulu is available
+RUN curl -s "https://get.sdkman.io" | bash \
+    && bash -c "source /home/gitpod/.sdkman/bin/sdkman-init.sh \
+    && sdk install java 21.0.3.fx-zulu \
+    && sdk default java 21.0.3.fx-zulu \
+    && sdk use java 21.0.3.fx-zulu"
+
+# Set Java environment variables for gitpod user
+ENV JAVA_HOME=/home/gitpod/.sdkman/candidates/java/current
+ENV PATH=$JAVA_HOME/bin:$PATH
+
 # Fix node version we develop against
 ARG GITPOD_NODE_VERSION=22.15.1
 RUN bash -c ". .nvm/nvm.sh \
@@ -132,6 +143,9 @@ ENV PATH=/home/gitpod/.nvm/versions/node/v${GITPOD_NODE_VERSION}/bin:$PATH
 
 ## Register leeway autocompletion in bashrc
 RUN bash -c "echo . \<\(leeway bash-completion\) >> ~/.bashrc"
+
+## Register SDKMAN initialization in bashrc
+RUN bash -c "echo 'source \"\$HOME/.sdkman/bin/sdkman-init.sh\"' >> ~/.bashrc"
 
 ### Google Cloud ###
 # not installed via repository as then 'docker-credential-gcr' is not available


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
