### PR TITLE
[VS Code Browser] Update stable code to `1.111.0`

### DIFF
--- a/install/installer/pkg/components/ide-service/ide-configmap.json
+++ b/install/installer/pkg/components/ide-service/ide-configmap.json
@@ -8,11 +8,11 @@
         "type": "browser",
         "logo": "{{.IdeLogoBase}}/vscode.svg",
         "label": "Browser",
-        "image": "{{.Repository}}/ide/code:commit-0ace0a96fe587b8cc1e7c3be22fc951cd6d90898",
+        "image": "{{.Repository}}/ide/code:commit-6c27cf5c879cc2031058f637a5b690796f1bcdd7",
         "latestImage": "{{.ResolvedCodeBrowserImageLatest}}",
         "imageLayers": [
-          "{{.Repository}}/ide/gitpod-code-web:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
-          "{{.Repository}}/ide/code-codehelper:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+          "{{.Repository}}/ide/gitpod-code-web:commit-1f3fbf948ea6e1824a77741d2924a5fd7ae9f79c",
+          "{{.Repository}}/ide/code-codehelper:commit-1f3fbf948ea6e1824a77741d2924a5fd7ae9f79c"
         ],
         "latestImageLayers": [
           "{{.CodeWebExtensionImage}}",
@@ -20,6 +20,14 @@
         ],
         "allowPin": true,
         "versions": [
+          {
+            "version": "1.102.3",
+            "image": "{{.Repository}}/ide/code:commit-0ace0a96fe587b8cc1e7c3be22fc951cd6d90898",
+            "imageLayers": [
+              "{{.Repository}}/ide/gitpod-code-web:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8",
+              "{{.Repository}}/ide/code-codehelper:commit-fe9d7520ed3d386386e599983b5b1c2a55ced7f8"
+            ]
+          },
           {
             "version": "1.101.2",
             "image": "{{.Repository}}/ide/code:commit-fe29f3040155d94e7dc864784fba21fd07b1859f",


### PR DESCRIPTION
## Description
Update code to `1.111.0`

## How to test

Should be tested already in build PR, double check:

- [x] New version is pinnable
- [x] Stable version is updated and it can start workspace with it

### Preview status
<p>Gitpod was successfully deployed to your preview environment.</p>
<ul>
	<li><b>🏷️ Name</b> - hw-stable-code</li>
	<li><b>🔗 URL</b> - <a href="https://hw-stable-code.preview.gitpod-dev.com/workspaces" target="_blank">hw-stable-code.preview.gitpod-dev.com/workspaces</a>.</li>
	<li><b>📚 Documentation</b> - See our <a href="https://www.notion.so/gitpod/6debd359591b43688b52f76329d04010#7c1ce80ab31a41e29eff2735e38eec39" target="_blank">internal documentation</a> for information on how to interact with your preview environment.</li>
	<li><b>📦 Version</b> - hw-stable-code-gha.226</li>
	<li><b>🗒️ Logs</b> - <a href="https://console.cloud.google.com/logs/query;query=jsonPayload.kubernetes.host%3D%22preview-hw-stable-code%22%0A%0A--%20Filter%20on%20service:%0A--%20jsonPayload.serviceContext.service%3D%22ws-manager-mk2%22%0A;duration=P1D?project=gitpod-dev-preview" target="_blank">GCP Logs Explorer</a></li>
</ul>

## Werft options:

- [x] /werft with-preview
- [x] /werft analytics=segment
- [x] /werft with-large-vm