### PR TITLE
Fix preview env GC not deleting terraform workspaces

### DIFF
--- a/dev/preview/workflow/preview/deploy-preview.sh
+++ b/dev/preview/workflow/preview/deploy-preview.sh
@@ -39,7 +39,10 @@ terraform_plan || PLAN_EXIT_CODE=$?
 case ${PLAN_EXIT_CODE} in
 0)
   log_success "No changes to the plan"
-  exit 0
+  # Don't exit yet if DESTROY is set - we still need to delete the workspace
+  if [ -z "${DESTROY-}" ]; then
+    exit 0
+  fi
   ;;
 1)
   log_error "Terraform plan failed"


### PR DESCRIPTION
## Description

The preview environment GC job repeatedly reports deleting the same environments across multiple runs. This happens because when `terraform plan -destroy` finds no resources to destroy (exit code 0), the script exits before deleting the terraform workspace.

The workspace is what `previewctl list stale` uses to detect preview environments, so orphaned workspaces keep appearing in subsequent GC runs.

## Related Issue(s)

N/A - discovered via workflow run analysis:
- https://github.com/gitpod-io/gitpod/actions/runs/21019539995
- https://github.com/gitpod-io/gitpod/actions/runs/21023959032

## How to test

1. Wait for the next scheduled GC run (every 4 hours) or trigger manually
2. Verify that preview environments with no resources are cleaned up and don't reappear in subsequent runs
3. Alternatively, check the job logs for "delete_workspace" being called after "No changes to the plan"