### PR TITLE
[npm] Add repository field to published packages

### DIFF
--- a/components/gitpod-protocol/package.json
+++ b/components/gitpod-protocol/package.json
@@ -2,6 +2,10 @@
     "name": "@gitpod/gitpod-protocol",
     "version": "0.1.5",
     "license": "UNLICENSED",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/gitpod-io/gitpod"
+    },
     "main": "./lib/index.js",
     "types": "./lib/index.d.ts",
     "files": [

--- a/components/ide-metrics-api/typescript-grpc/package.json
+++ b/components/ide-metrics-api/typescript-grpc/package.json
@@ -2,6 +2,10 @@
   "name": "@gitpod/ide-metrics-api-grpc",
   "version": "0.0.1",
   "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gitpod-io/gitpod"
+  },
   "scripts": {
     "build": "sh build.sh"
   },

--- a/components/ide-metrics-api/typescript-grpcweb/package.json
+++ b/components/ide-metrics-api/typescript-grpcweb/package.json
@@ -2,6 +2,10 @@
   "name": "@gitpod/ide-metrics-api-grpcweb",
   "version": "0.0.1",
   "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gitpod-io/gitpod"
+  },
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "scripts": {

--- a/components/local-app-api/typescript-grpcweb/package.json
+++ b/components/local-app-api/typescript-grpcweb/package.json
@@ -2,6 +2,10 @@
   "name": "@gitpod/local-app-api-grpcweb",
   "version": "0.1.5",
   "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gitpod-io/gitpod"
+  },
   "main": "lib/localapp.js",
   "types": "lib/localapp.d.ts",
   "scripts": {

--- a/components/public-api/typescript/package.json
+++ b/components/public-api/typescript/package.json
@@ -2,6 +2,10 @@
   "name": "@gitpod/public-api",
   "version": "0.1.5",
   "license": "AGPL-3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gitpod-io/gitpod"
+  },
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "module": "./lib/esm/index.js",

--- a/components/supervisor-api/typescript-grpc/package.json
+++ b/components/supervisor-api/typescript-grpc/package.json
@@ -2,6 +2,10 @@
   "name": "@gitpod/supervisor-api-grpc",
   "version": "0.1.5",
   "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gitpod-io/gitpod"
+  },
   "scripts": {
     "build": "sh build.sh"
   },

--- a/components/supervisor-api/typescript-grpcweb/package.json
+++ b/components/supervisor-api/typescript-grpcweb/package.json
@@ -2,6 +2,10 @@
   "name": "@gitpod/supervisor-api-grpcweb",
   "version": "0.1.5",
   "license": "UNLICENSED",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/gitpod-io/gitpod"
+  },
   "scripts": {
     "build": "sh build.sh"
   },


### PR DESCRIPTION
Adds the `repository` field to all npm packages in the `publish-api` leeway package.

This field is required for npm provenance publishing with OIDC authentication.

**Packages updated:**
- `@gitpod/ide-metrics-api-grpc`
- `@gitpod/ide-metrics-api-grpcweb`
- `@gitpod/gitpod-protocol`
- `@gitpod/local-app-api-grpcweb`
- `@gitpod/supervisor-api-grpc`
- `@gitpod/supervisor-api-grpcweb`
- `@gitpod/public-api`