### PR TITLE
Build Caddy v2.11.0-beta.2 from source for ide-proxy and dashboard

### DIFF
--- a/components/dashboard/leeway.Dockerfile
+++ b/components/dashboard/leeway.Dockerfile
@@ -18,8 +18,13 @@ RUN find . -type f \( -name '*.html' -o -name '*.js' -o -name '*.css' -o -name '
 
 COPY components-gitpod-protocol--gitpod-schema/gitpod-schema.json /www/static/schemas/gitpod-schema.json
 
+# Build Caddy from source to get v2.11.0-beta.2 with fixed smallstep/certificates
+FROM caddy:builder AS caddy-builder
+RUN xcaddy build v2.11.0-beta.2 --output /caddy
+
 FROM caddy/caddy:2.11-alpine
 
+COPY --from=caddy-builder /caddy /usr/bin/caddy
 COPY components-dashboard--static/conf/Caddyfile /etc/caddy/Caddyfile
 COPY --from=compress /www /www
 

--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -16,8 +16,13 @@ RUN for FILE in `ls /bin/gitpod-local-companion*`;do \
 RUN mkdir -p static/code
 RUN curl -o static/code/marketplace.json "https://raw.githubusercontent.com/EclipseFdn/publish-extensions/d9a7cc2d486ca881e9df310324f9752f48156283/extension-control/extensions.json"
 
+# Build Caddy from source to get v2.11.0-beta.2 with fixed smallstep/certificates
+FROM caddy:builder AS caddy-builder
+RUN xcaddy build v2.11.0-beta.2 --output /caddy
+
 FROM caddy/caddy:2.11-alpine
 
+COPY --from=caddy-builder /caddy /usr/bin/caddy
 COPY conf/Caddyfile /etc/caddy/Caddyfile
 COPY static /www/
 COPY --from=compress /static /www


### PR DESCRIPTION
## Description

The `caddy/caddy:2.11-alpine` Docker image is built from Caddy v2.11.0-beta.1, which still contains the vulnerable `smallstep/certificates v0.28.4`.

This PR adds a build stage to compile Caddy v2.11.0-beta.2 from source using `xcaddy`, which includes `smallstep/certificates v0.29.0` that fixes the critical vulnerability.

### Changes

- **ide-proxy**: Add `caddy-builder` stage to build Caddy v2.11.0-beta.2 from source
- **dashboard**: Add `caddy-builder` stage to build Caddy v2.11.0-beta.2 from source

### Vulnerability Fixed

**CRITICAL severity:**
- GHSA-h8cp-697h-8c8p - smallstep/certificates authorization bypass in ACME/SCEP (CVSS 10.0)

### Why this approach?

The proxy component already builds Caddy from source with plugins, so it was already fixed. The ide-proxy and dashboard components were using the pre-built Docker image which hasn't been updated to include the fix yet.

## Related Issue(s)

Fixes CLC-2189

## How to test

Tested on preview environment `gpl-clc-211e4ee7afe0.preview.gitpod-dev.com`:

- [x] Proxy health check returns 200
- [x] Dashboard loads without errors
- [x] Workspace IDE access works
- [x] SSH tunnel connectivity
- [x] CORS preflight requests
- [x] Workspace port forwarding
- [x] Workspace download
- [x] Terminal works (WebSocket connection)
- [x] ConfigCat endpoint responds
- [x] Analytics endpoint responds
- [x] Static binary downloads work

All tests verified on 2026-01-12.