### PR TITLE
[JetBrains] Update IDE images to new build version

### DIFF
--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -13,15 +13,15 @@ defaultArgs:
   codeWebExtensionCommit: 3953e8160fffa97dd4a4509542b4bf7ff9b704cd
   xtermCommit: d547d4ff4590b66c3ea24342fc62e3afcf6b77bc
   noVerifyJBPlugin: false
-  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2025.1.1.1.tar.gz"
-  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2025.1.1.tar.gz"
-  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-2025.1.1.1.tar.gz"
-  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2025.1.1.tar.gz"
-  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2025.1.1.tar.gz"
-  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2025.1.1.tar.gz"
+  intellijDownloadUrl: "https://download.jetbrains.com/idea/ideaIU-2025.2.tar.gz"
+  golandDownloadUrl: "https://download.jetbrains.com/go/goland-2025.2.tar.gz"
+  pycharmDownloadUrl: "https://download.jetbrains.com/python/pycharm-2025.2.tar.gz"
+  phpstormDownloadUrl: "https://download.jetbrains.com/webide/PhpStorm-2025.2.tar.gz"
+  rubymineDownloadUrl: "https://download.jetbrains.com/ruby/RubyMine-2025.2.tar.gz"
+  webstormDownloadUrl: "https://download.jetbrains.com/webstorm/WebStorm-2025.2.tar.gz"
   riderDownloadUrl: "https://download.jetbrains.com/rider/JetBrains.Rider-2024.1.4.tar.gz"
-  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2025.1.1.tar.gz"
-  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2025.1.2.tar.gz"
+  clionDownloadUrl: "https://download.jetbrains.com/cpp/CLion-2025.2.tar.gz"
+  rustroverDownloadUrl: "https://download.jetbrains.com/rustrover/RustRover-2025.2.tar.gz"
   jbBackendVersion: "latest"
   dockerVersion: "27.5.1"
   dockerComposeVersion: "2.34.0-gitpod.1"

--- a/components/ide/jetbrains/backend-plugin/gradle-stable.properties
+++ b/components/ide/jetbrains/backend-plugin/gradle-stable.properties
@@ -2,10 +2,10 @@
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
 # revert pluginSinceBuild if it's unnecessary
-pluginSinceBuild=251.25410
-pluginUntilBuild=251.*
+pluginSinceBuild=252.23892
+pluginUntilBuild=252.*
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.
-pluginVerifierIdeVersions=2025.1
+pluginVerifierIdeVersions=2025.2
 # Version from "com.jetbrains.intellij.idea" which can be found at https://www.jetbrains.com/intellij-repository/snapshots
-platformVersion=251.26094.98
+platformVersion=252.23892-EAP-CANDIDATE-SNAPSHOT

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -287,6 +287,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2025.1.1.1",
+            "image": "{{.Repository}}/ide/intellij:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
+          {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/intellij:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
             "imageLayers": [
@@ -436,6 +444,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2025.1.1",
+            "image": "{{.Repository}}/ide/goland:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
+          {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/goland:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
             "imageLayers": [
@@ -578,6 +594,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2025.1.1.1",
+            "image": "{{.Repository}}/ide/pycharm:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
+          {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/pycharm:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
             "imageLayers": [
@@ -710,6 +734,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2025.1.1",
+            "image": "{{.Repository}}/ide/phpstorm:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
           {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/phpstorm:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
@@ -844,6 +876,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2025.1.1",
+            "image": "{{.Repository}}/ide/rubymine:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
+          {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/rubymine:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
             "imageLayers": [
@@ -976,6 +1016,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2025.1.1",
+            "image": "{{.Repository}}/ide/webstorm:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
           {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/webstorm:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
@@ -1171,6 +1219,14 @@
         "allowPin": true,
         "versions": [
           {
+            "version": "2025.1.1",
+            "image": "{{.Repository}}/ide/clion:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
+          {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/clion:commit-175fb0bebdc172d8af798007d86db475c38ecf07",
             "imageLayers": [
@@ -1295,6 +1351,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "2025.1.2",
+            "image": "{{.Repository}}/ide/rustrover:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+            "imageLayers": [
+              "{{.Repository}}/ide/jb-backend-plugin:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/jb-launcher:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
           {
             "version": "2025.1",
             "image": "{{.Repository}}/ide/rustrover:commit-175fb0bebdc172d8af798007d86db475c38ecf07",


### PR DESCRIPTION
## Description
This PR updates the JetBrains IDE images to the most recent `stable` version.

## How to test

Merge if:
- [ ] Tests are green, if something breaks then add tests for regressions.

<details>
<summary>if you want to test manually for some reasons</summary>

1. For each IDE changed on this PR, follow these steps:
2. Open the preview environment generated for this branch
3. Choose the stable version of the IDE that you're testing as your default editor
4. Start a workspace using any repository (e.g: `https://github.com/gitpod-io/empty`)
5. Verify that the workspace starts successfully
6. Verify that the IDE opens successfully
7. Verify that the version of the IDE corresponds to the one being updated in this PR
8. Warmup is working properly using IntelliJ and spring-petclinic project sample

The following resources should help, in case something goes wrong (e.g. workspaces don't start):

- https://www.gitpod.io/docs/troubleshooting#gitpod-logs-in-jetbrains-gateway
- https://docs.google.com/document/d/1K9PSB0G6NwX2Ns_SX_HEgMYTKYsgMJMY2wbh0p6t3lQ
</details>

## Release Notes
```release-note
Update JetBrains IDE images to most recent stable version.
```

## Werft options:
<!--
Optional annotations to add to the werft job.
* with-preview - whether to create a preview environment for this PR
-->
- [x] /werft with-preview
- [x] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] with-integration-tests=jetbrains
- [x] latest-ide-version=false

_This PR was created automatically with GitHub Actions using [this](https://github.com/gitpod-io/gitpod/blob/main/.github/workflows/jetbrains-updates.yml) GHA_