### PR TITLE
[dev] Automatically authorize gh

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,7 @@
   "mounts": [
     "source=/usr/local/gitpod/config/,target=/usr/local/gitpod/config/,type=bind"
   ],
+  "onCreateCommand": "bash /workspace/gitpod/dev/setup-github-auth.sh",
   "remoteEnv": {
     "GIT_EDITOR": "code --wait",
     "KUBE_EDITOR": "code --wait"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -47,6 +47,10 @@ tasks:
       leeway run components/local-app:install-cli
       leeway run components/local-app:cli-completion
       exit 0
+  - name: Setup GitHub CLI Auth
+    init: |
+      bash /workspace/gitpod/dev/setup-github-auth.sh
+      exit 0
   # This task takes care of configuring your workspace so it can manage and interact
   # with preview environments.
   - name: Preview environment configuration

--- a/dev/github-token.sh
+++ b/dev/github-token.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# GitHub Token Helper
+# Dynamically retrieves GitHub token from git credentials
+# Safe to source - will not error if git credentials are unavailable
+
+# Only set GH_TOKEN if not already set and git credential is available
+if [ -z "$GH_TOKEN" ] && command -v git >/dev/null 2>&1; then
+    # Attempt to get token from git credentials, suppress errors
+    TOKEN=$(printf 'protocol=https\nhost=github.com\n' | git credential fill 2>/dev/null | awk -F= '/password/ {print $2}' 2>/dev/null)
+    
+    # Only export if we got a non-empty token
+    if [ -n "$TOKEN" ]; then
+        export GH_TOKEN="$TOKEN"
+    fi
+    
+    unset TOKEN
+fi

--- a/dev/setup-github-auth.sh
+++ b/dev/setup-github-auth.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# GitHub CLI Authentication Setup
+# Adds sourcing of GitHub token helper to shell profiles
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GITHUB_TOKEN_HELPER="$SCRIPT_DIR/github-token.sh"
+
+{
+    echo ""
+    echo "# GitHub token helper"
+    echo "source \"$GITHUB_TOKEN_HELPER\""
+} >> ~/.bashrc
+
+{
+    echo ""
+    echo "# GitHub token helper"
+    echo "source \"$GITHUB_TOKEN_HELPER\""
+} >> ~/.zshrc
+
+source "$GITHUB_TOKEN_HELPER"
+
+echo "✅ GitHub CLI configured"


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
