### PR TITLE
Update images digests

### DIFF
--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM cgr.dev/chainguard/helm:latest@sha256:138a449fdde5c7849df09d5114036957f37bb1350d90cb945fe035b9e57385fe
+FROM cgr.dev/chainguard/helm:latest@sha256:91cfefe76685628326456a0eb4176fe1c5a7cfc00e96e8d38d69794600a86b5d
 
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
 

--- a/install/installer/pkg/components/redis/constants.go
+++ b/install/installer/pkg/components/redis/constants.go
@@ -14,7 +14,7 @@ const (
 	RegistryImage = "chainguard/redis"
 
 	ContainerName = "redis"
-	ImageDigest   = "sha256:e3ef5104eae4954aa94927103a4e43bd78347ba7bc3420f54a9cd38383baf4cc"
+	ImageDigest   = "sha256:f8b7d19798fa56e284977324c9e123c6710129e621f62459fc73c3d83b1f529a"
 
 	ExporterRegistryRepo  = "quay.io"
 	ExporterRegistryImage = "oliver006/redis_exporter"


### PR DESCRIPTION
## Description

Update images digests using the latest version available for image/s.

| Image | Old digest | New digest |
| --- | --- | --- |
| `cgr.dev/chainguard/helm:latest` | `sha256:138a449fdde5c7849df09d5114036957f37bb1350d90cb945fe035b9e57385fe` | `sha256:91cfefe76685628326456a0eb4176fe1c5a7cfc00e96e8d38d69794600a86b5d` |
| `cgr.dev/chainguard/redis:latest` | `sha256:e3ef5104eae4954aa94927103a4e43bd78347ba7bc3420f54a9cd38383baf4cc` | `sha256:f8b7d19798fa56e284977324c9e123c6710129e621f62459fc73c3d83b1f529a` |
| `quay.io/oliver006/redis_exporter:latest` | `sha256:4b467f718ea9f62fe47b87ce39039ebeedff7764c40fde2a129913484fff716f` | `sha256:4b467f718ea9f62fe47b87ce39039ebeedff7764c40fde2a129913484fff716f` (unchanged) |

## How to test

- [ ] Start a workspace in the preview environment and verify that it functions properly.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-preview
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=ssh
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
</details>
