### PR TITLE
fix: prevent XSS in returnToPath parameter by validating protocol

### DIFF
--- a/components/dashboard/src/utils.test.ts
+++ b/components/dashboard/src/utils.test.ts
@@ -45,6 +45,12 @@ test("urlHash and isTrustedUrlOrPath", () => {
         { location: "/", trusted: true },
         // eslint-disable-next-line no-script-url
         { location: "javascript:alert(1)", trusted: false },
+        // XSS bypass attempt with javascript: protocol and matching hostname
+        // eslint-disable-next-line no-script-url
+        { location: "javascript://example.org/%250aalert(1)", trusted: false },
+        // Other protocol attempts
+        { location: "data:text/html,<script>alert(1)</script>", trusted: false },
+        { location: "vbscript:alert(1)", trusted: false },
     ];
     isTrustedUrlOrPathCases.forEach(({ location, trusted }) => {
         expect(isTrustedUrlOrPath(location)).toBe(trusted);

--- a/components/dashboard/src/utils.ts
+++ b/components/dashboard/src/utils.ts
@@ -227,7 +227,9 @@ export function parseUrl(url: string): URL | null {
 
 export function isTrustedUrlOrPath(urlOrPath: string) {
     const url = parseUrl(urlOrPath);
-    const isTrusted = url ? window.location.hostname === url.hostname : urlOrPath.startsWith("/");
+    const isTrusted = url
+        ? window.location.hostname === url.hostname && url.protocol === "https:"
+        : urlOrPath.startsWith("/");
     if (!isTrusted) {
         console.warn("Untrusted URL", urlOrPath);
     }


### PR DESCRIPTION
## Description
Fixed a DOM XSS vulnerability in the `returnToPath` parameter validation. The vulnerability allowed attackers to bypass security checks using javascript: protocol URLs with matching hostnames (e.g., `javascript://gitpod.io/%250a{{malicious code}}`).

The fix adds protocol validation to ensure only HTTPS URLs with matching hostnames are trusted.

## Related Issue(s)
Fixes #CLC-1594

## How to test
1. Navigate to the login page with a malicious returnToPath parameter:
   /login?returnToPath=javascript://gitpod.io/%250aalert(1)
2. Verify the redirect is blocked (check console for "Untrusted URL" warning)
3. Test legitimate redirects still work:
- `/login?returnToPath=/workspaces`
- `/login?returnToPath=https://gitpod.io/dashboard`
4. Run the unit tests: `cd components/dashboard && npm test -- src/utils.test.ts`

## Documentation
No documentation changes required - this is a security fix that doesn't change user-facing functionality.

#### Preview status

<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - pd-clc-1594</li>
	<li><b>🔗 URL</b> - <a href="https://pd-clc-1594.preview.gitpod-dev.com/workspaces" target="_blank">pd-clc-1594.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - pd-CLC-1594-gha.33439</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-pd-clc-1594%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
   Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
   Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
   If enabled this will build `install/preview`
- [x] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
   If enabled this will create the environment on GCE infra
- [x] /werft preemptible
   Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
   Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>