### PR TITLE
Fix leeway remote cache access in Ona environments

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -193,7 +193,7 @@ RUN curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o aws
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
     rm -rf awscliv2.zip ./aws
 
-ENV GO_VERSION=1.24.4
+ENV GO_VERSION=1.24.9
 ENV GOPATH=/root/go-packages
 ENV GOROOT=/root/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
## Problem

In Ona (devcontainer) environments, leeway rebuilds most packages from scratch instead of using the remote cache, significantly increasing environment startup time.

<img width="990" height="249" alt="image" src="https://github.com/user-attachments/assets/7b1a2766-b839-478a-b255-b46c97469c7d" />


## Root Cause

The Go version in `.devcontainer/Dockerfile` (1.24.4) differed from the Classic dev image (1.24.9).

Since `WORKSPACE.yaml` includes `go version` in the `environmentManifest`, this version difference caused all package hashes to differ between Classic and Ona environments, resulting in cache misses.

Before fix:
```
☁️  checking remote cache for past build artifacts for 172 packages
☁️  downloading 113 cached build artifacts
```

After fix:
```
☁️  checking remote cache for past build artifacts for 193 packages
☁️  downloading 191 cached build artifacts
```

## Solution

Update Go version in `.devcontainer/Dockerfile` from 1.24.4 to 1.24.9 to match Classic.