### PR TITLE
Unblock Ona on Classic: Fix SDKMAN_DIR mismatch in Flex environments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -294,6 +294,7 @@ RUN mkdir -p ~/.terraform \
 
 ## Java
 ENV JAVA_VERSION=11.0.27.fx-zulu
+# Install SDKMAN as root first (working approach), then create gitpod user and symlink
 RUN curl -fsSL "https://get.sdkman.io" | bash \
     && bash -c ". /root/.sdkman/bin/sdkman-init.sh \
     && sed -i 's/sdkman_selfupdate_enable=true/sdkman_selfupdate_enable=false/g' /root/.sdkman/etc/config \
@@ -308,6 +309,17 @@ RUN curl -fsSL "https://get.sdkman.io" | bash \
     && printf '<settings>\n  <localRepository>/workspace/m2-repository/</localRepository>\n</settings>\n' > /root/.m2/settings.xml \
     && echo 'export SDKMAN_DIR=\"/root/.sdkman\"' >> /root/.bashrc.d/99-java \
     && echo '[[ -s \"/root/.sdkman/bin/sdkman-init.sh\" ]] && source \"/root/.sdkman/bin/sdkman-init.sh\"' >> /root/.bashrc.d/99-java"
+
+# Create gitpod user and set up symlinks for SDKMAN compatibility with BUILD.yaml files
+RUN useradd -m -s /bin/bash gitpod && \
+    usermod -aG sudo gitpod && \
+    echo 'gitpod ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers && \
+    mkdir -p /home/gitpod/.bashrc.d && \
+    ln -sf /root/.sdkman /home/gitpod/.sdkman && \
+    ln -sf /root/.m2 /home/gitpod/.m2 && \
+    echo 'export SDKMAN_DIR="/home/gitpod/.sdkman"' >> /home/gitpod/.bashrc.d/99-java && \
+    echo '[[ -s "/home/gitpod/.sdkman/bin/sdkman-init.sh" ]] && source "/home/gitpod/.sdkman/bin/sdkman-init.sh"' >> /home/gitpod/.bashrc.d/99-java
+
 # above, we are adding the sdkman init to .bashrc (executing sdkman-init.sh does that), because one is executed on interactive shells, the other for non-interactive shells (e.g. plugin-host)
 ENV GRADLE_USER_HOME=/workspace/.gradle/
 


### PR DESCRIPTION
## Description
Install SDKMAN as root (proven working approach) then create gitpod user with symlinks to make SDKMAN accessible at /home/gitpod/.sdkman path expected by JetBrains plugin BUILD.yaml files. This resolves the issue where leeway run dev:preview fails in Flex environments due to SDKMAN path mismatch.

## Related Issue(s)
Fixes CLC-1619

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
