### PR TITLE
[previewctl] Add error logging in install-context command

### DIFF
--- a/dev/preview/previewctl/cmd/install_context.go
+++ b/dev/preview/previewctl/cmd/install_context.go
@@ -41,6 +41,7 @@ func newInstallContextCmd(logger *logrus.Logger) *cobra.Command {
 	install := func(retry bool, timeout time.Duration) error {
 		name, err := preview.GetName(branch)
 		if err != nil {
+			logger.WithError(err).Error("failed to get preview name")
 			return err
 		}
 
@@ -51,6 +52,7 @@ func newInstallContextCmd(logger *logrus.Logger) *cobra.Command {
 
 		p, err := preview.New(branch, logger)
 		if err != nil {
+			logger.WithError(err).Error("failed to create preview config")
 			return err
 		}
 
@@ -66,7 +68,9 @@ func newInstallContextCmd(logger *logrus.Logger) *cobra.Command {
 			SSHPrivateKeyPath: opts.sshPrivateKeyPath,
 		})
 
-		if err == nil {
+		if err != nil {
+			logger.WithError(err).Error("failed to install context")
+		} else {
 			lastSuccessfulPreviewEnvironment = p
 		}
 


### PR DESCRIPTION
## Problem

When `previewctl install-context` fails, the error message only shows `exit status 1` without any context about what went wrong:

```
+ previewctl install-context --branch workspace-637d043885 --log-level debug --timeout 10m
Error: exit status 1
...
time="2026-01-12 13:32:49" level=fatal msg="command failed." err="exit status 1"
```

## Root Cause

The failure happens before any logging occurs, likely in `PreRunE` when generating the SSH key. The `GenerateSSHPrivateKey()` function:
1. Doesn't create the parent directory if it doesn't exist (e.g., `/github/home/.ssh/`)
2. Uses `cmd.Run()` which discards all output, so `ssh-keygen` failures are silent

## Solution

### 1. Fix SSH key generation (`preview.go`)
- Create the parent directory with `os.MkdirAll()` before running `ssh-keygen`
- Capture and include `ssh-keygen` output in error messages

### 2. Add error logging in install function (`install_context.go`)
- Log errors with context at each failure point:
  - `failed to get preview name`
  - `failed to create preview config`
  - `failed to install context`

This complements PR #21246 which added error logging in `installVMSSHKeys()`.