### PR TITLE
[server] Fix mismatch collation issue in workspace instance metrics query

### DIFF
--- a/components/gitpod-db/src/typeorm/workspace-db-impl.ts
+++ b/components/gitpod-db/src/typeorm/workspace-db-impl.ts
@@ -476,7 +476,12 @@ export class TypeORMWorkspaceDBImpl extends TransactionalDBImpl<WorkspaceDB> imp
         const sessions = (await workspaceInstanceRepo
             .createQueryBuilder("wsi")
             .leftJoinAndMapOne("wsi.workspace", DBWorkspace, "ws", "ws.id = wsi.workspaceId")
-            .leftJoinAndMapOne("wsi.metrics", DBWorkspaceInstanceMetrics, "wsim", "wsim.instanceId = wsi.id")
+            .leftJoinAndMapOne(
+                "wsi.metrics",
+                DBWorkspaceInstanceMetrics,
+                "wsim",
+                "wsim.instanceId COLLATE utf8mb4_general_ci = wsi.id COLLATE utf8mb4_general_ci",
+            )
             .where("ws.organizationId = :organizationId", { organizationId })
             .andWhere("wsi.creationTime >= :periodStart", { periodStart: periodStart.toISOString() })
             .andWhere("wsi.creationTime <= :periodEnd", { periodEnd: periodEnd.toISOString() })


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Search in codebase with `d_b_org_env_var`, `d_b_workspace_instance_metrics`, `DBOrgEnvVar`, `DBWorkspaceInstanceMetrics` (which table is altered in the last db migration) and check their usage, make sure the joined rows are using the same collation

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes CLC-1500

## How to test
<!-- Provide steps to test this PR -->
- Open workspace in preview
- Check the Insight page, it should work as usual

**Verify in real case**
- Alter tables with queries below (generated by Claude.ai)
```
-- MySQL queries to standardize collation to utf8mb4_0900_ai_ci
-- Based on the current schema analysis

-- First, alter the database default collation
ALTER DATABASE gitpod CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- Tables that need collation changes to utf8mb4_0900_ai_ci:

-- 1. d_b_app_installation (currently utf8mb4_general_ci)
ALTER TABLE d_b_app_installation CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 2. d_b_audit_log (currently latin1_swedish_ci)
ALTER TABLE d_b_audit_log CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 3. d_b_auth_provider_entry (currently utf8mb4_general_ci)
ALTER TABLE d_b_auth_provider_entry CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 4. d_b_blocked_repository (currently latin1_swedish_ci)
ALTER TABLE d_b_blocked_repository CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 5. d_b_code_sync_collection (currently latin1_swedish_ci)
ALTER TABLE d_b_code_sync_collection CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 6. d_b_code_sync_resource (currently latin1_swedish_ci)
ALTER TABLE d_b_code_sync_resource CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 7. d_b_cost_center (currently utf8mb4_general_ci)
ALTER TABLE d_b_cost_center CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 8. d_b_email_domain_filter (currently utf8mb4_general_ci)
ALTER TABLE d_b_email_domain_filter CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 9. d_b_free_credits (currently latin1_swedish_ci)
ALTER TABLE d_b_free_credits CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 10. d_b_gitpod_token (currently utf8mb4_general_ci)
ALTER TABLE d_b_gitpod_token CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 11. d_b_identity (currently utf8mb4_general_ci)
ALTER TABLE d_b_identity CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 12. d_b_installation_admin (currently latin1_swedish_ci)
ALTER TABLE d_b_installation_admin CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 13. d_b_license_key (currently latin1_swedish_ci)
ALTER TABLE d_b_license_key CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 14. d_b_linked_in_profile (currently utf8mb4_general_ci)
ALTER TABLE d_b_linked_in_profile CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 15. d_b_oauth_auth_code_entry (currently latin1_swedish_ci)
ALTER TABLE d_b_oauth_auth_code_entry CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 16. d_b_oidc_client_config (currently latin1_swedish_ci)
ALTER TABLE d_b_oidc_client_config CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 17. d_b_one_time_secret (currently utf8mb4_general_ci)
ALTER TABLE d_b_one_time_secret CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 18. d_b_org_env_var (already utf8mb4_0900_ai_ci - no change needed)
-- ALTER TABLE d_b_org_env_var CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 19. d_b_org_settings (currently utf8mb4_general_ci)
ALTER TABLE d_b_org_settings CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 20. d_b_personal_access_token (currently latin1_swedish_ci)
ALTER TABLE d_b_personal_access_token CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 21. d_b_prebuild_info (currently utf8mb4_general_ci)
ALTER TABLE d_b_prebuild_info CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 22. d_b_prebuilt_workspace (currently utf8mb4_general_ci)
ALTER TABLE d_b_prebuilt_workspace CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 23. d_b_prebuilt_workspace_updatable (currently utf8mb4_general_ci)
ALTER TABLE d_b_prebuilt_workspace_updatable CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 24. d_b_project (currently utf8mb4_general_ci)
ALTER TABLE d_b_project CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 25. d_b_project_env_var (currently utf8mb4_general_ci)
ALTER TABLE d_b_project_env_var CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 26. d_b_project_info (currently utf8mb4_general_ci)
ALTER TABLE d_b_project_info CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 27. d_b_project_usage (currently utf8mb4_general_ci)
ALTER TABLE d_b_project_usage CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 28. d_b_repository_white_list (currently utf8mb4_general_ci)
ALTER TABLE d_b_repository_white_list CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 29. d_b_snapshot (currently utf8mb4_general_ci)
ALTER TABLE d_b_snapshot CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 30. d_b_stripe_customer (currently latin1_swedish_ci)
ALTER TABLE d_b_stripe_customer CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 31. d_b_team (currently utf8mb4_general_ci)
ALTER TABLE d_b_team CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 32. d_b_team_membership (currently utf8mb4_general_ci)
ALTER TABLE d_b_team_membership CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 33. d_b_team_membership_invite (currently utf8mb4_general_ci)
ALTER TABLE d_b_team_membership_invite CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 34. d_b_token_entry (currently utf8mb4_general_ci)
ALTER TABLE d_b_token_entry CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 35. d_b_usage (currently latin1_swedish_ci)
ALTER TABLE d_b_usage CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 36. d_b_user (currently utf8mb4_general_ci)
ALTER TABLE d_b_user CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 37. d_b_user_env_var (currently utf8mb4_general_ci)
ALTER TABLE d_b_user_env_var CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 38. d_b_user_ssh_public_key (currently utf8mb4_general_ci)
ALTER TABLE d_b_user_ssh_public_key CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 39. d_b_volume_snapshot (currently utf8mb4_general_ci)
ALTER TABLE d_b_volume_snapshot CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 40. d_b_webhook_event (currently utf8mb4_general_ci)
ALTER TABLE d_b_webhook_event CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 41. d_b_workspace (currently utf8mb4_general_ci)
ALTER TABLE d_b_workspace CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 42. d_b_workspace_cluster (currently utf8mb4_general_ci)
ALTER TABLE d_b_workspace_cluster CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 43. d_b_workspace_instance (currently utf8mb4_general_ci)
ALTER TABLE d_b_workspace_instance CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 44. d_b_workspace_instance_metrics (already utf8mb4_0900_ai_ci - no change needed)
-- ALTER TABLE d_b_workspace_instance_metrics CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 45. d_b_workspace_instance_user (currently utf8mb4_general_ci)
ALTER TABLE d_b_workspace_instance_user CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 46. d_b_workspace_report_entry (currently utf8mb4_general_ci)
ALTER TABLE d_b_workspace_report_entry CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;

-- 47. migrations (currently latin1_swedish_ci)
ALTER TABLE migrations CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci;
```
- Check the Insight page

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-db-coll</li>
	<li><b>🔗 URL</b> - <a href="https://hw-db-coll.preview.gitpod-dev.com/workspaces" target="_blank">hw-db-coll.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-db-coll-gha.33339</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-db-coll%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
