### PR TITLE
chore: fix inconsistent function name in comment

### DIFF
--- a/components/ws-daemon/pkg/iws/uidmap.go
+++ b/components/ws-daemon/pkg/iws/uidmap.go
@@ -155,7 +155,7 @@ func WriteMapping(hostPID uint64, gid bool, mapping []*api.WriteIDMappingRequest
 	return nil
 }
 
-// findHosPID translates an in-container PID to the root PID namespace.
+// findHostPID translates an in-container PID to the root PID namespace.
 func (m *Uidmapper) findHostPID(containerPID, inContainerPID uint64) (uint64, error) {
 	paths := []string{fmt.Sprint(containerPID)}
 	seen := make(map[string]struct{})

--- a/components/ws-manager-mk2/controllers/workspace_controller.go
+++ b/components/ws-manager-mk2/controllers/workspace_controller.go
@@ -566,7 +566,7 @@ func (r *WorkspaceReconciler) deleteSecret(ctx context.Context, name, namespace 
 	return err
 }
 
-// errorLogConflict logs the error if it's a conflict, instead of returning it as a reconciler error.
+// errorResultLogConflict logs the error if it's a conflict, instead of returning it as a reconciler error.
 // This is to reduce noise in our error logging, as conflicts are to be expected.
 // For conflicts, instead a result with `Requeue: true` is returned, which has the same requeuing
 // behaviour as returning an error.


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

The function name in the comments does not match the actual method name. 

This PR aims to fix that issue.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
