### PR TITLE
Update dev-environment image to main-gha.34181

### DIFF
--- a/.github/actions/delete-preview/Dockerfile
+++ b/.github/actions/delete-preview/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-gitpod/Dockerfile
+++ b/.github/actions/deploy-gitpod/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/deploy-monitoring-satellite/Dockerfile
+++ b/.github/actions/deploy-monitoring-satellite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/preview-create/Dockerfile
+++ b/.github/actions/preview-create/Dockerfile
@@ -1,4 +1,4 @@
-FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+FROM eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
 
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -106,7 +106,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ubuntu-latest-16-cores
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
       - uses: actions/checkout@v4
@@ -179,7 +179,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
       env:
         DB_HOST: "mysql"
@@ -515,7 +515,7 @@ jobs:
     environment: branch-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ubuntu-latest-16-cores
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
       - uses: actions/checkout@v4
@@ -183,7 +183,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
       env:
         DB_HOST: "mysql"
@@ -519,7 +519,7 @@ jobs:
     environment: main-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
     name: Configuration
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     outputs:
       name: ${{ steps.configuration.outputs.name }}
@@ -125,7 +125,7 @@ jobs:
     needs: [configuration, infrastructure]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
       volumes:
         - /var/tmp:/var/tmp

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -15,7 +15,7 @@ jobs:
   update-jetbrains:
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   jetbrains-smoke-test-linux:
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -92,7 +92,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
       volumes:
         - /var/tmp:/var/tmp

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Find stale preview environments"
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
     name: Configuration
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     outputs:
       name: ${{ steps.configuration.outputs.name }}
@@ -158,7 +158,7 @@ jobs:
     needs: [configuration, infrastructure]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
       - uses: actions/checkout@v4

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.33389
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:


### PR DESCRIPTION
## Description

Updates GitHub Actions workflows, Dockerfiles, and .gitpod.yml to use the latest dev-environment image version.

## Related Issue(s)

N/A

## How to test

Verify workflows run successfully with the new image version.

## Documentation

No documentation changes required.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold