### PR TITLE
Update images digests

### DIFF
--- a/install/installer/leeway.Dockerfile
+++ b/install/installer/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM cgr.dev/chainguard/helm:latest@sha256:f0083e11d6f9e62c0fb186c81ff6ab6aa4b559521de79ca1868ec26f10ec111f
+FROM cgr.dev/chainguard/helm:latest@sha256:ace840c624287cb4b3a06d0e564af916643b66b6b697a103f87dc3351c5a6d12
 
 COPY install-installer--app/installer install-installer--app/provenance-bundle.jsonl /app/
 

--- a/install/installer/pkg/components/redis/constants.go
+++ b/install/installer/pkg/components/redis/constants.go
@@ -18,7 +18,7 @@ const (
 
 	ExporterRegistryRepo  = "quay.io"
 	ExporterRegistryImage = "oliver006/redis_exporter"
-	ExporterImageDigest   = "sha256:9e19fc77b9c5cb138a9ec9335b8bbcbbed620c4df54f7eb29329cdd8db148f1d"
+	ExporterImageDigest   = "sha256:e33fa2b546fae70dcaa30ac96bf46f1459ac4a6072adc44abd0c264e69b3ae64"
 
 	ExporterContainerName = "exporter"
 	ExporterPortName      = "exporter"


### PR DESCRIPTION
Update images digests using the latest version available for image/s

## How to test

Start a workspace in the preview environment and verify that it functions properly.

## Preview status

gitpod:summary

<details>
<summary>Preview Environment / Integration Tests</summary>

/werft with-preview

/werft with-gce-vm If enabled this will create the environment on GCE infra

/werft preemptible Saves cost. Untick this only if you're really sure you need a non-preemtible machine.

with-integration-tests=ssh Valid options are all, workspace, webapp, ide, jetbrains, vscode, ssh. If enabled, with-preview and with-large-vm will be enabled.
</details>