### PR TITLE
Update subscription message and enhance upgrade plan details for Gitpod's transition to Ona

### DIFF
--- a/components/dashboard/src/components/UsageBasedBillingConfig.tsx
+++ b/components/dashboard/src/components/UsageBasedBillingConfig.tsx
@@ -322,7 +322,7 @@ export default function UsageBasedBillingConfig({ hideSubheading = false }: Prop
                                         All you loved in Gitpod Classic and more: Parallel coding agents with full VS
                                         Code in browser. Each runs in its own sandbox, fire off many at once and handoff
                                         to web or desktop IDE, even start on mobile. <br />
-                                        <br /> Gitpod Classic sunsets Oct 15 - migrate in September and get $100 Core
+                                        <br /> Gitpod Classic sunsets Oct 15 - migrate in September and get $100 in
                                         credits.
                                     </span>
                                 </div>


### PR DESCRIPTION
Revise the subscription error message and provide clearer information about the transition from Gitpod to Ona, including new features and migration details. Update the UI to reflect these changes and remove outdated payment methods.

fixes GRO-1107

/hold