### PR TITLE
Revise sunset notice for Gitpod Classic

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Gitpod Classic is a developer platform providing on-demand, pre-configured development environments in the cloud. It allows developers to spin up secure workspaces with a simple .gitpod.yml configuration file, eliminating the need for manual environment setup. The platform integrates seamlessly with GitHub, GitLab, Bitbucket, and Azure DevOps, offering features like prebuilt environments, collaborative code reviews, and professional developer experience with VS Code extensions and customization options. Workspaces are ephemeral, secure, and based on Docker, providing developers with the same capabilities as their local Linux machines but in a consistent, reproducible cloud environment.
 
-> **Important: [Gitpod Classic pay-as-you-go will sunset on October 15th](https://ona.com/stories/gitpod-classic-payg-sunset)** 2025 (this date does not apply to Enterprise customers). All existing pay-as-you-go users should migrate to Ona before this date. See our blog for detailed instructions.
+> **Important: [Gitpod Classic pay-as-you-go did sunset on October 15th](https://ona.com/stories/gitpod-classic-payg-sunset)** 2025. See our blog for detailed instructions.
 
 ## Documentation
 


### PR DESCRIPTION
Updated sunset date for Gitpod Classic pay-as-you-go.

## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold
