### PR TITLE
Update JetBrains Gateway docs links to ona.com

### DIFF
--- a/components/ide-service/example-ide-config.json
+++ b/components/ide-service/example-ide-config.json
@@ -126,7 +126,7 @@
           "phpstorm"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
         ]
       },
       "jetbrains-toolbox": {
@@ -138,7 +138,7 @@
           "phpstorm"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Toolbox with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Toolbox with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
         ]
       },
       "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath.golden
@@ -65,7 +65,7 @@
                         "phpstorm"
                     ],
                     "installationSteps": [
-                        "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+                        "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
                     ]
                 },
                 "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath.json
@@ -64,7 +64,7 @@
           "phpstorm"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
         ]
       },
       "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_resolve.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_resolve.golden
@@ -67,7 +67,7 @@
                         "phpstorm"
                     ],
                     "installationSteps": [
-                        "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+                        "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
                     ]
                 },
                 "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_resolve.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_resolve.json
@@ -66,7 +66,7 @@
           "phpstorm"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
         ]
       },
       "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.golden
@@ -160,7 +160,7 @@
                         "phpstorm"
                     ],
                     "installationSteps": [
-                        "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+                        "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
                     ]
                 },
                 "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_happypath_versions.json
@@ -119,7 +119,7 @@
           "phpstorm"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
         ]
       },
       "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_idetype_not_correct.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_idetype_not_correct.json
@@ -66,7 +66,7 @@
           "phpstorm"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
         ]
       },
       "vscode": {

--- a/components/ide-service/pkg/server/testdata/ideconfig_idetype_unknown.json
+++ b/components/ide-service/pkg/server/testdata/ideconfig_idetype_unknown.json
@@ -66,7 +66,7 @@
           "phpstorm"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
+          "If you don't see an open dialog in your browser, make sure you have the \u003ca target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'\u003eJetBrains Gateway with Gitpod Plugin\u003c/a\u003e installed on your machine, and then click \u003cb\u003e${OPEN_LINK_LABEL}\u003c/b\u003e below."
         ]
       },
       "vscode": {

--- a/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnector.kt
+++ b/components/ide/jetbrains/gateway-plugin/src/main/kotlin/io/gitpod/jetbrains/gateway/GitpodConnector.kt
@@ -19,7 +19,7 @@ class GitpodConnector : GatewayConnector {
 
     override fun getDescription() = "Connect to Gitpod workspaces"
 
-    override fun getDocumentationAction() = GatewayConnectorDocumentationPage("https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway")
+    override fun getDocumentationAction() = GatewayConnectorDocumentationPage("https://ona.com/docs/classic/user/integrations/jetbrains-gateway")
 
     override fun getConnectorId() = "gitpod.connector"
 

--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -1453,7 +1453,7 @@
           "rustrover"
         ],
         "installationSteps": [
-          "If you don't see an open dialog in your browser, make sure you have the <a target='_blank' class='gp-link' href='https://www.gitpod.io/docs/ides-and-editors/jetbrains-gateway#getting-started-jetbrains-gateway'>JetBrains Gateway with Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below."
+          "If you don't see an open dialog in your browser, make sure you have the <a target='_blank' class='gp-link' href='https://ona.com/docs/classic/user/integrations/jetbrains-gateway#getting-started'>JetBrains Gateway with Gitpod Plugin</a> installed on your machine, and then click <b>${OPEN_LINK_LABEL}</b> below."
         ]
       },
       "jetbrains-toolbox": {


### PR DESCRIPTION
## Description

Migrate JetBrains Gateway documentation URLs from `gitpod.io/docs` to `ona.com/docs/classic` as part of the domain rebrand. The previous links were broken as well.

## Related Issue(s)

Fixes https://app.usepylon.com/issues?conversationID=477fb45c-e701-4aa2-8b74-28e5439cf801

## How to test

1. Search the changed files for `jetbrains-gateway` URLs
2. Verify all point to `ona.com/docs/classic/user/integrations/jetbrains-gateway`
3. Confirm no remaining references to `www.gitpod.io/docs/ides-and-editors/jetbrains-gateway`