### PR TITLE
Block AF_ALG in workspace seccomp profile

### DIFF
--- a/components/ws-daemon/seccomp-profile-installer/main.go
+++ b/components/ws-daemon/seccomp-profile-installer/main.go
@@ -8,26 +8,36 @@ import (
 	"encoding/json"
 	"log"
 	"os"
+	"syscall"
 
 	"github.com/containerd/containerd/contrib/seccomp"
 	"github.com/opencontainers/runtime-spec/specs-go"
 )
 
-func main() {
-	enc := json.NewEncoder(os.Stdout)
-	enc.SetIndent("", "  ")
-	enc.SetEscapeHTML(false)
-
+func defaultWorkspaceSeccompProfile(capabilities []string) *specs.LinuxSeccomp {
 	spec := specs.Spec{
 		Process: &specs.Process{
 			Capabilities: &specs.LinuxCapabilities{
-				Bounding: os.Args[1:],
+				Bounding: capabilities,
 			},
 		},
 	}
 
 	s := seccomp.DefaultProfile(&spec)
 	s.Syscalls = append(s.Syscalls,
+		// AF_ALG exposes the kernel crypto API via sockets. Blocking only this
+		// family keeps regular networking intact while removing the copy.fail path.
+		specs.LinuxSyscall{
+			Names:  []string{"socket"},
+			Action: specs.ActErrno,
+			Args: []specs.LinuxSeccompArg{
+				{
+					Index: 0,
+					Value: syscall.AF_ALG,
+					Op:    specs.OpEqualTo,
+				},
+			},
+		},
 		specs.LinuxSyscall{
 			Names: []string{
 				"clone",
@@ -58,6 +68,16 @@ func main() {
 			Action: specs.ActAllow,
 		},
 	)
+
+	return s
+}
+
+func main() {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.SetEscapeHTML(false)
+
+	s := defaultWorkspaceSeccompProfile(os.Args[1:])
 
 	err := enc.Encode(s)
 	if err != nil {

--- a/components/ws-daemon/seccomp-profile-installer/main_test.go
+++ b/components/ws-daemon/seccomp-profile-installer/main_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2020 Gitpod GmbH. All rights reserved.
+// Licensed under the GNU Affero General Public License (AGPL).
+// See License.AGPL.txt in the project root for license information.
+
+package main
+
+import (
+	"slices"
+	"syscall"
+	"testing"
+
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+func TestDefaultWorkspaceSeccompProfileBlocksAFALGSocket(t *testing.T) {
+	profile := defaultWorkspaceSeccompProfile([]string{"AUDIT_WRITE", "NET_BIND_SERVICE"})
+
+	for _, syscallRule := range profile.Syscalls {
+		if !slices.Contains(syscallRule.Names, "socket") || syscallRule.Action != specs.ActErrno {
+			continue
+		}
+
+		for _, arg := range syscallRule.Args {
+			if arg.Index == 0 && arg.Value == syscall.AF_ALG && arg.Op == specs.OpEqualTo {
+				return
+			}
+		}
+	}
+
+	t.Fatalf("expected seccomp profile to block socket(AF_ALG, ...)")
+}
+
+func TestDefaultWorkspaceSeccompProfileKeepsRegularSocketsAvailable(t *testing.T) {
+	profile := defaultWorkspaceSeccompProfile([]string{"AUDIT_WRITE", "NET_BIND_SERVICE"})
+
+	for _, syscallRule := range profile.Syscalls {
+		if slices.Contains(syscallRule.Names, "socket") && syscallRule.Action == specs.ActAllow && len(syscallRule.Args) == 0 {
+			return
+		}
+	}
+
+	t.Fatalf("expected seccomp profile to preserve generic socket allow rule")
+}


### PR DESCRIPTION
## Description
Block `socket(AF_ALG, ...)` in the workspace seccomp profile while preserving the default socket allow rule for normal networking.

This narrows the workspace seccomp profile against the `copy.fail` / `CVE-2026-31431` attack path without disabling ordinary TCP, UDP, or Unix-domain socket workloads.

The change also extracts the profile builder into a helper and adds package tests that assert:
- `socket(AF_ALG, ...)` is denied
- generic `socket` support remains available in the generated profile

## Related Issue(s)
N/A

## How to test
1. Run `go test ./...` in `components/ws-daemon/seccomp-profile-installer`
2. Run `go run . AUDIT_WRITE FSETID KILL NET_BIND_SERVICE SYS_PTRACE` in `components/ws-daemon/seccomp-profile-installer`
3. Verify the generated JSON still contains the generic `socket` allow rule and now also contains an `SCMP_ACT_ERRNO` rule for `socket` with argument 0 equal to `AF_ALG`

## Documentation
No

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
      Run the build with werft instead of GHA
- [ ] leeway-no-cache
- [ ] /werft no-test
      Run Leeway with `--dont-test`
</details>

<details>
<summary>Publish</summary>

- [ ] /werft publish-to-npm
- [ ] /werft publish-to-jb-marketplace
</details>

<details>
<summary>Installer</summary>

- [ ] analytics=segment
- [ ] with-dedicated-emulation
- [ ] workspace-feature-flags
  Add desired feature flags to the end of the line above, space separated
</details>

<details>
<summary>Preview Environment / Integration Tests</summary>

- [ ] /werft with-local-preview
      If enabled this will build `install/preview`
- [ ] /werft with-preview
- [ ] /werft with-large-vm
- [x] /werft with-gce-vm
      If enabled this will create the environment on GCE infra
- [x] /werft preemptible
      Saves cost. Untick this only if you're really sure you need a non-preemtible machine.
- [ ] with-integration-tests=all
      Valid options are `all`, `workspace`, `webapp`, `ide`, `jetbrains`, `vscode`, `ssh`. If enabled, `with-preview` and `with-large-vm` will be enabled.
- [ ] with-monitoring
</details>

/hold