### PR TITLE
Address phase 2 docker-up critical CVE findings

### DIFF
--- a/components/docker-up/BUILD.yaml
+++ b/components/docker-up/BUILD.yaml
@@ -49,8 +49,6 @@ packages:
         - ["mv", "components-docker-up--bin-docker-up/docker-up", "docker-up"]
         - ["mv", "components-docker-up--bin-docker-up/checksums.txt", "checksums.txt"]
         - ["mv", "components-docker-up--bin-docker-up/docker-compose", "docker-compose-linux-x86_64"]
-        - ["mv", "components-docker-up--bin-docker-up/docker-compose-linux-x86_64.provenance.json", "docker-compose-linux-x86_64.provenance.json"]
-        - ["mv", "components-docker-up--bin-docker-up/docker-compose-linux-x86_64.sbom.json", "docker-compose-linux-x86_64.sbom.json"]
         - ["rm", "-r", "components-docker-up--bin-docker-up"]
         - ["mv", "components-docker-up--bin-runc-facade/docker-up", "runc-facade"]
         - ["rm", "-r", "components-docker-up--bin-runc-facade"]

--- a/components/docker-up/dependencies.sh
+++ b/components/docker-up/dependencies.sh
@@ -6,15 +6,56 @@
 set -euo pipefail
 
 RUNC_VERSION=v1.1.15
+RUNC_VERSION_WITHOUT_V=${RUNC_VERSION#v}
+output_dir=$(pwd)
+
+cleanup() {
+  rm -rf "${compose_dir:-}" "${runc_dir:-}"
+}
+trap cleanup EXIT
+
+build_docker_compose() {
+  compose_dir=$(mktemp -d)
+  curl -fsSL "https://github.com/docker/compose/archive/refs/tags/v${DOCKER_COMPOSE_VERSION}.tar.gz" \
+    | tar -xz --strip-components=1 -C "${compose_dir}"
+
+  (
+    cd "${compose_dir}"
+    go mod edit \
+      -require=golang.org/x/crypto@v0.52.0 \
+      -require=golang.org/x/net@v0.55.0 \
+      -require=google.golang.org/grpc@v1.79.3
+    go mod tidy
+    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+      -trimpath \
+      -ldflags="-s -w -X github.com/docker/compose/v2/internal.Version=v${DOCKER_COMPOSE_VERSION}" \
+      -o "${output_dir}/docker-compose" \
+      ./cmd
+  )
+}
+
+build_runc() {
+  runc_dir=$(mktemp -d)
+  curl -fsSL "https://github.com/opencontainers/runc/archive/refs/tags/${RUNC_VERSION}.tar.gz" \
+    | tar -xz --strip-components=1 -C "${runc_dir}"
+
+  (
+    cd "${runc_dir}"
+    go mod edit -require=golang.org/x/net@v0.55.0
+    go mod tidy
+    CGO_ENABLED=1 GOFLAGS=-mod=mod GOOS=linux GOARCH=amd64 go build \
+      -trimpath \
+      -tags seccomp \
+      -ldflags="-s -w -X main.version=${RUNC_VERSION_WITHOUT_V}" \
+      -o "${output_dir}/runc" \
+      .
+  )
+}
 
 # DOCKER_VERSION and DOCKER_COMPOSE_VERSION are defined in WORKSPACE.yaml
 curl -o docker.tgz      -fsSL "https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz"
-# Docker Compose — using upstream; MTU is propagated via dockerd --default-network-opt
-curl -o docker-compose  -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64"
-curl -o docker-compose-linux-x86_64.provenance.json -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64.provenance.json"
-curl -o docker-compose-linux-x86_64.sbom.json -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64.sbom.json"
-# Filter checksums to only the linux-x86_64 files we downloaded
-curl -fsSL "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/checksums.txt" \
-  | grep "linux-x86_64" > checksums.txt
 
-curl -o runc            -fsSL "https://github.com/opencontainers/runc/releases/download/${RUNC_VERSION}/runc.amd64"
+build_docker_compose
+build_runc
+
+sha256sum docker-compose | sed 's/docker-compose$/docker-compose-linux-x86_64/' > checksums.txt

--- a/components/docker-up/leeway.Dockerfile
+++ b/components/docker-up/leeway.Dockerfile
@@ -10,6 +10,6 @@ LABEL skip-n.registry-facade.gitpod.io="2"
 WORKDIR /usr/local/bin
 WORKDIR /usr/bin
 
-COPY components-docker-up--app/* ./
-
+COPY components-docker-up--app/docker-up /usr/bin/docker-up
+COPY components-docker-up--app/runc-facade /usr/bin/runc-facade
 COPY components-docker-up--app/docker-compose /usr/local/bin/docker-compose


### PR DESCRIPTION
## Summary

Implements Phase 2 of the CLC-2255 critical CVE remediation plan for `components/docker-up`:

- Rebuilds Docker Compose `v2.40.3` from source during `go generate`, preserving the current Compose version while overriding vulnerable modules:
  - `golang.org/x/crypto@v0.52.0`
  - `golang.org/x/net@v0.55.0`
  - `google.golang.org/grpc@v1.79.3`
- Rebuilds runc from the existing `v1.1.15` source line, preserving the major/minor/patch version while building with fixed `golang.org/x/net@v0.55.0` and the current Go toolchain.
- Keeps runc seccomp support enabled during the rebuild.
- Removes the duplicate Docker Compose copy from the scratch image by copying only:
  - `/usr/bin/docker-up`
  - `/usr/bin/runc-facade`
  - `/usr/local/bin/docker-compose`
- Drops upstream Compose release provenance/SBOM sidecar handling because the Compose binary is now locally rebuilt rather than downloaded as an upstream release asset.

## Issues

Relates to CLC-2255

## Validation

- `git diff --check`
- `bash -n components/docker-up/dependencies.sh`
- `leeway build components/docker-up:docker --dont-test -Dversion=dev -DimageRepoBase=localhost:5000/gitpod`
- `leeway sbom scan components/docker-up:docker --with-dependencies --output-dir /tmp/docker-up-phase2-final-scan -Dversion=dev -DimageRepoBase=localhost:5000/gitpod`
  - `components/docker-up:bin-docker-up: critical=0 high=43 ignored=1`
  - `components/docker-up:app: critical=0 high=39 ignored=1`
  - `components/docker-up:docker: critical=0 high=39 ignored=1`
  - `components/docker-up:bin-runc-facade: critical=0 high=6 ignored=0`
  - `components/common-go:lib: critical=0 high=0 ignored=0`
  - `components/scrubber:lib: critical=0 high=0 ignored=0`
- `docker run --rm 221a0d1b6b3551448cfca53f3a3d75b4b8ced8c3:latest /usr/local/bin/docker-compose version`
  - `Docker Compose version v2.40.3`
- Confirmed `/usr/bin/docker-compose` is absent from the scratch image; container exits `127` for that path.

## Notes

Phase 1 was merged in #21496 before this PR was opened, so this draft targets `main` directly.