### PR TITLE
Replace removed transferwise/sanitize-branch-name action with local composite action

### DIFF
--- a/.github/actions/sanitize-branch-name/action.yml
+++ b/.github/actions/sanitize-branch-name/action.yml
@@ -1,0 +1,15 @@
+name: Sanitize Branch Name
+description: Sanitize the current branch name for use in Docker tags and version strings
+outputs:
+  sanitized-branch-name:
+    description: Branch name with invalid characters replaced by hyphens
+    value: ${{ steps.sanitize.outputs.sanitized-branch-name }}
+runs:
+  using: composite
+  steps:
+    - id: sanitize
+      shell: bash
+      run: |
+        BRANCH="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+        SANITIZED=$(echo "$BRANCH" | sed 's/[^a-zA-Z0-9._-]/-/g' | tr '[:upper:]' '[:lower:]')
+        echo "sanitized-branch-name=$SANITIZED" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -60,7 +60,7 @@ jobs:
     steps:
       - name: "Determine Branch"
         id: branches
-        uses: transferwise/sanitize-branch-name@009d85a96fcfe62a685b371dc8f299e53385ed9c # pin@v1
+        uses: ./.github/actions/sanitize-branch-name
         # Since we trigger this worklow on other event types, besides pull_request
         # We use this action to help us get the pr body, as it's not included in push/workflow_dispatch events
       - uses: 8BitJonny/gh-get-current-pr@2.2.0

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -58,6 +58,11 @@ jobs:
       pr_number: ${{ steps.pr-details.outputs.number }}
       pr_body: ${{ steps.pr-details.outputs.pr_body }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
       - name: "Determine Branch"
         id: branches
         uses: ./.github/actions/sanitize-branch-name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,6 +61,11 @@ jobs:
       pr_number: ${{ steps.pr-details.outputs.number }}
       pr_body: ${{ steps.pr-details.outputs.pr_body }}
     steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
       - name: "Determine Branch"
         id: branches
         uses: ./.github/actions/sanitize-branch-name

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
     steps:
       - name: "Determine Branch"
         id: branches
-        uses: transferwise/sanitize-branch-name@009d85a96fcfe62a685b371dc8f299e53385ed9c # pin@v1
+        uses: ./.github/actions/sanitize-branch-name
         # Since we trigger this worklow on other event types, besides pull_request
         # We use this action to help us get the pr body, as it's not included in push/workflow_dispatch events
       - uses: 8BitJonny/gh-get-current-pr@2.2.0


### PR DESCRIPTION
## Description

The `transferwise/sanitize-branch-name` GitHub Action repository is no longer publicly accessible, breaking all workflows that reference it.

This replaces it with a local composite action at `.github/actions/sanitize-branch-name/` that does the same thing: takes the current branch name and replaces characters invalid in Docker tags/version strings with hyphens.

Same fix as https://github.com/gitpod-io/gitpod-next/pull/18708.

## Related Issue(s)

N/A

## How to test

Any CI workflow that runs the "Determine Branch" step will exercise the new composite action.