### PR TITLE
[server] Add Kiro editor OAuth client support

### DIFF
--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -166,26 +166,7 @@ const vscodeInsiders = createVSCodeClient("vscode-insiders", "VS Code Insiders")
 
 const vscodium = createVSCodeClient("vscodium", "VSCodium");
 const cursor = createVSCodeClient("cursor", "Cursor");
-
-const kiroClient: OAuthClient = {
-    id: "kiro-gitpod",
-    secret: "kiro-gitpod-secret",
-    name: "Kiro Editor: Gitpod extension",
-    redirectUris: ["kiro://gitpod.extension/complete-gitpod-auth"],
-    allowedGrants: ["authorization_code"],
-    scopes: [
-        { name: "function:getGitpodTokenScopes" },
-        { name: "function:getLoggedInUser" },
-        { name: "function:getWorkspace" },
-        { name: "function:getWorkspaces" },
-        { name: "function:getOwnerToken" },
-        { name: "function:startWorkspace" },
-        { name: "function:stopWorkspace" },
-        { name: "function:deleteWorkspace" },
-        { name: "function:listenForWorkspaceInstanceUpdates" },
-        { name: "resource:default" },
-    ],
-};
+const kiro = createVSCodeClient("kiro", "Kiro");
 
 export const inMemoryDatabase: InMemory = {
     clients: {
@@ -198,7 +179,7 @@ export const inMemoryDatabase: InMemory = {
         [cursor.id]: cursor,
         [desktopClient.id]: desktopClient,
         [toolbox.id]: toolbox,
-        [kiroClient.id]: kiroClient,
+        [kiro.id]: kiro,
     },
     tokens: {},
     scopes: {},

--- a/components/server/src/oauth-server/db.ts
+++ b/components/server/src/oauth-server/db.ts
@@ -167,6 +167,26 @@ const vscodeInsiders = createVSCodeClient("vscode-insiders", "VS Code Insiders")
 const vscodium = createVSCodeClient("vscodium", "VSCodium");
 const cursor = createVSCodeClient("cursor", "Cursor");
 
+const kiroClient: OAuthClient = {
+    id: "kiro-gitpod",
+    secret: "kiro-gitpod-secret",
+    name: "Kiro Editor: Gitpod extension",
+    redirectUris: ["kiro://gitpod.extension/complete-gitpod-auth"],
+    allowedGrants: ["authorization_code"],
+    scopes: [
+        { name: "function:getGitpodTokenScopes" },
+        { name: "function:getLoggedInUser" },
+        { name: "function:getWorkspace" },
+        { name: "function:getWorkspaces" },
+        { name: "function:getOwnerToken" },
+        { name: "function:startWorkspace" },
+        { name: "function:stopWorkspace" },
+        { name: "function:deleteWorkspace" },
+        { name: "function:listenForWorkspaceInstanceUpdates" },
+        { name: "resource:default" },
+    ],
+};
+
 export const inMemoryDatabase: InMemory = {
     clients: {
         [localClient.id]: localClient,
@@ -178,6 +198,7 @@ export const inMemoryDatabase: InMemory = {
         [cursor.id]: cursor,
         [desktopClient.id]: desktopClient,
         [toolbox.id]: toolbox,
+        [kiroClient.id]: kiroClient,
     },
     tokens: {},
     scopes: {},


### PR DESCRIPTION
Add support for Kiro editor OAuth integration to enable workspace management from the Kiro text editor.

Adds kiro-gitpod OAuth client with standard workspace management scopes.