### PR TITLE
Fix CVE-2026-27143: bump Go toolchain to 1.25.9

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -193,7 +193,7 @@ RUN curl -sSL "https://awscli.amazonaws.com/awscli-exe-linux-$(arch).zip" -o aws
     ./aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update && \
     rm -rf awscliv2.zip ./aws
 
-ENV GO_VERSION=1.24.13
+ENV GO_VERSION=1.25.9
 ENV GOPATH=/root/go-packages
 ENV GOROOT=/root/go
 ENV PATH=$GOROOT/bin:$GOPATH/bin:$PATH

--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -112,7 +112,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ubuntu-latest-16-cores
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
@@ -140,7 +140,7 @@ jobs:
       (needs.configuration.outputs.is_scheduled_run != 'true')
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
@@ -187,7 +187,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
       env:
         DB_HOST: "mysql"
@@ -410,7 +410,7 @@ jobs:
     if: needs.configuration.outputs.is_scheduled_run != 'true'
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
@@ -463,7 +463,7 @@ jobs:
     environment: branch-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     if: needs.configuration.outputs.with_monitoring == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
@@ -492,7 +492,7 @@ jobs:
     environment: branch-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ubuntu-latest-16-cores
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
@@ -143,7 +143,7 @@ jobs:
       (needs.configuration.outputs.is_scheduled_run != 'true')
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
@@ -190,7 +190,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
       env:
         DB_HOST: "mysql"
@@ -448,7 +448,7 @@ jobs:
     if: needs.configuration.outputs.is_scheduled_run != 'true'
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
@@ -501,7 +501,7 @@ jobs:
     environment: main-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     if: needs.configuration.outputs.with_monitoring == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
@@ -530,7 +530,7 @@ jobs:
     environment: main-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
     name: Configuration
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     outputs:
       name: ${{ steps.configuration.outputs.name }}
@@ -93,7 +93,7 @@ jobs:
     needs: [configuration]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
@@ -126,7 +126,7 @@ jobs:
     needs: [configuration, infrastructure]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
       volumes:
         - /var/tmp:/var/tmp
@@ -216,7 +216,7 @@ jobs:
     if: github.event.inputs.skip_delete != 'true' && always()
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -15,7 +15,7 @@ jobs:
   update-jetbrains:
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   jetbrains-smoke-test-linux:
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -60,7 +60,7 @@ jobs:
     needs: [configuration]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
@@ -93,7 +93,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
       volumes:
         - /var/tmp:/var/tmp
@@ -171,7 +171,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.ref_type == 'branch' || github.event.inputs.name != ''
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Find stale preview environments"
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}
@@ -43,7 +43,7 @@ jobs:
     needs: [stale]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     if: ${{ needs.stale.outputs.count > 0 }}
     strategy:

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
     name: Configuration
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     outputs:
       name: ${{ steps.configuration.outputs.name }}
@@ -126,7 +126,7 @@ jobs:
     needs: [configuration]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
@@ -159,7 +159,7 @@ jobs:
     needs: [configuration, infrastructure]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
@@ -183,7 +183,7 @@ jobs:
     if: inputs.skip_delete != 'true' && always()
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:fix-go-1-24-13-cve-2025-68121-gha.181
+image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -71,9 +71,5 @@ defaultVariant:
         [
           "sh",
           "-c",
-          # --go=1.24 keeps lint compatible with the v1.64.x golangci-lint built into the
-          # CI dev-environment image (which is itself built with Go 1.24). Our toolchain bump
-          # to 1.25.9 only addresses CVE-2026-27143 in the Go stdlib; we don't use any 1.25
-          # language features.
-          "golangci-lint run --go=1.24 --disable govet,errcheck,staticcheck --allow-parallel-runners --timeout 15m",
+          "golangci-lint run --disable govet,errcheck,staticcheck --allow-parallel-runners --timeout 15m",
         ]

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -71,5 +71,9 @@ defaultVariant:
         [
           "sh",
           "-c",
-          "golangci-lint run --disable govet,errcheck,staticcheck --allow-parallel-runners --timeout 15m",
+          # --go=1.24 keeps lint compatible with the v1.64.x golangci-lint built into the
+          # CI dev-environment image (which is itself built with Go 1.24). Our toolchain bump
+          # to 1.25.9 only addresses CVE-2026-27143 in the Go stdlib; we don't use any 1.25
+          # language features.
+          "golangci-lint run --go=1.24 --disable govet,errcheck,staticcheck --allow-parallel-runners --timeout 15m",
         ]

--- a/components/blobserve/go.mod
+++ b/components/blobserve/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/blobserve
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/blobserve/go.mod
+++ b/components/blobserve/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/blobserve
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/common-go
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/common-go/go.mod
+++ b/components/common-go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/common-go
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/content-service-api/go/go.mod
+++ b/components/content-service-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/content-service/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/content-service-api/go/go.mod
+++ b/components/content-service-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/content-service/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/content-service-api/typescript/util/go.mod
+++ b/components/content-service-api/typescript/util/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/content-service-api/util
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/content-service-api/typescript/util/go.mod
+++ b/components/content-service-api/typescript/util/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/content-service-api/util
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/content-service/go.mod
+++ b/components/content-service/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/content-service
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/content-service/go.mod
+++ b/components/content-service/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/content-service
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/docker-up/go.mod
+++ b/components/docker-up/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/docker-up
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/docker-up/go.mod
+++ b/components/docker-up/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/docker-up
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ee/agent-smith/cmd/testbed/go.mod
+++ b/components/ee/agent-smith/cmd/testbed/go.mod
@@ -2,6 +2,6 @@ module testbed
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/ee/agent-smith/cmd/testbed/go.mod
+++ b/components/ee/agent-smith/cmd/testbed/go.mod
@@ -2,6 +2,6 @@ module testbed
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/ee/agent-smith/cmd/testtarget/go.mod
+++ b/components/ee/agent-smith/cmd/testtarget/go.mod
@@ -2,6 +2,6 @@ module testtarget
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/ee/agent-smith/cmd/testtarget/go.mod
+++ b/components/ee/agent-smith/cmd/testtarget/go.mod
@@ -2,6 +2,6 @@ module testtarget
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/ee/agent-smith/go.mod
+++ b/components/ee/agent-smith/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/agent-smith
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ee/agent-smith/go.mod
+++ b/components/ee/agent-smith/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/agent-smith
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gitpod-cli
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/gitpod-cli/go.mod
+++ b/components/gitpod-cli/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gitpod-cli
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/gitpod-db/go/go.mod
+++ b/components/gitpod-db/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/gitpod-db/go
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/gitpod-db/go/go.mod
+++ b/components/gitpod-db/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/gitpod-db/go
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/gitpod-protocol/go/go.mod
+++ b/components/gitpod-protocol/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gitpod-protocol
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/gitpod-protocol/go/go.mod
+++ b/components/gitpod-protocol/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gitpod-protocol
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide-metrics-api/go.mod
+++ b/components/ide-metrics-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/ide-metrics-api/go.mod
+++ b/components/ide-metrics-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/ide-metrics-api/go/go.mod
+++ b/components/ide-metrics-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-metrics-api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ide-metrics-api/go/go.mod
+++ b/components/ide-metrics-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-metrics-api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide-metrics/go.mod
+++ b/components/ide-metrics/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-metrics
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ide-metrics/go.mod
+++ b/components/ide-metrics/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-metrics
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide-service-api/go/go.mod
+++ b/components/ide-service-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-service-api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ide-service-api/go/go.mod
+++ b/components/ide-service-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-service-api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide-service/go.mod
+++ b/components/ide-service/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-service
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ide-service/go.mod
+++ b/components/ide-service/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ide-service
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide/code-desktop/status/go.mod
+++ b/components/ide/code-desktop/status/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/code-desktop/status
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ide/code-desktop/status/go.mod
+++ b/components/ide/code-desktop/status/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/code-desktop/status
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide/code/codehelper/go.mod
+++ b/components/ide/code/codehelper/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/code/codehelper
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ide/code/codehelper/go.mod
+++ b/components/ide/code/codehelper/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/code/codehelper
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide/jetbrains/cli/go.mod
+++ b/components/ide/jetbrains/cli/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/jetbrains/cli
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ide/jetbrains/cli/go.mod
+++ b/components/ide/jetbrains/cli/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/jetbrains/cli
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide/jetbrains/launcher/go.mod
+++ b/components/ide/jetbrains/launcher/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/jetbrains/launcher
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ide/jetbrains/launcher/go.mod
+++ b/components/ide/jetbrains/launcher/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/jetbrains/launcher
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/image-builder-api/go.mod
+++ b/components/image-builder-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/image-builder-api/go.mod
+++ b/components/image-builder-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/image-builder-api/go/go.mod
+++ b/components/image-builder-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/image-builder/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/image-builder-api/go/go.mod
+++ b/components/image-builder-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/image-builder/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/image-builder-bob/go.mod
+++ b/components/image-builder-bob/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/image-builder/bob
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/image-builder-bob/go.mod
+++ b/components/image-builder-bob/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/image-builder/bob
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/image-builder-mk3/go.mod
+++ b/components/image-builder-mk3/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/image-builder
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/image-builder-mk3/go.mod
+++ b/components/image-builder-mk3/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/image-builder
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/local-app-api/go.mod
+++ b/components/local-app-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/local-app-api/go.mod
+++ b/components/local-app-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/local-app-api/go/go.mod
+++ b/components/local-app-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/local-app/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/local-app-api/go/go.mod
+++ b/components/local-app-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/local-app/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/local-app/go.mod
+++ b/components/local-app/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/local-app
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/local-app/go.mod
+++ b/components/local-app/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/local-app
 
 go 1.24.0
 
-toolchain go1.24.13
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/node-labeler/go.mod
+++ b/components/node-labeler/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/node-labeler
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/node-labeler/go.mod
+++ b/components/node-labeler/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/node-labeler
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/openvsx-proxy/go.mod
+++ b/components/openvsx-proxy/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/openvsx-proxy
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/openvsx-proxy/go.mod
+++ b/components/openvsx-proxy/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/openvsx-proxy
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/public-api-server
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/public-api-server/go.mod
+++ b/components/public-api-server/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/public-api-server
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/public-api/go/go.mod
+++ b/components/public-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/public-api/go
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/public-api/go/go.mod
+++ b/components/public-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/public-api/go
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/registry-facade-api/go.mod
+++ b/components/registry-facade-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/registry-facade-api/go.mod
+++ b/components/registry-facade-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/registry-facade-api/go/go.mod
+++ b/components/registry-facade-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/registry-facade/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/registry-facade-api/go/go.mod
+++ b/components/registry-facade-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/registry-facade/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/registry-facade/go.mod
+++ b/components/registry-facade/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/registry-facade
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/registry-facade/go.mod
+++ b/components/registry-facade/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/registry-facade
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/scrubber/go.mod
+++ b/components/scrubber/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/scrubber
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/scrubber/go.mod
+++ b/components/scrubber/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/scrubber
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/server/go/go.mod
+++ b/components/server/go/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/gitpod/server/go
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/server/go/go.mod
+++ b/components/server/go/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/gitpod/server/go
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/service-waiter/go.mod
+++ b/components/service-waiter/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/service-waiter
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/service-waiter/go.mod
+++ b/components/service-waiter/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/service-waiter
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/spicedb/codegen/go.mod
+++ b/components/spicedb/codegen/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/spicedb/codegen
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/spicedb/codegen/go.mod
+++ b/components/spicedb/codegen/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/spicedb/codegen
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/spicedb/go.mod
+++ b/components/spicedb/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/spicedb
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/spicedb/go.mod
+++ b/components/spicedb/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/components/spicedb
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/supervisor-api/go.mod
+++ b/components/supervisor-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/supervisor-api/go.mod
+++ b/components/supervisor-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/supervisor-api/go/go.mod
+++ b/components/supervisor-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/supervisor/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/supervisor-api/go/go.mod
+++ b/components/supervisor-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/supervisor/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/supervisor
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/supervisor/go.mod
+++ b/components/supervisor/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/supervisor
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/usage-api/go/go.mod
+++ b/components/usage-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/usage-api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/usage-api/go/go.mod
+++ b/components/usage-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/usage-api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/usage
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/usage/go.mod
+++ b/components/usage/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/usage
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/workspacekit/go.mod
+++ b/components/workspacekit/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/workspacekit
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/workspacekit/go.mod
+++ b/components/workspacekit/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/workspacekit
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon-api/go.mod
+++ b/components/ws-daemon-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/ws-daemon-api/go.mod
+++ b/components/ws-daemon-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/ws-daemon-api/go/go.mod
+++ b/components/ws-daemon-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon-api/go/go.mod
+++ b/components/ws-daemon-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon/go.mod
+++ b/components/ws-daemon/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon/go.mod
+++ b/components/ws-daemon/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon/nsinsider/go.mod
+++ b/components/ws-daemon/nsinsider/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon/nsinsider
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon/nsinsider/go.mod
+++ b/components/ws-daemon/nsinsider/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon/nsinsider
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon/seccomp-profile-installer/go.mod
+++ b/components/ws-daemon/seccomp-profile-installer/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon/seccomp-profile-installer
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-daemon/seccomp-profile-installer/go.mod
+++ b/components/ws-daemon/seccomp-profile-installer/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-daemon/seccomp-profile-installer
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-manager-api/go.mod
+++ b/components/ws-manager-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0

--- a/components/ws-manager-api/go.mod
+++ b/components/ws-manager-api/go.mod
@@ -2,6 +2,6 @@ module github.com/gitpod-io/generated_code_dependencies
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0

--- a/components/ws-manager-api/go/go.mod
+++ b/components/ws-manager-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-manager/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-manager-api/go/go.mod
+++ b/components/ws-manager-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-manager/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-manager-bridge-api/go/go.mod
+++ b/components/ws-manager-bridge-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-manager-bridge/api
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-manager-bridge-api/go/go.mod
+++ b/components/ws-manager-bridge-api/go/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-manager-bridge/api
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-manager-mk2/go.mod
+++ b/components/ws-manager-mk2/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-manager-mk2
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/components/ws-manager-mk2/go.mod
+++ b/components/ws-manager-mk2/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-manager-mk2
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-proxy
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/components/ws-proxy/go.mod
+++ b/components/ws-proxy/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/ws-proxy
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/addlicense/go.mod
+++ b/dev/addlicense/go.mod
@@ -2,7 +2,7 @@ module github.com/google/addlicense
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/addlicense/go.mod
+++ b/dev/addlicense/go.mod
@@ -2,7 +2,7 @@ module github.com/google/addlicense
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/blowtorch/go.mod
+++ b/dev/blowtorch/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/blowtorch
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/blowtorch/go.mod
+++ b/dev/blowtorch/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/blowtorch
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/changelog/go.mod
+++ b/dev/changelog/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/changelog
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/changelog/go.mod
+++ b/dev/changelog/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/changelog
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/gp-gcloud/go.mod
+++ b/dev/gp-gcloud/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gp-gcloud
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/gp-gcloud/go.mod
+++ b/dev/gp-gcloud/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gp-gcloud
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/gpctl/go.mod
+++ b/dev/gpctl/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gpctl
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/gpctl/go.mod
+++ b/dev/gpctl/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/gpctl
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/image/Dockerfile
+++ b/dev/image/Dockerfile
@@ -4,14 +4,14 @@
 
 FROM gitpod/workspace-gitpod-dev:latest
 
-ENV TRIGGER_REBUILD 45
+ENV TRIGGER_REBUILD 46
 
 USER root
 
 ### Go ###
 # Pin Go version explicitly to ensure all CI-built binaries use a
-# non-vulnerable toolchain (CVE-2025-68121 requires >= 1.24.13).
-ENV GO_VERSION=1.24.13
+# non-vulnerable toolchain (CVE-2026-27143 requires >= 1.25.9).
+ENV GO_VERSION=1.25.9
 RUN rm -rf /usr/local/go /home/gitpod/go /home/gitpod/.cache/go-build \
     && curl -fsSL "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz \
     && ln -sf /usr/local/go/bin/go /usr/bin/go \

--- a/dev/kubecdl/go.mod
+++ b/dev/kubecdl/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/kubecdl
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/kubecdl/go.mod
+++ b/dev/kubecdl/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/kubecdl
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/loadgen/go.mod
+++ b/dev/loadgen/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/loadgen
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/loadgen/go.mod
+++ b/dev/loadgen/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/loadgen
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/preview/previewctl/go.mod
+++ b/dev/preview/previewctl/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/previewctl
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/preview/previewctl/go.mod
+++ b/dev/preview/previewctl/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/previewctl
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/rejector/go.mod
+++ b/dev/rejector/go.mod
@@ -2,7 +2,7 @@ module gitpod.io/rejector/v2
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/rejector/go.mod
+++ b/dev/rejector/go.mod
@@ -2,7 +2,7 @@ module gitpod.io/rejector/v2
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/ssh-load-test/go.mod
+++ b/dev/ssh-load-test/go.mod
@@ -2,7 +2,7 @@ module test
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/ssh-load-test/go.mod
+++ b/dev/ssh-load-test/go.mod
@@ -2,7 +2,7 @@ module test
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/dev/version-manifest/go.mod
+++ b/dev/version-manifest/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/version-manifest
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/dev/version-manifest/go.mod
+++ b/dev/version-manifest/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/version-manifest
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/installer
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/install/installer/go.mod
+++ b/install/installer/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/installer
 
 go 1.24.0
 
-toolchain go1.24.13
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/install/preview/prettylog/go.mod
+++ b/install/preview/prettylog/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/install/preview/prettylog
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/install/preview/prettylog/go.mod
+++ b/install/preview/prettylog/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/install/preview/prettylog
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/operations/observability/mixins/go.mod
+++ b/operations/observability/mixins/go.mod
@@ -2,7 +2,7 @@ module gitpod-io/mixin-utils
 
 go 1.24
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/operations/observability/mixins/go.mod
+++ b/operations/observability/mixins/go.mod
@@ -2,7 +2,7 @@ module gitpod-io/mixin-utils
 
 go 1.24
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/test
 
 go 1.24.0
 
-toolchain go1.25.9
+toolchain go1.24.13
 
 godebug tlsmlkem=0
 

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,7 +2,7 @@ module github.com/gitpod-io/gitpod/test
 
 go 1.24.0
 
-toolchain go1.24.3
+toolchain go1.25.9
 
 godebug tlsmlkem=0
 


### PR DESCRIPTION
## Description

The daily vulnerability scan on `main` ([build run](https://github.com/gitpod-io/gitpod/actions/runs/24809514798)) flagged 13 Classic component images with a single critical Go stdlib vulnerability:

- **[CVE-2026-27143](https://nvd.nist.gov/vuln/detail/CVE-2026-27143)** ([GO-2026-4868](https://pkg.go.dev/vuln/GO-2026-4868)): the Go compiler did not correctly check underflow/overflow on arithmetic over induction variables in loops, allowing invalid indexing at runtime that could lead to memory corruption.
- **Fixed in:** Go `1.25.9` (or `1.26.2`)

Affected images (all are pure-Go binaries on the same Wolfi base):
`image-builder-mk3`, `blobserve`, `registry-facade`, `public-api-server`, `ide-service`, `content-service`, `ee/agent-smith`, `ide-metrics`, `node-labeler`, `openvsx-proxy`, `service-waiter`, `ws-manager-mk2`, `ws-proxy`.

This PR bumps the Go toolchain across the workspace from `1.24.13` to `1.25.9`:

- Set `toolchain go1.25.9` in all 71 `go.mod` files
- Update `GO_VERSION` in `dev/image/Dockerfile` and bump `TRIGGER_REBUILD` so the CI dev-environment image installs the patched compiler
- Update `GO_VERSION` in `.devcontainer/Dockerfile` for dev-environment consistency

> [!NOTE]
> A follow-up commit will be needed to update the `dev-environment` image tag references in `.gitpod.yml` and `.github/workflows/*.yml` once the new image is published, as was done in #21327.

## Related Issue(s)

Fixes [CLC-2243](https://linear.app/ona-team/issue/CLC-2243/critical-vulnerabilities-detected-in-multiple-classic-images)

## How to test

Verified locally by rebuilding all 13 affected components with `GOTOOLCHAIN=go1.25.9` and scanning each binary with grype:

```
$ grype <binary> --only-fixed -o json | jq '.matches[] | select(.vulnerability.severity == "Critical")'
# (no output across all 13 components)
```

Before the bump the same scan reports `CVE-2026-27143` as Critical for `stdlib@go1.24.13`.

## Documentation

* No (toolchain bump only)

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
- [ ] leeway-no-cache
- [ ] /werft no-test
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] /werft preemptible
- [ ] with-integration-tests=all
- [ ] with-monitoring
</details>

/hold
