### PR TITLE
Bump proxy base image to caddy/caddy:2.11.2-alpine (CVE-2026-22184)

### DIFF
--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /plugins
 COPY plugins /plugins
 
 # build caddy
-RUN xcaddy build v2.11.1 \
+RUN xcaddy build v2.11.2 \
   --output /caddy \
   --with github.com/gitpod-io/gitpod/proxy/plugins/corsorigin=/plugins/corsorigin \
   --with github.com/gitpod-io/gitpod/proxy/plugins/secwebsocketkey=/plugins/secwebsocketkey \
@@ -22,7 +22,7 @@ RUN xcaddy build v2.11.1 \
   --with github.com/gitpod-io/gitpod/proxy/plugins/sshtunnel=/plugins/sshtunnel \
   --with github.com/gitpod-io/gitpod/proxy/plugins/frontend_dev=/plugins/frontend_dev
 
-FROM caddy/caddy:2.11-alpine
+FROM caddy/caddy:2.11.2-alpine
 
 # Ensure latest packages are present, like security updates.
 RUN apk upgrade --no-cache \


### PR DESCRIPTION
## Motivation

The proxy Dockerfile was missed in #21333 and still uses `caddy/caddy:2.11-alpine`, which ships zlib 1.3.1-r2 (CVE-2026-22184). The other Caddy-based images (dashboard, ide-proxy) were already bumped.

Fixes CLC-2227.

## Changes

Bump `caddy/caddy:2.11-alpine` → `caddy/caddy:2.11.2-alpine` in `components/proxy/Dockerfile`. Together with the existing `apk upgrade --no-cache`, this resolves CVE-2026-22184 (zlib 1.3.1-r2 → 1.3.2-r0).

## Verification

Built the final stage locally and confirmed with grype that no critical/zlib vulnerabilities remain."