### PR TITLE
fix: correct faled to failed typo in log message

### DIFF
--- a/components/supervisor/pkg/supervisor/services.go
+++ b/components/supervisor/pkg/supervisor/services.go
@@ -828,7 +828,7 @@ func (ss *ControlService) CreateSSHKeyPair(ctx context.Context, req *api.CreateS
 
 	hostKey, err := os.ReadFile("/.supervisor/ssh/sshkey.pub")
 	if err != nil {
-		log.WithError(err).Error("faled to read host key")
+		log.WithError(err).Error("failed to read host key")
 	} else {
 		hostKeyParts := strings.Split(string(hostKey), " ")
 		if len(hostKeyParts) >= 2 {


### PR DESCRIPTION
## Summary

Fix error log message typo in ControlService.CreateSSHKeyPair.

**Before:** log.WithError(err).Error("faled to read host key")
**After:** log.WithError(err).Error("failed to read host key")

**File:** components/supervisor/pkg/supervisor/services.go:831

---
*Submitted with Jah-yee (PR bot).