### PR TITLE
feat: add block-no-verify PreToolUse hook to .claude/settings.json

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,5 +21,13 @@
         "WebFetch(domain:www.gitpod.io)"
       ],
       "deny": []
+    },
+    "hooks": {
+      "PreToolUse": [
+        {
+          "matcher": "Bash",
+          "hooks": [{ "type": "command", "command": "npx block-no-verify@1.1.2" }]
+        }
+      ]
     }
   }


### PR DESCRIPTION
## Summary

Adds `block-no-verify@1.1.2` as a `PreToolUse` Bash hook in `.claude/settings.json`, alongside the existing `permissions` configuration.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads `tool_input.command` from the Claude Code hook stdin payload, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The existing `permissions` block is preserved unchanged.

Closes #21355

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
