### PR TITLE
Fix NLS mismatch in debug workspaces

### DIFF
--- a/components/ide/code/leeway.Dockerfile
+++ b/components/ide/code/leeway.Dockerfile
@@ -148,6 +148,11 @@ FROM scratch
 # copy static web resources in first layer to serve from blobserve
 COPY --from=code_builder --chown=33333:33333 /vscode-web/ /ide/
 COPY --from=code_builder --chown=33333:33333 /vscode-reh-linux-x64/ /ide/
+# Restore web client NLS files overwritten by REH copy
+COPY --from=code_builder --chown=33333:33333 /vscode-web/out/nls.messages.js /ide/out/nls.messages.js
+COPY --from=code_builder --chown=33333:33333 /vscode-web/out/nls.messages.json /ide/out/nls.messages.json
+COPY --from=code_builder --chown=33333:33333 /vscode-web/out/nls.keys.json /ide/out/nls.keys.json
+COPY --from=code_builder --chown=33333:33333 /vscode-web/out/nls.metadata.json /ide/out/nls.metadata.json
 
 ARG CODE_VERSION
 ARG CODE_COMMIT


### PR DESCRIPTION
## Description

Debug workspaces created via `gp validate` throw `!!! NLS MISSING: 1837 !!!` in the browser console, breaking UI components.

The IDE Docker image copies `/vscode-web/` then `/vscode-reh-linux-x64/` into `/ide/`. The REH overlay overwrites the web client's NLS files (`nls.messages.js`, etc.) with the REH server's version, which has different message counts and index ordering.

Normal workspaces are unaffected because blobserve reads only the first Docker layer (the web client). Debug workspaces serve from the merged `/ide/` filesystem, so `workbench.js` references NLS indices that don't exist in the REH's `nls.messages.js`.

This became a problem after #21350 changed the build pipeline from `compile-build-without-mangling` (shared NLS state) to `core-ci` (separate builds with divergent NLS outputs).

Fix: restore the four web client NLS files after the REH overlay.

## Related Issue(s)

Fixes CLC-2237

## How to test

1. Build the IDE image with this change
2. Start a workspace and run `gp validate`
3. Open the debug workspace URL in the browser
4. Verify no `NLS MISSING` errors in the browser console

## Documentation

No docs changes needed.

/hold