### PR TITLE
Fix critical CVEs in image-builder-bob: bump buildkit base to v0.20.1-gitpod.7

### DIFF
--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM ghcr.io/gitpod-io/buildkit:v0.20.1-gitpod.6
+FROM ghcr.io/gitpod-io/buildkit:v0.20.1-gitpod.7
 
 USER root
 RUN apk --no-cache add sudo bash \


### PR DESCRIPTION
## Description

Bumps the pinned buildkit base image used by `components/image-builder-bob:docker` from `v0.20.1-gitpod.6` to [`v0.20.1-gitpod.7`](https://github.com/gitpod-io/buildkit/releases/tag/v0.20.1-gitpod.7), which rebases on **Alpine 3.23** and **Go 1.26.2**.

This clears the two critical CVEs that the daily scheduled `Build` workflow's `Check for Critical Vulnerabilities` step has been failing on:

| CVE | Package | Installed (gitpod.6) | Fixed (gitpod.7) |
|---|---|---|---|
| **CVE-2026-31789** (Critical) | Alpine `libssl3` / `libcrypto3` | `3.5.5-r0` | rebased to Alpine 3.23 |
| **CVE-2025-68121** (Critical) | Go stdlib (crypto/tls) | `go1.22.4` (in moby/buildkit) | Go 1.26.2 |

Verified locally with grype: the new image has zero critical Alpine apk vulnerabilities. The remaining stdlib Critical findings (CVE-2025-22871, CVE-2026-27143, CVE-2025-68121) only show up in the legacy `buildkit-cni-*` plugin binaries, which Leeway's vulnerability rollup does not include in the failing-package count — i.e. the same scope as before, minus the two we set out to fix.

## Related Issue(s)

Fixes [CLC-2245](https://linear.app/ona-team/issue/CLC-2245/daily-build-critical-cve-2026-31789-libcryptolibssl-detected-in-image)

## How to test

Trigger the `Build` workflow with `simulate_scheduled_run=true` (or wait for the next nightly schedule) and confirm `Check for Critical Vulnerabilities` passes for `components/image-builder-bob:docker`.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
- [x] /werft preemptible
- [ ] with-integration-tests=all
- [ ] with-monitoring
</details>
