### PR TITLE
[proxy] Force HTTP/1.1 for public-api backend connections

### DIFF
--- a/components/proxy/conf/Caddyfile
+++ b/components/proxy/conf/Caddyfile
@@ -187,7 +187,13 @@ api.{$GITPOD_DOMAIN} {
 		import server_public_api
 	}
 
-	reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002
+	# Force HTTP/1.1 to backend to avoid HTTP/2 SETTINGS_ENABLE_CONNECT_PROTOCOL
+	# which can cause protocol errors with some corporate proxies/middleboxes
+	reverse_proxy public-api-server.{$KUBE_NAMESPACE}.{$KUBE_DOMAIN}:9002 {
+		transport http {
+			versions 1.1
+		}
+	}
 }
 
 # always redirect to HTTPS


### PR DESCRIPTION
## Problem

Some customers using VSCode Desktop experience connection failures with `ConnectError: [internal] Protocol error` when connecting to Gitpod workspaces. The error occurs at the HTTP/2 session level:

```
Error: Protocol error
    at Http2Session.onSessionInternalError (node:internal/http2/core:859:26)
```

Browser-based IDEs work fine for the same users.

## Root Cause

Caddy 2.9+ added WebSocket over HTTP/2 support (RFC 8441), which causes Caddy to send `SETTINGS_ENABLE_CONNECT_PROTOCOL=1` in HTTP/2 SETTINGS frames when connecting to backends.

Some corporate proxies and SSL inspection appliances (middleboxes) don't properly handle this relatively new HTTP/2 setting, causing:
- Malformed HTTP/2 frames
- Protocol errors
- Session termination

## Solution

Force HTTP/1.1 for the `public-api-server` backend connection. This avoids the HTTP/2 SETTINGS frame issue while maintaining HTTP/2 support for client-to-Caddy connections.

```caddyfile
reverse_proxy public-api-server... {
    transport http {
        versions 1.1
    }
}
```

## Impact

- Client connections to Caddy still use HTTP/2 (no change)
- Only the Caddy-to-backend connection is affected
- Connect-RPC/gRPC traffic works over HTTP/1.1

## Testing

This is a draft PR for validation. We need to:
1. Deploy to a test environment
2. Have the affected customer verify the fix
3. Monitor for any performance impact