### PR TITLE
fix: migrate from bitnami/mysql to bitnamilegacy/mysql

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,10 +175,10 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     services:
       mysql:
-        image: bitnami/mysql:8.0.33-debian-11-r24
+        image: bitnamilegacy/mysql:8.0.33-debian-11-r24
         env:
           MYSQL_ROOT_PASSWORD: test
-          #MYSQL_TCP_PORT: 23306 bitnami/mysql does not honor this, but has it's own:
+          #MYSQL_TCP_PORT: 23306 bitnamilegacy/mysql does not honor this, but has it's own:
           MYSQL_PORT_NUMBER: 23306
           MYSQL_AUTHENTICATION_PLUGIN: mysql_native_password
         ports:

--- a/components/gitpod-db/BUILD.yaml
+++ b/components/gitpod-db/BUILD.yaml
@@ -76,7 +76,7 @@ packages:
         # Check if a DB is present. If not: start one and wait until it's up
         # Note: In CI there is a DB running as sidecar; in workspaces we're starting it once.
         #       Re-use of the instance because of the init scripts (cmp. next step).
-        # (gpl): It would be nice to use bitnami/mysql here as we do in previews. However the container does not start in Gitpod workspaces due to some docker/kernel/namespace issue.
+        # (gpl): It would be nice to use bitnamilegacy/mysql here as we do in previews. However the container does not start in Gitpod workspaces due to some docker/kernel/namespace issue.
         - ["sh", "-c", "mysqladmin ping --wait=${DB_RETRIES:-1} -h $DB_HOST --port $DB_PORT -p$DB_PASSWORD -u$DB_USER --default-auth=mysql_native_password --silent || (docker container rm test-mysql; docker run --name test-mysql -d -e MYSQL_ROOT_PASSWORD=$DB_PASSWORD -e MYSQL_TCP_PORT=$DB_PORT -p $DB_PORT:$DB_PORT mysql:8.0.33 --default-authentication-plugin=mysql_native_password; while ! mysqladmin ping -h \"$DB_HOST\" -P \"$DB_PORT\" -p$DB_PASSWORD -u$DB_USER --default-auth=mysql_native_password --silent; do echo \"waiting for DB...\"; sleep 2; done)"]
         # Apply the DB initialization scripts (re-creates the "gitpod" DB if already there)
         - ["mkdir", "-p", "init-scripts"]

--- a/install/installer/third_party/charts/mysql/values.yaml
+++ b/install/installer/third_party/charts/mysql/values.yaml
@@ -5,6 +5,7 @@
 mysql:
   fullnameOverride: mysql
   image:
+    registry: docker.io/bitnamilegacy
     tag: "overwritten"
   primary:
     extraEnvVars:


### PR DESCRIPTION
## Problem

Bitnami has deprecated their public Debian-based MySQL images and moved them to a paid model. This is blocking our CI builds as referenced in the brownout incident.

## Solution

Migrate to use `bitnamilegacy/mysql` images which contain the same functionality but are available from the legacy repository.

## Changes

- **GitHub Actions**: Updated CI workflow to use `bitnamilegacy/mysql:8.0.33-debian-11-r24`
- **Helm Chart**: Added `registry: docker.io/bitnamilegacy` to MySQL chart values
- **Documentation**: Updated comments to reflect the migration

## Testing

- ✅ Verified all file changes are correct
- ✅ No other bitnami/mysql references found in codebase
- ⏳ CI will validate the new image works correctly

## References

- Fixes: CLC-1948
- Bitnami announcement: https://hub.docker.com/r/bitnami/mysql#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog