### PR TITLE
Fix update-image-digest workflow missing token

### DIFF
--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -115,6 +115,7 @@ jobs:
             Why? This is required to trigger workflows, so that PR checks pass and allow merging.
           labels: automated pr, kind/cleanup, release-note-none
           branch: update-digests
+          branch-suffix: timestamp
           delete-branch: true
 
       - name: Get previous job's status


### PR DESCRIPTION
## Description

The `update-image-digest.yml` workflow was failing because `secrets.ROBOQUAT_AUTOMATIC_CHANGELOG` is not available. This removes the explicit token parameter so the workflow uses the default `GITHUB_TOKEN` instead.

Also adds instructions for reviewers to trigger workflow checks after approval, since PRs created by `GITHUB_TOKEN` don't automatically trigger workflows.

## Related Issue(s)

Fixes CLC-2186

## How to test

1. Trigger the workflow manually via workflow_dispatch
2. Verify it creates a PR successfully (if there are digest updates)

## Documentation

No

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold