### PR TITLE
[build] Fix HOME environment in deploy-gitpod action

### DIFF
--- a/.github/actions/deploy-gitpod/action.yml
+++ b/.github/actions/deploy-gitpod/action.yml
@@ -45,6 +45,10 @@ runs:
       run: |
         set -euox pipefail
 
+        # GitHub Actions sets HOME=/github/home which doesn't exist in the container.
+        # Restore HOME to /home/gitpod where the dev-environment is configured.
+        export HOME=/home/gitpod
+
         export VERSION="${INPUT_VERSION}"
         export IMAGE_REPO_BASE="${INPUT_IMAGE_REPO_BASE}"
 


### PR DESCRIPTION
## Problem

`previewctl install-context` fails with `exit status 1` when generating SSH keys because the HOME directory doesn't exist.

## Root Cause

Commit 80317cad8 converted `deploy-gitpod` from a Docker-based action to a composite action. The old Docker action explicitly set `export HOME=/home/gitpod`, but the composite action inherits GitHub Actions' default `HOME=/github/home`, which doesn't exist in the container.

```
Saving key "/github/home/.ssh/vm_ed25519" failed: No such file or directory
```

## Validation

Tested locally with the dev-environment container:

```bash
$ docker run --rm -e HOME=/github/home eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-npm-oidc-support-gha.42 \
  bash -c 'ssh-keygen -t ed25519 -q -N "" -f "$HOME/.ssh/vm_ed25519"'
Saving key "/github/home/.ssh/vm_ed25519" failed: No such file or directory

$ docker run --rm -e HOME=/github/home eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-npm-oidc-support-gha.42 \
  bash -c 'export HOME=/home/gitpod; mkdir -p $HOME/.ssh; ssh-keygen -t ed25519 -q -N "" -f "$HOME/.ssh/vm_ed25519" && echo SUCCESS'
SUCCESS
```

## Solution

Restore `export HOME=/home/gitpod` in the deploy-gitpod action to match the original Docker-based action behavior.