### PR TITLE
Redirect non-authenticated users from `gitpod.io/#` to `app.ona.com/#` for workspace creation

### DIFF
--- a/components/dashboard/src/App.tsx
+++ b/components/dashboard/src/App.tsx
@@ -18,6 +18,7 @@ import { LinkedInCallback } from "react-linkedin-login-oauth2";
 import { useQueryParams } from "./hooks/use-query-params";
 import { useTheme } from "./theme-context";
 import QuickStart from "./components/QuickStart";
+import { isGitpodIo, getURLHash } from "./utils";
 
 export const StartWorkspaceModalKeyBinding = `${/(Mac|iPhone|iPod|iPad)/i.test(navigator.platform) ? "⌘" : "Ctrl﹢"}O`;
 
@@ -62,6 +63,15 @@ const App: FC = () => {
 
     if (loading) {
         return <AppLoading />;
+    }
+
+    // Redirect non-signed-in Gitpod Classic PAYG users from gitpod.io/# to app.ona.com/#
+    const hash = getURLHash();
+    if (!user && isGitpodIo() && location.pathname === "/" && hash !== "") {
+        // Preserve the hash fragment when redirecting
+        const hashFragment = window.location.hash;
+        window.location.href = `https://app.ona.com/${hashFragment}`;
+        return <AppLoading />; // Show loading while redirecting
     }
 
     // Technically this should get handled in the QueryErrorBoundary, but having it here doesn't hurt

--- a/memory-bank/activeContext.md
+++ b/memory-bank/activeContext.md
@@ -19,6 +19,7 @@ Building a comprehensive knowledge base of the Gitpod codebase and architecture 
 - Enhanced API component documentation with code generation information
 - Implemented server readiness probe with database, SpiceDB, and Redis connectivity checks
 - **Improved `registry-facade` resilience by implementing a comprehensive retry mechanism for blob retrieval, addressing transient network errors.**
+- **Implemented redirect for non-signed-in Gitpod Classic PAYG users from `gitpod.io/#` (with hash fragments) to `app.ona.com/#`, preserving hash fragments. Only applies to users with hash fragments, not all gitpod.io visitors.**
 
 ## Next Steps
 

--- a/memory-bank/components/dashboard.md
+++ b/memory-bank/components/dashboard.md
@@ -65,6 +65,13 @@ The Dashboard provides interfaces for:
    - IDE preferences
    - Feature preview settings
 
+4. **Redirection Logic**:
+   - Redirects non-signed-in Gitpod Classic PAYG users from `gitpod.io/#` to `app.ona.com/#`
+   - Only triggers when a hash fragment is present (`hash !== ""`)
+   - Preserves hash fragments during the redirect
+   - Only applies to the root path (`/`) on gitpod.io domains
+   - Does NOT redirect users visiting `gitpod.io/` without hash fragments
+
 ## Development Workflow
 
 The Dashboard supports several development workflows:


### PR DESCRIPTION
### Summary
This PR implements a targeted redirect for non-authenticated Gitpod Classic PAYG users who visit `gitpod.io` with hash fragments (typically workspace creation URLs) to redirect them to `app.ona.com` instead.

### How It Works
The redirect triggers when **ALL** of the following conditions are met:
1. User is **not authenticated** (`!user`)
2. On a **Gitpod.io domain** (`isGitpodIo()` returns true)
3. On the **root path** (`location.pathname === "/"`)
4. **Hash fragment is present** (`hash !== ""`)

When triggered, users are redirected from `gitpod.io/#<context>` to `https://app.ona.com/#<context>`

### Scenarios Affected ✅
- `gitpod.io/#https://github.com/user/repo` → `app.ona.com/#https://github.com/user/repo`
- `gitpod.io/#prebuild/https://github.com/user/repo` → `app.ona.com/#prebuild/https://github.com/user/repo`
- `gitpod.io/#GITPOD_WORKSPACE_ID=xyz/https://github.com/user/repo` → `app.ona.com/#GITPOD_WORKSPACE_ID=xyz/https://github.com/user/repo`
- Any other workspace creation URLs with hash fragments

### Scenarios NOT Affected ❌
- **Regular gitpod.io visitors**: Users visiting `gitpod.io/` without hash fragments see the normal login page
- **Authenticated users**: Signed-in users continue using the dashboard normally, regardless of hash presence
- **Non-root paths**: Users on `/workspaces`, `/settings`, etc. are unaffected
- **Enterprise installations**: Only affects Gitpod.io (PAYG) domains
- **Other dashboard pages**: `/new`, `/login`, etc. work normally

### Edge Cases Considered
1. **Empty hash**: `gitpod.io/#` (empty hash) → No redirect (normal login page)
2. **Loading states**: Shows loading spinner during redirect to prevent flashing
3. **Hash preservation**: Complex hashes with environment variables are fully preserved
4. **Domain variants**: Works across all Gitpod.io domains (staging, dev environments)
5. **Quick start flow**: `/quickstart` pages remain unaffected
6. **Direct navigation**: Users can still directly access other dashboard routes
7. **Browser back/forward**: Standard browser navigation behavior maintained

### Testing Scenarios
- [ ] Non-authenticated user visits `gitpod.io/#https://github.com/test/repo` → redirected to `app.ona.com/#https://github.com/test/repo`
- [ ] Non-authenticated user visits `gitpod.io/` → sees normal login page
- [ ] Authenticated user visits `gitpod.io/#https://github.com/test/repo` → normal workspace creation flow
- [ ] Enterprise user visits their instance → no redirect
- [ ] User visits `gitpod.io/settings` → normal settings page

### Risk Assessment: Low
- **Scope**: Only affects non-authenticated users with hash fragments
- **Fallback**: Users can still access regular login if needed
- **Reversible**: Easy to disable if issues arise
- **Performance**: Minimal impact, only checks conditions during app initialization


/hold