### PR TITLE
[build] Fix HOME environment in Install previewctl step

### DIFF
--- a/.github/actions/deploy-gitpod/action.yml
+++ b/.github/actions/deploy-gitpod/action.yml
@@ -30,6 +30,9 @@ runs:
       shell: bash
       run: |
         set -euo pipefail
+        # GitHub Actions sets HOME=/github/home which doesn't exist in the container.
+        # Restore HOME to /home/gitpod where the dev-environment is configured.
+        export HOME=/home/gitpod
         leeway run dev/preview/previewctl:install
 
     - name: Deploy Gitpod

--- a/dev/preview/previewctl/pkg/preview/preview.go
+++ b/dev/preview/previewctl/pkg/preview/preview.go
@@ -6,6 +6,7 @@ package preview
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -122,7 +123,18 @@ func (c *Config) GetName() string {
 }
 
 func GenerateSSHPrivateKey(path string) error {
-	return exec.Command("ssh-keygen", "-t", "ed25519", "-q", "-N", "", "-f", path).Run()
+	// Ensure the parent directory exists
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return fmt.Errorf("failed to create SSH key directory %s: %w", dir, err)
+	}
+
+	cmd := exec.Command("ssh-keygen", "-t", "ed25519", "-q", "-N", "", "-f", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ssh-keygen failed: %w: %s", err, string(output))
+	}
+	return nil
 }
 
 func SSHPreview(branch string) error {


### PR DESCRIPTION
## Problem

`previewctl install-context` fails with `exit status 1` when generating SSH keys because:
1. The `.ssh` directory doesn't exist in the container
2. `ssh-keygen` cannot create parent directories

**Finally** green: https://github.com/gitpod-io/gitpod/actions/runs/20951173092/job/60204946552

Fixes CLC-2192

## Root Cause

The `GenerateSSHPrivateKey()` function runs `ssh-keygen` but doesn't ensure the parent directory exists. When the `.ssh` directory is missing, `ssh-keygen` fails with "No such file or directory".

## Validation

Tested locally by simulating the GitHub Actions environment:

```bash
$ docker run --rm --user root -e HOME=/home/gitpod \
    eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:gpl-npm-oidc-support-gha.42 \
    bash -c 'ls /home/gitpod/.ssh'
ls: cannot access '/home/gitpod/.ssh': No such file or directory

$ docker run --rm --user root -e HOME=/home/gitpod \
    bash -c 'ssh-keygen -t ed25519 -q -N "" -f /home/gitpod/.ssh/vm_ed25519'
Saving key "/home/gitpod/.ssh/vm_ed25519" failed: No such file or directory
```

After fix - previewctl creates the directory and generates the key successfully.

## Solution

Update `GenerateSSHPrivateKey()` to:
1. Create the parent directory with `os.MkdirAll()` before running `ssh-keygen`
2. Capture and include `ssh-keygen` output in error messages for better debugging

Also adds `export HOME=/home/gitpod` to the "Install previewctl" step (from #21252 which only fixed the "Deploy Gitpod" step).