### PR TITLE
chore: pin GitHub Actions to SHA (PDE-215)

### DIFF
--- a/.github/workflows/Monitor Branch Protection Changes.yml
+++ b/.github/workflows/Monitor Branch Protection Changes.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send Tampering Alert
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # pin@v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.BRANCH_PROTECTION_SLACK_BOT_TOKEN }}
         with:
@@ -72,7 +72,7 @@ jobs:
     steps:
       - name: Check Branch Protection Rules
         id: check-rules
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # pin@v7
         with:
           github-token: ${{ secrets.BRANCH_PROTECTION_PAT }}
           script: |
@@ -205,7 +205,7 @@ jobs:
 
       - name: Send Slack Notification - Branch Protection Event
         if: github.event_name == 'branch_protection_rule'
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # pin@v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.BRANCH_PROTECTION_SLACK_BOT_TOKEN }}
         with:
@@ -264,7 +264,7 @@ jobs:
 
       - name: Send Slack Notification - Changes Detected
         if: steps.check-rules.outputs.changes_detected == 'true'
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # pin@v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.BRANCH_PROTECTION_SLACK_BOT_TOKEN }}
         with:
@@ -315,7 +315,7 @@ jobs:
 
       - name: Send Slack Notification - Error
         if: failure()
-        uses: slackapi/slack-github-action@v1.24.0
+        uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # pin@v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.BRANCH_PROTECTION_SLACK_BOT_TOKEN }}
         with:

--- a/.github/workflows/authorization.yml
+++ b/.github/workflows/authorization.yml
@@ -12,8 +12,8 @@ jobs:
     name: Validate schema
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Validate SpiceDB schema
-        uses: authzed/action-spicedb-validate@v1.0.1
+        uses: authzed/action-spicedb-validate@3c2214196c200ff012a12d4fc12204efa7a3a416 # pin@v1.0.1
         with:
           validationfile: "components/spicedb/schema/schema.yaml"

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: "Determine Branch"
         id: branches
-        uses: transferwise/sanitize-branch-name@v1
+        uses: transferwise/sanitize-branch-name@009d85a96fcfe62a685b371dc8f299e53385ed9c # pin@v1
         # Since we trigger this worklow on other event types, besides pull_request
         # We use this action to help us get the pr body, as it's not included in push/workflow_dispatch events
       - uses: 8BitJonny/gh-get-current-pr@2.2.0
@@ -110,7 +110,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -137,7 +137,7 @@ jobs:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -189,7 +189,7 @@ jobs:
         # GitHub action + MySQL 8.0 need longer to initialize
         DB_RETRIES: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - uses: ./.github/actions/setup-environment
         with:
           identity_provider: ${{ github.ref == 'refs/heads/main' && secrets.CORE_DEV_PROVIDER || secrets.DEV_PREVIEW_PROVIDER }}
@@ -240,7 +240,7 @@ jobs:
 
           exit $RESULT
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # pin@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -382,12 +382,12 @@ jobs:
             echo "No critical vulnerabilities found."
           fi
       - name: Upload SBOMs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: sboms
           path: ${{ steps.scan.outputs.leeway_sboms_dir }}
       - name: Upload vulnerability reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: vulnerability-reports
           path: ${{ steps.scan.outputs.leeway_vulnerability_reports_dir }}
@@ -408,7 +408,7 @@ jobs:
           app-id: 308947
           installation-id: 35574470
       - name: trigger installation
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
         with:
           github-token: ${{ steps.auth.outputs.token }}
           script: |
@@ -440,7 +440,7 @@ jobs:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -457,7 +457,7 @@ jobs:
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
           image_repo_base: ${{needs.configuration.outputs.image_repo_base}}/build
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
         if: needs.configuration.outputs.pr_number != '' && contains(needs.configuration.outputs.pr_body, 'gitpod:summary')
         with:
           script: |
@@ -491,7 +491,7 @@ jobs:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-monitoring
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -523,7 +523,7 @@ jobs:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Run integration test
         id: integration-test
         uses: ./.github/actions/integration-tests
@@ -584,7 +584,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.WORKSPACE_SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":x:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: "Determine Branch"
         id: branches
-        uses: transferwise/sanitize-branch-name@v1
+        uses: transferwise/sanitize-branch-name@009d85a96fcfe62a685b371dc8f299e53385ed9c # pin@v1
         # Since we trigger this worklow on other event types, besides pull_request
         # We use this action to help us get the pr body, as it's not included in push/workflow_dispatch events
       - uses: 8BitJonny/gh-get-current-pr@2.2.0
@@ -113,7 +113,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -140,7 +140,7 @@ jobs:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -192,7 +192,7 @@ jobs:
         # GitHub action + MySQL 8.0 need longer to initialize
         DB_RETRIES: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - uses: ./.github/actions/setup-environment
         with:
           identity_provider: ${{ github.ref == 'refs/heads/main' && secrets.CORE_DEV_PROVIDER || secrets.DEV_PREVIEW_PROVIDER }}
@@ -243,7 +243,7 @@ jobs:
 
           exit $RESULT
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # pin@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -385,12 +385,12 @@ jobs:
             echo "No critical vulnerabilities found."
           fi
       - name: Upload SBOMs
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: sboms
           path: ${{ steps.scan.outputs.leeway_sboms_dir }}
       - name: Upload vulnerability reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: vulnerability-reports
           path: ${{ steps.scan.outputs.leeway_vulnerability_reports_dir }}
@@ -411,7 +411,7 @@ jobs:
           app-id: 308947
           installation-id: 35574470
       - name: trigger installation
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
         with:
           github-token: ${{ steps.auth.outputs.token }}
           script: |
@@ -443,7 +443,7 @@ jobs:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -460,7 +460,7 @@ jobs:
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
           image_repo_base: ${{needs.configuration.outputs.image_repo_base}}/build
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
         if: needs.configuration.outputs.pr_number != '' && contains(needs.configuration.outputs.pr_body, 'gitpod:summary')
         with:
           script: |
@@ -494,7 +494,7 @@ jobs:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-monitoring
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -526,7 +526,7 @@ jobs:
       group: ${{ needs.configuration.outputs.preview_name }}-integration-test
       cancel-in-progress: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Run integration test
         id: integration-test
         uses: ./.github/actions/integration-tests
@@ -587,7 +587,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.WORKSPACE_SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":x:"

--- a/.github/workflows/check-gitpodyaml.yml
+++ b/.github/workflows/check-gitpodyaml.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify
-        uses: KeisukeYamashita/create-comment@v1
+        uses: KeisukeYamashita/create-comment@1d95d97d7b1b73ab66e5ca931610e4e10ddc5eed # pin@v1
         with:
           number: ${{ github.event.pull_request.number }}
           comment: |

--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -10,7 +10,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Install dependencies
         run: |
           curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
@@ -40,7 +40,7 @@ jobs:
           fi
       - name: Create Release Pull Request
         if: steps.changes.outputs.dirty
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # pin@v6
         with:
           title: "[VS Code Browser] Build stable code `${{steps.updates.outputs.codeVersion}}`"
           body: |
@@ -89,10 +89,10 @@ jobs:
             team-experience
       - name: Get previous job's status
         id: lastrun
-        uses: filiptronicek/get-last-job-status@main
+        uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -14,7 +14,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - uses: ./.github/actions/setup-environment
         with:
           identity_provider: ${{ github.ref == 'refs/heads/main' && secrets.CORE_DEV_PROVIDER || secrets.DEV_PREVIEW_PROVIDER }}
@@ -42,10 +42,10 @@ jobs:
             .:docker-nightly
       - name: Get previous job's status
         id: lastrun
-        uses: filiptronicek/get-last-job-status@main
+        uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/code-updates.yml
+++ b/.github/workflows/code-updates.yml
@@ -7,7 +7,7 @@ jobs:
   update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Install dependencies
         run: |
           curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
@@ -38,7 +38,7 @@ jobs:
       - name: Create Release Pull Request
         if: ${{steps.changes.outputs.dirty && steps.updates.outputs.codeVersion}}
         id: code-update-pr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # pin@v6
         with:
           title: "[VS Code Browser] Update stable code to `${{steps.updates.outputs.codeVersion}}`"
           body: |
@@ -70,7 +70,7 @@ jobs:
 
       - name: Create Images Update Pull Request
         if: ${{steps.changes.outputs.dirty && !steps.updates.outputs.codeVersion}}
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # pin@v6
         with:
           title: "[code] update code image layers"
           body: |
@@ -104,7 +104,7 @@ jobs:
             team-experience
       - name: Slack notification (code)
         if: ${{ steps.code-update-pr.outputs.pull-request-url }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
@@ -124,7 +124,7 @@ jobs:
           app-id: 308947
           installation-id: 35574470
       - name: Trigger Open VS Code Server Release
-        uses: actions/github-script@v6
+        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
         with:
           github-token: ${{ steps.auth.outputs.token }}
           script: |

--- a/.github/workflows/configcat.yml
+++ b/.github/workflows/configcat.yml
@@ -9,9 +9,9 @@ jobs:
     name: Scan repository for configcat code references
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Scan & upload
-        uses: configcat/scan-repository@v2
+        uses: configcat/scan-repository@ccf34cbd7866cb9036351d9d4bf117e9aca311bf # pin@v2
         with:
           api-user: ${{ secrets.CONFIGCAT_API_USER }}
           api-pass: ${{ secrets.CONFIGCAT_API_PASS }}

--- a/.github/workflows/dashboard-sync.yml
+++ b/.github/workflows/dashboard-sync.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@master
+        uses: actions/checkout@61b9e3751b92087fd0b06925ba6dd6314e06f089 # pin@master
       - name: Run GitHub File Sync
-        uses: BetaHuhn/repo-file-sync-action@v1
+        uses: BetaHuhn/repo-file-sync-action@8b92be3375cf1d1b0cd579af488a9255572e4619 # pin@v1
         with:
           GH_PAT: ${{ secrets.ROBOQUAT_FSYNC_TOKEN }}

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
               } >> $GITHUB_OUTPUT
           fi
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
@@ -95,7 +95,7 @@ jobs:
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -131,7 +131,7 @@ jobs:
         - /var/tmp:/var/tmp
         - /tmp:/tmp
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         env:
           HOME: /home/gitpod
@@ -196,12 +196,12 @@ jobs:
           exit $FAILURE_COUNT
       - name: Test Summary
         id: test_summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # pin@v2
         with:
           paths: "test/tests/**/TEST-*.xml"
         if: always()
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         if: success() || failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
@@ -215,7 +215,7 @@ jobs:
     if: github.event.inputs.skip_delete != 'true' && always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -18,7 +18,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -62,10 +62,10 @@ jobs:
           fi
       - name: Get previous job's status
         id: lastrun
-        uses: filiptronicek/get-last-job-status@main
+        uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.find-target.outputs.buildNumber && steps.leeway-build.outputs.leewayUsingCache == 'false') || failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -44,17 +44,17 @@ jobs:
           echo "- Build URL: ${{ inputs.build_url }}" >> $GITHUB_STEP_SUMMARY
           echo "- JB Product: ${{ inputs.jb_product }}" >> $GITHUB_STEP_SUMMARY
           echo "- Latest Version: ${{ inputs.use_latest }}" >> $GITHUB_STEP_SUMMARY
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2
+      - uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # pin@v2
         with:
           go-version: "1.19"
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # pin@v4
         with:
           distribution: zulu
           java-version: "11"
           cache: "gradle"
       - name: Setup FFmpeg
-        uses: FedericoCarboni/setup-ffmpeg@v1
+        uses: FedericoCarboni/setup-ffmpeg@dbe266744738dd1fa54db0ecb35d11461c94a90a # pin@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Download build dependency
@@ -78,7 +78,7 @@ jobs:
           fi
       - name: Cache leeway build
         id: cache-npm
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # pin@v3
         with:
           path: /tmp/cache/
           key: ${{ runner.os }}-leeway-cache-${{ hashFiles('gateway.version') }}
@@ -114,7 +114,7 @@ jobs:
           cp -r dev/jetbrains-test/video dev/jetbrains-test/build/reports
       - name: Save report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: video
           path: |

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -28,7 +28,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout Repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
             - name: Install dependencies
               run: |
                 curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
@@ -58,7 +58,7 @@ jobs:
             - name: Create Pull Request for Gateway Plugin
               id: create-gateway-pr
               if: ${{ steps.changes.outputs.dirty && !inputs.isBackendPlugin }}
-              uses: peter-evans/create-pull-request@v6
+              uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # pin@v6
               with:
                   title: "[JetBrains] Update Platform Version from ${{ inputs.pluginName }}"
                   body: |
@@ -105,7 +105,7 @@ jobs:
             - name: Create Pull Request for Backend Plugin
               id: create-backend-pr
               if: ${{ steps.changes.outputs.dirty && inputs.isBackendPlugin }}
-              uses: peter-evans/create-pull-request@v6
+              uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # pin@v6
               with:
                   title: "[JetBrains] Update Platform Version from ${{ inputs.pluginName }}"
                   body: |
@@ -148,10 +148,10 @@ jobs:
                   author: Robo Quat <roboquat@gitpod.io>
             - name: Get previous job's status
               id: lastrun
-              uses: filiptronicek/get-last-job-status@main
+              uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
             - name: Slack Notification
               if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-              uses: rtCamp/action-slack-notify@v2
+              uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
               env:
                   SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
                   SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -10,7 +10,7 @@ jobs:
     update-jetbrains:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
             - name: Install dependencies
               run: |
                 curl -fsSL https://github.com/csweichel/oci-tool/releases/download/v0.2.1/oci-tool_0.2.1_linux_amd64.tar.gz | tar xz -C /usr/local/bin
@@ -35,7 +35,7 @@ jobs:
                 fi
             - name: Create Pull Request
               if: ${{steps.changes.outputs.dirty}}
-              uses: peter-evans/create-pull-request@v6
+              uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # pin@v6
               with:
                   title: "[JetBrains] Update IDE images to new build version"
                   body: |
@@ -92,10 +92,10 @@ jobs:
                     team-experience
             - name: Get previous job's status
               id: lastrun
-              uses: filiptronicek/get-last-job-status@main
+              uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
             - name: Slack Notification
               if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-              uses: rtCamp/action-slack-notify@v2
+              uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
               env:
                   SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -62,7 +62,7 @@ jobs:
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -98,7 +98,7 @@ jobs:
         - /var/tmp:/var/tmp
         - /tmp:/tmp
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -145,18 +145,18 @@ jobs:
           fi
       - name: Test Summary
         id: test_summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86 # pin@v2
         with:
           paths: "test/tests/**/TEST.xml"
         if: always()
       - id: auth
         if: failure()
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@955352c3b43196640b567e4646256d2fbb4aa1c7 # pin@v1
         with:
           token_format: access_token
           credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         if: failure()
         env:
           SLACK_WEBHOOK: "${{ secrets.DEVX_SLACK_WEBHOOK }}"
@@ -170,7 +170,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -18,7 +18,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -17,7 +17,7 @@ jobs:
       names: ${{ steps.set-matrix.outputs.names }}
       count: ${{ steps.set-matrix.outputs.count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
         with:
           fetch-depth: 0
       - name: Setup Environment
@@ -48,7 +48,7 @@ jobs:
       matrix:
         name: ${{ fromJSON(needs.stale.outputs.names) }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:

--- a/.github/workflows/public-api.yml
+++ b/.github/workflows/public-api.yml
@@ -7,14 +7,14 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: bufbuild/buf-setup-action@v1
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
+      - uses: bufbuild/buf-setup-action@a47c93e0b1648d5651a065437926377d060baa99 # pin@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: bufbuild/buf-lint-action@v1
+      - uses: bufbuild/buf-lint-action@06f9dd823d873146471cfaaf108a993fe00e5325 # pin@v1
         with:
           input: "components/public-api"
-      - uses: bufbuild/buf-breaking-action@v1
+      - uses: bufbuild/buf-breaking-action@c57b3d842a5c3f3b454756ef65305a50a587c5ba # pin@v1
         with:
           input: "components/public-api"
           # We compare against the target branch of the Pull Request, normally main

--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -12,7 +12,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # pin@v9
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
                   stale-issue-message: "This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions."

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -14,7 +14,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
 
       - name: Set git identity
         run: |
@@ -24,7 +24,7 @@ jobs:
           GITHUB_USER: roboquat
           GITHUB_EMAIL: roboquat@gitpod.io
 
-      - uses: imjasonh/setup-crane@v0.1
+      - uses: imjasonh/setup-crane@5146f708a817ea23476677995bf2133943b9be0b # pin@v0.1
 
       - name: Check if an update is available
         shell: bash
@@ -113,10 +113,10 @@ jobs:
 
       - name: Get previous job's status
         id: lastrun
-        uses: filiptronicek/get-last-job-status@main
+        uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.RELEASE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -59,7 +59,7 @@ jobs:
       version: ${{ steps.configuration.outputs.version }}
       image_repo_base: ${{ steps.configuration.outputs.image_repo_base }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: "Set outputs"
         id: configuration
         shell: bash
@@ -112,7 +112,7 @@ jobs:
               } >> $GITHUB_OUTPUT
           fi
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
+        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.WORKSPACE_SLACK_WEBHOOK }}
@@ -128,7 +128,7 @@ jobs:
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:
@@ -161,7 +161,7 @@ jobs:
       image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34181
       options: --user root
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Integration Test
         id: integration-test
         uses: ./.github/actions/integration-tests
@@ -182,7 +182,7 @@ jobs:
     if: inputs.skip_delete != 'true' && always()
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
       - name: Setup Environment
         uses: ./.github/actions/setup-environment
         with:


### PR DESCRIPTION
Pin all external GitHub Actions to specific commit SHAs for supply chain security.

## Changes

27 unique actions pinned (~100 references across 22 workflow files):

- `actions/cache@v3`
- `actions/checkout@master`, `@v2`, `@v4`
- `actions/github-script@v6`, `@v7`
- `actions/setup-go@v2`
- `actions/setup-java@v4`
- `actions/stale@v9`
- `actions/upload-artifact@v4`
- `authzed/action-spicedb-validate@v1.0.1`
- `BetaHuhn/repo-file-sync-action@v1`
- `bufbuild/buf-breaking-action@v1`
- `bufbuild/buf-lint-action@v1`
- `bufbuild/buf-setup-action@v1`
- `configcat/scan-repository@v2`
- `docker/login-action@v3`
- `FedericoCarboni/setup-ffmpeg@v1`
- `filiptronicek/get-last-job-status@main`
- `google-github-actions/auth@v1`
- `imjasonh/setup-crane@v0.1`
- `KeisukeYamashita/create-comment@v1`
- `peter-evans/create-pull-request@v6`
- `rtCamp/action-slack-notify@v2`
- `slackapi/slack-github-action@v1.24.0`
- `test-summary/action@v2`
- `transferwise/sanitize-branch-name@v1`

## Exceptions

- `gitpod-io/gh-app-auth@v0.1`: internal Gitpod action, not pinned to SHA

## Related

- Part of [PDE-138](https://linear.app/ona-team/issue/PDE-138)
- Closes [PDE-215](https://linear.app/ona-team/issue/PDE-215)