### PR TITLE
Add netcat and redis-tools to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,6 +58,9 @@ RUN yes | unminimize \
     pigz \
     ### MySQL client ###
     mysql-client \
+    ### Network tools ###
+    netcat-openbsd \
+    redis-tools \
     ### Cypress deps
     libgtk2.0-0 \
     libgtk-3-0 \


### PR DESCRIPTION
This PR adds two commonly used network and database tools to the devcontainer:

- **netcat-openbsd** (binary name: `nc`) - Network utility for testing connections, port scanning, and data transfer
- **redis-tools** (binary name: `redis-cli`) - Redis command-line client for interacting with Redis instances

Both tools are frequently needed during development and debugging, especially for:
- Testing network connectivity and services
- Debugging Redis connections and data
- General network troubleshooting

The tools are installed alongside other development utilities in the Dockerfile and will be available in all devcontainer environments.