### PR TITLE
[CLC-2041] Block signups for Classic PAYG sunset

### DIFF
--- a/components/server/src/util/featureflags.ts
+++ b/components/server/src/util/featureflags.ts
@@ -85,3 +85,19 @@ export async function isUserLoginBlockedBySunset(user: User, isDedicatedInstalla
     // Installation-owned users (no organizationId) are blocked
     return true;
 }
+
+export async function isUserSignupBlockedBySunset(userId: string, isDedicatedInstallation: boolean): Promise<boolean> {
+    // Dedicated installations are never blocked
+    if (isDedicatedInstallation) {
+        return false;
+    }
+
+    const config = await getClassicPaygSunsetConfig(userId);
+
+    if (!config.enabled) {
+        return false;
+    }
+
+    // New users don't have roles/permissions or organizations yet, so we block all signups
+    return true;
+}


### PR DESCRIPTION
## Summary

Blocks new user signups when Classic PAYG sunset is enabled, complementing the existing login and workspace operation blocks from CLC-2032.

## Changes

### Backend (components/server/src/util/featureflags.ts)
- Added `isUserSignupBlockedBySunset()` function
  - Checks if sunset feature flag is enabled
  - Exempts dedicated installations
  - Blocks all signups (new users don't have organizations or roles yet)

### Backend (components/server/src/auth/generic-auth-provider.ts)
- Added signup blocking check in OAuth callback flow
- Blocks user creation when `VerifyResult.WithIdentity` is detected (new user signup)
- Redirects blocked signups to https://app.ona.com/login
- Logs blocked signup attempts for monitoring

## Testing

The implementation follows the same pattern as CLC-2032:
- Uses the same `classic_payg_sunset_enabled` feature flag
- Exempts dedicated installations via `isDedicatedInstallation` check
- Redirects to app.ona.com/login (consistent with login blocking)

Manual testing needed:
- [ ] Verify new users cannot sign up when sunset is enabled on gitpod.io
- [ ] Verify existing users can still log in (if not blocked by login checks)
- [ ] Verify dedicated installations are not affected
- [ ] Verify appropriate redirect to app.ona.com/login

## Related

- Closes CLC-2041
- Related to CLC-2032 (login and workspace blocking)