### PR TITLE
Add granular tracing spans for git checkout and supervisor startup

### DIFF
--- a/components/content-service/pkg/initializer/git.go
+++ b/components/content-service/pkg/initializer/git.go
@@ -238,8 +238,15 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 
 		// we already cloned the git repository but we need to check CloneTarget exists
 		// to avoid calling fetch from a non-existing branch
-		gitout, err := ws.GitWithOutput(ctx, nil, "ls-remote", "--exit-code", "origin", ws.CloneTarget)
-		if err != nil || len(gitout) == 0 {
+		var lsRemoteErr error
+		func() {
+			lsSpan, lsCtx := opentracing.StartSpanFromContext(ctx, "git.ls_remote")
+			lsSpan.SetTag("branch", ws.CloneTarget)
+			defer tracing.FinishSpan(lsSpan, &lsRemoteErr)
+
+			gitout, lsRemoteErr = ws.GitWithOutput(lsCtx, nil, "ls-remote", "--exit-code", "origin", ws.CloneTarget)
+		}()
+		if lsRemoteErr != nil || len(gitout) == 0 {
 			log.WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Warnf("Invalid default branch name. Changing to %v", defaultBranch)
 			ws.CloneTarget = defaultBranch
 		}
@@ -255,12 +262,25 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		if !isShallow {
 			fetchArgs = []string{"origin", "--recurse-submodules=no", ws.CloneTarget}
 		}
-		if err := ws.Git(ctx, "fetch", fetchArgs...); err != nil {
+		if err := func() (fetchErr error) {
+			fetchSpan, fetchCtx := opentracing.StartSpanFromContext(ctx, "git.fetch_branch")
+			fetchSpan.SetTag("branch", ws.CloneTarget)
+			fetchSpan.SetTag("shallow", isShallow)
+			defer tracing.FinishSpan(fetchSpan, &fetchErr)
+
+			return ws.Git(fetchCtx, "fetch", fetchArgs...)
+		}(); err != nil {
 			log.WithError(err).WithField("isShallow", isShallow).WithField("remoteURI", ws.RemoteURI).WithField("branch", ws.CloneTarget).Error("Cannot fetch remote branch")
 			return err
 		}
 
-		if err := ws.Git(ctx, "-c", "core.hooksPath=/dev/null", "checkout", "-B", branchName, "origin/"+ws.CloneTarget); err != nil {
+		if err := func() (checkoutErr error) {
+			checkoutSpan, checkoutCtx := opentracing.StartSpanFromContext(ctx, "git.checkout")
+			checkoutSpan.SetTag("branch", branchName)
+			defer tracing.FinishSpan(checkoutSpan, &checkoutErr)
+
+			return ws.Git(checkoutCtx, "-c", "core.hooksPath=/dev/null", "checkout", "-B", branchName, "origin/"+ws.CloneTarget)
+		}(); err != nil {
 			log.WithError(err).WithField("remoteURI", ws.RemoteURI).WithField("branch", branchName).Error("Cannot fetch remote branch")
 			return err
 		}
@@ -273,24 +293,45 @@ func (ws *GitInitializer) realizeCloneTarget(ctx context.Context) (err error) {
 		// We did a shallow clone before, hence need to fetch the commit we are about to check out.
 		// Because we don't want to make the "git fetch" mechanism in supervisor more complicated,
 		// we'll just fetch the 20 commits right away.
-		if err := ws.Git(ctx, "fetch", "origin", ws.CloneTarget, "--depth=20"); err != nil {
+		if err := func() (fetchErr error) {
+			fetchSpan, fetchCtx := opentracing.StartSpanFromContext(ctx, "git.fetch_commit")
+			fetchSpan.SetTag("commit", ws.CloneTarget)
+			defer tracing.FinishSpan(fetchSpan, &fetchErr)
+
+			return ws.Git(fetchCtx, "fetch", "origin", ws.CloneTarget, "--depth=20")
+		}(); err != nil {
 			return err
 		}
 
 		// checkout specific commit
-		if err := ws.Git(ctx, "-c", "core.hooksPath=/dev/null", "checkout", ws.CloneTarget); err != nil {
+		if err := func() (checkoutErr error) {
+			checkoutSpan, checkoutCtx := opentracing.StartSpanFromContext(ctx, "git.checkout")
+			checkoutSpan.SetTag("commit", ws.CloneTarget)
+			defer tracing.FinishSpan(checkoutSpan, &checkoutErr)
+
+			return ws.Git(checkoutCtx, "-c", "core.hooksPath=/dev/null", "checkout", ws.CloneTarget)
+		}(); err != nil {
 			return err
 		}
 	default:
 		// update to remote HEAD
-		if _, err := ws.GitWithOutput(ctx, nil, "reset", "--hard", "origin/HEAD"); err != nil {
-			var giterr git.OpFailedError
-			if errors.As(err, &giterr) && strings.Contains(giterr.Output, "unknown revision or path not in the working tree") {
-				// 'git reset --hard origin/HEAD' returns a non-zero exit code if origin does not have a single commit (empty repository).
-				// In this case that's not an error though, hence we don't want to fail here.
-			} else {
-				return err
+		if err := func() error {
+			resetSpan, resetCtx := opentracing.StartSpanFromContext(ctx, "git.reset_hard")
+			var resetErr error
+			defer tracing.FinishSpan(resetSpan, &resetErr)
+
+			_, resetErr = ws.GitWithOutput(resetCtx, nil, "reset", "--hard", "origin/HEAD")
+			if resetErr != nil {
+				var giterr git.OpFailedError
+				if errors.As(resetErr, &giterr) && strings.Contains(giterr.Output, "unknown revision or path not in the working tree") {
+					// 'git reset --hard origin/HEAD' returns a non-zero exit code if origin does not have a single commit (empty repository).
+					// In this case that's not an error though, hence we don't want to fail here.
+					resetErr = nil
+				}
 			}
+			return resetErr
+		}(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/components/supervisor/pkg/supervisor/supervisor.go
+++ b/components/supervisor/pkg/supervisor/supervisor.go
@@ -49,10 +49,13 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	"github.com/opentracing/opentracing-go"
+
 	"github.com/gitpod-io/gitpod/common-go/analytics"
 	"github.com/gitpod-io/gitpod/common-go/experiments"
 	"github.com/gitpod-io/gitpod/common-go/log"
 	"github.com/gitpod-io/gitpod/common-go/pprof"
+	"github.com/gitpod-io/gitpod/common-go/tracing"
 	csapi "github.com/gitpod-io/gitpod/content-service/api"
 	"github.com/gitpod-io/gitpod/content-service/pkg/executor"
 	"github.com/gitpod-io/gitpod/content-service/pkg/git"
@@ -180,6 +183,11 @@ func Run(options ...RunOption) {
 		o(&opts)
 	}
 
+	tracingCloser := tracing.Init("supervisor")
+	if tracingCloser != nil {
+		defer tracingCloser.Close()
+	}
+
 	cfg, err := GetConfig()
 	if err != nil {
 		log.WithError(err).Fatal("configuration error")
@@ -271,15 +279,20 @@ func Run(options ...RunOption) {
 	}
 
 	if !opts.RunGP {
-		gitpodService = serverapi.NewServerApiService(ctx, &serverapi.ServiceConfig{
-			Host:              host,
-			Endpoint:          endpoint,
-			InstanceID:        cfg.WorkspaceInstanceID,
-			WorkspaceID:       cfg.WorkspaceID,
-			OwnerID:           cfg.OwnerId,
-			SupervisorVersion: Version,
-			ConfigcatEnabled:  cfg.ConfigcatEnabled,
-		}, tokenService)
+		func() {
+			span, _ := opentracing.StartSpanFromContext(ctx, "startup.api_client_setup")
+			defer span.Finish()
+
+			gitpodService = serverapi.NewServerApiService(ctx, &serverapi.ServiceConfig{
+				Host:              host,
+				Endpoint:          endpoint,
+				InstanceID:        cfg.WorkspaceInstanceID,
+				WorkspaceID:       cfg.WorkspaceID,
+				OwnerID:           cfg.OwnerId,
+				SupervisorVersion: Version,
+				ConfigcatEnabled:  cfg.ConfigcatEnabled,
+			}, tokenService)
+		}()
 	}
 
 	if cfg.GetDesktopIDE() != nil {
@@ -605,6 +618,10 @@ func installDotfiles(ctx context.Context, cfg *Config, tokenService *InMemoryTok
 	if repo == "" {
 		return
 	}
+
+	span, ctx := opentracing.StartSpanFromContext(ctx, "devcontainer.dotfiles")
+	span.SetTag("repo", repo)
+	defer span.Finish()
 
 	const dotfilePath = "/home/gitpod/.dotfiles"
 	if _, err := os.Stat(dotfilePath); err == nil {
@@ -1673,13 +1690,17 @@ func startSSHServer(ctx context.Context, cfg *Config, wg *sync.WaitGroup) {
 	}
 
 	go func() {
+		span, ctx := opentracing.StartSpanFromContext(ctx, "devcontainer.start_ssh")
 		ssh, err := newSSHServer(ctx, cfg, childProcEnvvars)
 		if err != nil {
+			tracing.LogError(span, err)
+			span.Finish()
 			log.WithError(err).Error("err creating SSH server")
 			return
 		}
 		configureSSHDefaultDir(cfg)
 		configureSSHMessageOfTheDay()
+		span.Finish()
 		err = ssh.listenAndServe()
 		if err != nil {
 			log.WithError(err).Error("err starting SSH server")


### PR DESCRIPTION
## Context

Resolves [CORE-7634](https://linear.app/ona-team/issue/CORE-7634/add-granular-tracing-spans-for-git-checkout-and-post-creation-setup)

Git checkout/reset took 5s for a small repo (AndroidBlock) but without sub-spans we can't determine which git operation is slow. Similarly, supervisor startup phases lack spans for dotfiles, SSH, and API client setup.

## Changes

### `content-service/pkg/initializer/git.go`

Break down the existing `realizeCloneTarget` span into individual sub-operations:

| Span | Operation |
|------|-----------|
| `git.ls_remote` | Branch existence check (network call) |
| `git.fetch_branch` | Fetch specific branch |
| `git.fetch_commit` | Fetch specific commit |
| `git.checkout` | Branch/commit checkout |
| `git.reset_hard` | Reset to origin/HEAD |

### `supervisor/pkg/supervisor/supervisor.go`

Initialize opentracing in the supervisor and add spans:

| Span | Operation |
|------|-----------|
| `startup.api_client_setup` | Gitpod API service creation |
| `devcontainer.dotfiles` | Dotfiles clone and install |
| `devcontainer.start_ssh` | SSH server creation and setup |

## Notes

Several spans from the issue (`devcontainer.chown`, `devcontainer.write_secrets`, `devcontainer.docker_login`, `startup.gateway_setup`) reference `reconciler.go` which does not exist in this codebase — these likely belong to a different component (Gitpod Flex agent) and are not addressed here.

No `git.clean` call exists in the current `realizeCloneTarget` implementation, so that span was omitted.

No direct performance savings — this enables data-driven optimization of startup bottlenecks.