### PR TITLE
Revert audit log args redaction to restore CloudWatch visibility

### DIFF
--- a/components/server/src/audit/AuditLogService.ts
+++ b/components/server/src/audit/AuditLogService.ts
@@ -53,16 +53,7 @@ export class AuditLogService {
             action: method,
             args: argsScrubbed,
         };
-        // The args param contains workspace IDs and other sensitive data. Since
-        // it's quite hard to detect them, best way is to simply not log it at
-        // all. It's still part of the audit database but does not appear in the
-        // component logs.
-        const logEntryForLogging = {
-            ...logEntry,
-            args: ["[redacted]"],
-        };
-
-        log.info("audit", new TrustedValue(logEntryForLogging));
+        log.info("audit", new TrustedValue(logEntry));
         await this.dbAuditLog.recordAuditLog(logEntry);
     }
 


### PR DESCRIPTION
## Problem

Customer reported that commit b007b1dca broke their audit monitoring setup by redacting args in CloudWatch logs (`/aws/containerinsights/meta/audit`). This has created security concerns as they've lost visibility into admin actions.

## Root Cause

Commit b007b1dca redacted args in the container logs (via `log.info()`) to prevent sensitive data exposure, but this affected customers who rely on CloudWatch for audit trail monitoring.

## Solution

Revert the args redaction to restore audit visibility in CloudWatch logs. The original audit database logs were never affected and continue to work properly.

## Impact

- ✅ Restores audit visibility for customers using CloudWatch monitoring
- ✅ Maintains compliance and security monitoring capabilities

Fixes customer complaint about missing args in CloudWatch audit logs.

Co-authored-by: Ona <no-reply@ona.com>