### PR TITLE
[VS Code Browser] Update stable code to `1.102.3`

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,11 +8,11 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-fe29f3040155d94e7dc864784fba21fd07b1859f",
+        "image": "{{.Repository}}/ide/code:commit-0ace0a96fe587b8cc1e7c3be22fc951cd6d90898",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
-          "{{.Repository}}/ide/gitpod-code-web:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
-          "{{.Repository}}/ide/code-codehelper:commit-c5a55dd02ababa6e40372e6f9aa03ae62afa30d6"
+          "{{.Repository}}/ide/gitpod-code-web:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+          "{{.Repository}}/ide/code-codehelper:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",
@@ -20,6 +20,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "1.101.2",
+            "image": "{{.Repository}}/ide/code:commit-fe29f3040155d94e7dc864784fba21fd07b1859f",
+            "imageLayers": [
+              "{{.Repository}}/ide/gitpod-code-web:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
+              "{{.Repository}}/ide/code-codehelper:commit-c5a55dd02ababa6e40372e6f9aa03ae62afa30d6"
+            ]
+          },
           {
             "version": "1.101.1",
             "image": "{{.Repository}}/ide/code:commit-25a0a64070cf41d36fba83149a8c445040cc6509",


### PR DESCRIPTION
## Description
Update code to `1.102.3`

## How to test

Should be tested already in build PR, double check:

- [ ] New version is pinnable
- [ ] Stable version is updated and it can start workspace with it

### Preview status
gitpod:summary

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment