### PR TITLE
Address phase 1 critical CVE findings

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -390,11 +390,13 @@ jobs:
             echo "No critical vulnerabilities found."
           fi
       - name: Upload SBOMs
+        if: ${{ always() && steps.scan.outputs.leeway_sboms_dir != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: sboms
           path: ${{ steps.scan.outputs.leeway_sboms_dir }}
       - name: Upload vulnerability reports
+        if: ${{ always() && steps.scan.outputs.leeway_vulnerability_reports_dir != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: vulnerability-reports

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -393,11 +393,13 @@ jobs:
             echo "No critical vulnerabilities found."
           fi
       - name: Upload SBOMs
+        if: ${{ always() && steps.scan.outputs.leeway_sboms_dir != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: sboms
           path: ${{ steps.scan.outputs.leeway_sboms_dir }}
       - name: Upload vulnerability reports
+        if: ${{ always() && steps.scan.outputs.leeway_vulnerability_reports_dir != '' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # pin@v4
         with:
           name: vulnerability-reports

--- a/WORKSPACE.yaml
+++ b/WORKSPACE.yaml
@@ -52,6 +52,9 @@ sbom:
         GHSA-4c29-8rgm-jvjj / CVE-2026-33747, but grype matches the emitted
         github.com/moby/buildkit module version and still reports v0.20.1-gitpod.8
         as vulnerable.
+        This workspace-level ignore is global for the vulnerability ID; keep it
+        limited to this known false positive and scope or remove it once artifact
+        scoped suppressions are available here.
 environmentManifest:
   - name: "go"
     command: ["sh", "-c", "go version | sed s/arm/amd/"]

--- a/components/image-builder-bob/leeway.Dockerfile
+++ b/components/image-builder-bob/leeway.Dockerfile
@@ -5,7 +5,8 @@
 FROM ghcr.io/gitpod-io/buildkit:v0.20.1-gitpod.8
 
 USER root
-RUN apk --no-cache add sudo bash \
+RUN apk upgrade --no-cache \
+    && apk --no-cache add sudo bash \
     && addgroup -g 33333 gitpod \
     && adduser -D -h /home/gitpod -s /bin/sh -u 33333 -G gitpod gitpod \
     && echo "gitpod ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/gitpod \

--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -2,14 +2,14 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM caddy:builder AS builder
+FROM caddy:2.11.4-builder AS builder
 
 WORKDIR /plugins
 
 COPY plugins /plugins
 
 # build caddy — pin smallstep/certificates to v0.30.1 (fixes GHSA-q4r8-xm5f-56gw)
-RUN xcaddy build v2.11.2 \
+RUN xcaddy build v2.11.4 \
   --output /caddy \
   --replace github.com/smallstep/certificates=github.com/smallstep/certificates@v0.30.1 \
   --with github.com/gitpod-io/gitpod/proxy/plugins/corsorigin=/plugins/corsorigin \
@@ -23,7 +23,7 @@ RUN xcaddy build v2.11.2 \
   --with github.com/gitpod-io/gitpod/proxy/plugins/sshtunnel=/plugins/sshtunnel \
   --with github.com/gitpod-io/gitpod/proxy/plugins/frontend_dev=/plugins/frontend_dev
 
-FROM caddy/caddy:2.11.2-alpine
+FROM caddy/caddy:2.11.4-alpine
 
 # Ensure latest packages are present, like security updates.
 RUN apk upgrade --no-cache \


### PR DESCRIPTION
## Summary

Implements Phase 1 of the CLC-2255 critical CVE remediation plan:

- Bumps the proxy Caddy builder/runtime images from 2.11.2 to 2.11.4.
- Runs `apk upgrade --no-cache` in the image-builder-bob Dockerfile before installing runtime packages, refreshing Alpine packages such as OpenSSL.
- Makes SBOM and vulnerability report uploads run with `always()` after the scan step, while guarding on populated scan output paths.
- Documents that the existing BuildKit `GO-2026-4858` suppression is workspace-global until artifact-scoped suppressions are available.

## Issues

Relates to CLC-2255

## Validation

- `git diff --check`
- `leeway build components/proxy:docker --dont-test -Dversion=dev -DimageRepoBase=localhost:5000/gitpod`
- `leeway sbom scan components/proxy:docker --output-dir /tmp/proxy-scan -Dversion=dev -DimageRepoBase=localhost:5000/gitpod`
  - `components/proxy:docker: critical=0 high=5`
- `leeway build components/image-builder-bob:docker --dont-test -Dversion=dev -DimageRepoBase=localhost:5000/gitpod`
- `leeway sbom scan components/image-builder-bob:docker --output-dir /tmp/bob-scan -Dversion=dev -DimageRepoBase=localhost:5000/gitpod`
  - `components/image-builder-bob:docker: critical=0 high=98 ignored=2`

Both Docker builds confirmed `libcrypto3` and `libssl3` were upgraded from `3.5.6-r0` to `3.5.7-r0`.