### PR TITLE
Update dashboard metadata to mention Ona rebrand

### DIFF
--- a/components/dashboard/public/index.html
+++ b/components/dashboard/public/index.html
@@ -12,17 +12,14 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">
-    <meta
-      name="Gitpod"
-      content="Always Ready-to-Code"
-    />
+    <meta name="description" content="Gitpod Classic Dashboard. Gitpod is now Ona - AI software engineers for your team at ona.com" />
     <meta
       name="extension-active"
       content="false"
     >
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Dashboard</title>
+    <title>Gitpod Dashboard</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/components/dashboard/public/manifest.json
+++ b/components/dashboard/public/manifest.json
@@ -1,6 +1,7 @@
 {
   "short_name": "Gitpod",
-  "name": "Gitpod - Always Ready-to-Code.",
+  "name": "Gitpod Dashboard - Now Ona",
+  "description": "Gitpod Classic Dashboard. Gitpod is now Ona - AI software engineers for your team at ona.com",
   "icons": [
     {
       "src": "favicon256.png",


### PR DESCRIPTION
Add description meta tag and update manifest to inform users that Gitpod is now Ona while keeping Gitpod Classic branding.

## Changes
- `index.html`: Added description meta tag mentioning Ona, updated title to "Gitpod Dashboard"
- `manifest.json`: Updated name to "Gitpod Dashboard - Now Ona", added description