### PR TITLE
[dev] Improve devcontainer, add automations

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,41 +1,121 @@
 {
-    "name": "gitpod",
-    "build": {
-        "context": "..",
-        "dockerfile": "./Dockerfile"
+  "name": "gitpod",
+  "build": {
+    "context": "..",
+    "dockerfile": "./Dockerfile"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+  },
+  "workspaceFolder": "/workspace/gitpod",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/gitpod,type=bind",
+  "mounts": [
+    "source=/usr/local/gitpod/config/,target=/usr/local/gitpod/config/,type=bind"
+  ],
+  "remoteEnv": {
+    "GIT_EDITOR": "code --wait",
+    "KUBE_EDITOR": "code --wait"
+  },
+  "forwardPorts": [
+    1337,
+    3000,
+    3001,
+    3306,
+    4000,
+    5900,
+    6080,
+    7777,
+    9229,
+    9999,
+    13001,
+    13444,
+    8022
+  ],
+  "portsAttributes": {
+    "13001": {
+      "label": "Port 13001",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
     },
-    "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/gitpod,type=bind",
-    "workspaceFolder": "/workspace/gitpod/",
-    "postCreateCommand": "dev/install-dependencies.sh",
-    "mounts": [
-        "source=/usr/local/gitpod/config/,target=/usr/local/gitpod/config/,type=bind"
-    ],
-    "remoteEnv": {
-        "GIT_EDITOR": "code --wait",
-        "KUBE_EDITOR": "code --wait"
+    "1337": {
+      "label": "Port 1337",
+      "onAutoForward": "openPreview",
+      "elevateIfNeeded": true
     },
-    "features": {
-        "ghcr.io/devcontainers/features/docker-in-docker:2": {
-            "installDockerComposeSwitch": false
-        }
+    "13444": {
+      "label": "Port 13444",
+      "elevateIfNeeded": true
     },
-    "customizations": {
-        "vscode": {
-            "extensions": [
-                "EditorConfig.EditorConfig",
-                "golang.go",
-                "hashicorp.terraform",
-                "ms-azuretools.vscode-docker",
-                "ms-kubernetes-tools.vscode-kubernetes-tools",
-                "stkb.rewrap",
-                "zxh404.vscode-proto3",
-                "matthewpi.caddyfile-support",
-                "timonwong.shellcheck",
-                "fwcd.kotlin",
-                "dbaeumer.vscode-eslint",
-                "esbenp.prettier-vscode",
-                "hbenl.vscode-mocha-test-adapter"
-            ]
-        }
+    "3000": {
+      "label": "Port 3000",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "3001": {
+      "label": "Port 3001",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "3306": {
+      "label": "Port 3306",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "4000": {
+      "label": "Port 4000",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "5900": {
+      "label": "Port 5900",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "6080": {
+      "label": "Port 6080",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "7777": {
+      "label": "Port 7777",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "8022": {
+      "label": "Port 8022",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "9229": {
+      "label": "Port 9229",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
+    },
+    "9999": {
+      "label": "Port 9999",
+      "onAutoForward": "ignore",
+      "elevateIfNeeded": true
     }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "EditorConfig.EditorConfig",
+        "golang.go",
+        "hashicorp.terraform",
+        "ms-azuretools.vscode-docker",
+        "ms-kubernetes-tools.vscode-kubernetes-tools",
+        "stkb.rewrap",
+        "zxh404.vscode-proto3",
+        "matthewpi.caddyfile-support",
+        "heptio.jsonnet",
+        "timonwong.shellcheck",
+        "fwcd.kotlin",
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "akosyakov.gitpod-monitor",
+        "hbenl.vscode-mocha-test-adapter"
+      ]
+    }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,87 +16,6 @@
     "GIT_EDITOR": "code --wait",
     "KUBE_EDITOR": "code --wait"
   },
-  "forwardPorts": [
-    1337,
-    3000,
-    3001,
-    3306,
-    4000,
-    5900,
-    6080,
-    7777,
-    9229,
-    9999,
-    13001,
-    13444,
-    8022
-  ],
-  "portsAttributes": {
-    "13001": {
-      "label": "Port 13001",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "1337": {
-      "label": "Port 1337",
-      "onAutoForward": "openPreview",
-      "elevateIfNeeded": true
-    },
-    "13444": {
-      "label": "Port 13444",
-      "elevateIfNeeded": true
-    },
-    "3000": {
-      "label": "Port 3000",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "3001": {
-      "label": "Port 3001",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "3306": {
-      "label": "Port 3306",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "4000": {
-      "label": "Port 4000",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "5900": {
-      "label": "Port 5900",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "6080": {
-      "label": "Port 6080",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "7777": {
-      "label": "Port 7777",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "8022": {
-      "label": "Port 8022",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "9229": {
-      "label": "Port 9229",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    },
-    "9999": {
-      "label": "Port 9999",
-      "onAutoForward": "ignore",
-      "elevateIfNeeded": true
-    }
-  },
   "customizations": {
     "vscode": {
       "extensions": [
@@ -108,12 +27,10 @@
         "stkb.rewrap",
         "zxh404.vscode-proto3",
         "matthewpi.caddyfile-support",
-        "heptio.jsonnet",
         "timonwong.shellcheck",
         "fwcd.kotlin",
         "dbaeumer.vscode-eslint",
         "esbenp.prettier-vscode",
-        "akosyakov.gitpod-monitor",
         "hbenl.vscode-mocha-test-adapter"
       ]
     }

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ dump.rdb
 
 # Claude settings
 .claude/settings.local.json
+
+# Gitpod mcp-config.json
+.gitpod/mcp-config.json

--- a/.gitpod/automations.yaml
+++ b/.gitpod/automations.yaml
@@ -1,0 +1,74 @@
+tasks:
+    removeADCFile:
+        command: |
+            if [[ -n "${GCP_ADC_FILE}" ]]; then
+              echo "$GCP_ADC_FILE" > "/home/gitpod/.config/gcloud/application_default_credentials.json"
+              yes | gcloud auth application-default revoke
+              gp env -u GCP_ADC_FILE
+            fi
+            exit 0
+        name: 'Remove GCP_ADC_FILE'
+        triggeredBy:
+            - postDevcontainerStart
+    installLocalAppCli:
+        command: |
+            leeway run components/local-app:install-cli
+            leeway run components/local-app:cli-completion
+            exit 0
+        name: 'Install `gitpod` CLI'
+        triggeredBy:
+            - postDevcontainerStart
+    configurePreview:
+        command: INSTALL_CONTEXT=true leeway run dev/preview:configure-workspace
+        dependsOn:
+            - installPreviewctl
+        name: 'Preview environment configuration'
+        triggeredBy:
+            - postDevcontainerStart
+    buildJava:
+        command: |
+            if [ -z "$RUN_GRADLE_TASK" ]; then
+              read -r -p "Press enter to continue Java gradle task"
+            fi
+            leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
+            leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel -- ./gradlew buildPlugin
+        name: 'Java: build with Gradle'
+    setupClaudeCode:
+        command: |
+            if [[ -z "${CLAUDE_JSON}" ]]; then
+              echo "Skipping setup for Claude Code. Setup a CLAUDE_JSON variable to reuse Claude Code in workspaces."
+            else
+              echo $CLAUDE_JSON > ~/.claude.json
+            fi
+        name: 'claude code'
+        triggeredBy:
+            - postDevcontainerStart
+    installPreviewctl:
+        command: leeway run dev/preview/previewctl:install
+        name: 'Preview environment configuration: init'
+    installInstallerDependencies:
+        command: |
+            (cd install/installer && make deps)
+            exit 0
+        name: 'Installer dependencies'
+        triggeredBy:
+            - postDevcontainerStart
+    buildTypescript:
+        command: yarn --network-timeout 100000 && yarn build
+        name: 'TypeScript: install and build'
+        triggeredBy:
+            - postDevcontainerStart
+    setupPreCommit:
+        command: |
+            pre-commit install --install-hooks
+            exit 0
+        name: 'Install pre-commit hooks'
+        triggeredBy:
+            - postDevcontainerStart
+    initGo:
+        command: |
+            ./components/gitpod-protocol/go/scripts/generate-config.sh
+            leeway exec --filter-type go -v -- go mod verify
+        name: 'Go: init'
+        triggeredBy:
+            - postDevcontainerStart

--- a/.gitpod/automations.yaml
+++ b/.gitpod/automations.yaml
@@ -1,15 +1,4 @@
 tasks:
-    removeADCFile:
-        command: |
-            if [[ -n "${GCP_ADC_FILE}" ]]; then
-              echo "$GCP_ADC_FILE" > "/home/gitpod/.config/gcloud/application_default_credentials.json"
-              yes | gcloud auth application-default revoke
-              gp env -u GCP_ADC_FILE
-            fi
-            exit 0
-        name: 'Remove GCP_ADC_FILE'
-        triggeredBy:
-            - postDevcontainerStart
     installLocalAppCli:
         command: |
             leeway run components/local-app:install-cli
@@ -27,22 +16,9 @@ tasks:
             - postDevcontainerStart
     buildJava:
         command: |
-            if [ -z "$RUN_GRADLE_TASK" ]; then
-              read -r -p "Press enter to continue Java gradle task"
-            fi
             leeway exec --package components/supervisor-api/java:lib --package components/gitpod-protocol/java:lib -- ./gradlew build
             leeway exec --package components/ide/jetbrains/backend-plugin:plugin-latest --package components/ide/jetbrains/gateway-plugin:publish-latest --parallel -- ./gradlew buildPlugin
         name: 'Java: build with Gradle'
-    setupClaudeCode:
-        command: |
-            if [[ -z "${CLAUDE_JSON}" ]]; then
-              echo "Skipping setup for Claude Code. Setup a CLAUDE_JSON variable to reuse Claude Code in workspaces."
-            else
-              echo $CLAUDE_JSON > ~/.claude.json
-            fi
-        name: 'claude code'
-        triggeredBy:
-            - postDevcontainerStart
     installPreviewctl:
         command: leeway run dev/preview/previewctl:install
         name: 'Preview environment configuration: init'

--- a/dev/install-dependencies.sh
+++ b/dev/install-dependencies.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-git config --global alias.lg "log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit"
-leeway run dev/preview:configure-workspace
-leeway run dev:install-dev-utils
-leeway run dev/preview/previewctl:install
-pre-commit install --install-hooks


### PR DESCRIPTION
Co-authored-by: Ona <no-reply@ona.com>

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
