### PR TITLE
Reject invalid workspace timeout units

### DIFF
--- a/components/gitpod-protocol/src/gitpod-service.ts
+++ b/components/gitpod-protocol/src/gitpod-service.ts
@@ -356,17 +356,15 @@ const WORKSPACE_MAXIMUM_TIMEOUT_HOURS = 24;
 export type WorkspaceTimeoutDuration = string;
 export namespace WorkspaceTimeoutDuration {
     export function validate(duration: string): WorkspaceTimeoutDuration {
-        duration = duration.toLowerCase();
+        duration = duration.trim().toLowerCase();
 
         try {
-            // Ensure the duration contains proper units (h, m, s, ms, us, ns)
-            // This prevents bare numbers like "1" from being accepted
-            if (!/[a-z]/.test(duration)) {
+            // Keep this strict: ws-manager validates with Go's time.ParseDuration, so aliases like
+            // "hr" or "hrs" must not be accepted here.
+            if (!/^(?:\d+(?:ns|us|µs|ms|s|m|h))+$/.test(duration)) {
                 throw new Error("Invalid duration format");
             }
 
-            // Use parse-duration library which supports Go duration format perfectly
-            // This handles mixed-unit durations like "1h30m", "2h15m", etc.
             const milliseconds = parse(duration);
 
             if (milliseconds === undefined || milliseconds === null) {

--- a/components/gitpod-protocol/src/timeout-validation.spec.ts
+++ b/components/gitpod-protocol/src/timeout-validation.spec.ts
@@ -55,11 +55,18 @@ describe("WorkspaceTimeoutDuration", () => {
             expect(() => WorkspaceTimeoutDuration.validate("1x")).to.throw("Invalid timeout format");
             expect(() => WorkspaceTimeoutDuration.validate("")).to.throw("Invalid timeout format");
             expect(() => WorkspaceTimeoutDuration.validate("1")).to.throw("Invalid timeout format");
+            expect(() => WorkspaceTimeoutDuration.validate("5hrs")).to.throw("Invalid timeout format");
+            expect(() => WorkspaceTimeoutDuration.validate("24hrs")).to.throw("Invalid timeout format");
+            expect(() => WorkspaceTimeoutDuration.validate("1hr")).to.throw("Invalid timeout format");
         });
 
         it("should handle case insensitivity", () => {
             expect(WorkspaceTimeoutDuration.validate("1H30M")).to.equal("1h30m");
             expect(WorkspaceTimeoutDuration.validate("90M")).to.equal("90m");
+        });
+
+        it("should trim whitespace", () => {
+            expect(WorkspaceTimeoutDuration.validate(" 5h ")).to.equal("5h");
         });
 
         it("should reject zero or negative durations", () => {


### PR DESCRIPTION
## Summary

- Tighten workspace timeout validation to only accept units supported by Go `time.ParseDuration`.
- Reject aliases such as `5hrs`, `24hrs`, and `1hr` before user preferences are persisted.
- Add regression coverage for invalid aliases and whitespace trimming.

## Testing

- `yarn --cwd components/gitpod-protocol build`
- `yarn --cwd components/gitpod-protocol mocha './lib/timeout-validation.spec.js' --exit`
- `yarn --cwd components/gitpod-protocol test` (`109 passing`)
- `yarn --cwd components/gitpod-protocol lint`