### PR TITLE
Pin Docker version in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,9 @@
     "dockerfile": "./Dockerfile"
   },
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:2": {}
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "28"
+    }
   },
   "workspaceFolder": "/workspace/gitpod",
   "workspaceMount": "source=${localWorkspaceFolder},target=/workspace/gitpod,type=bind",


### PR DESCRIPTION
## Summary

Pins the `docker-in-docker` devcontainer feature to Docker/Moby 28 instead of allowing the feature to install the current latest engine.

The current unpinned setup installed Moby 29.4.3 with containerd 2.3.0. In this Ona environment, the feature-generated `docker-init.sh` left `dockerd` unable to connect to its managed containerd process, causing Docker commands to fail with `Cannot connect to the Docker daemon at unix:///var/run/docker.sock`.

## Validation

- `gitpod environment devcontainer validate .devcontainer/devcontainer.json`
- `gitpod automations validate .gitpod/automations.yaml`

## Rebuild notes

I attempted devcontainer rebuilds after the config change. The Docker feature install step completed, but the runner failed during BuildKit image export with a containerd ref lock:

```text
failed to open writer: ref moby/1/bf70s19s2cw173yz22okwy4dl locked ... unavailable
```

That failure happens after the devcontainer feature installation and appears to be a runner-side image export/cache issue rather than a schema or Docker configuration error.