### PR TITLE
Update dev-environment image to main-gha.34488

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -112,7 +112,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ubuntu-latest-16-cores
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
@@ -140,7 +140,7 @@ jobs:
       (needs.configuration.outputs.is_scheduled_run != 'true')
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
@@ -187,7 +187,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
       env:
         DB_HOST: "mysql"
@@ -326,13 +326,6 @@ jobs:
           GITHUB_USER: roboquat
           GITHUB_EMAIL: roboquat@gitpod.io
           VERSION: ${{ needs.configuration.outputs.version }}
-      # Temporary bootstrap until CI runs on a dev-environment image containing Leeway v0.10.9.
-      - name: Install Leeway v0.10.9
-        shell: bash
-        run: |
-          curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.10.9/leeway_Linux_x86_64.tar.gz \
-            | tar -xz -C /usr/bin leeway
-          leeway version
       - name: Scan for Vulnerabilities
         id: scan
         shell: bash
@@ -478,7 +471,7 @@ jobs:
     if: needs.configuration.outputs.is_scheduled_run != 'true'
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
@@ -531,7 +524,7 @@ jobs:
     environment: branch-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     if: needs.configuration.outputs.with_monitoring == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
@@ -560,7 +553,7 @@ jobs:
     environment: branch-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       cancel-in-progress: ${{ needs.configuration.outputs.is_main_branch == 'false' }}
     runs-on: ubuntu-latest-16-cores
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
@@ -143,7 +143,7 @@ jobs:
       (needs.configuration.outputs.is_scheduled_run != 'true')
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-infrastructure
@@ -190,7 +190,7 @@ jobs:
         ports:
           - 6379:6379
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
       env:
         DB_HOST: "mysql"
@@ -329,13 +329,6 @@ jobs:
           GITHUB_USER: roboquat
           GITHUB_EMAIL: roboquat@gitpod.io
           VERSION: ${{ needs.configuration.outputs.version }}
-      # Temporary bootstrap until CI runs on a dev-environment image containing Leeway v0.10.9.
-      - name: Install Leeway v0.10.9
-        shell: bash
-        run: |
-          curl -fsSL https://github.com/gitpod-io/leeway/releases/download/v0.10.9/leeway_Linux_x86_64.tar.gz \
-            | tar -xz -C /usr/bin leeway
-          leeway version
       - name: Scan for Vulnerabilities
         id: scan
         shell: bash
@@ -516,7 +509,7 @@ jobs:
     if: needs.configuration.outputs.is_scheduled_run != 'true'
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     concurrency:
       group: ${{ github.ref == 'refs/heads/main' && github.run_id || github.sha }}-install
@@ -569,7 +562,7 @@ jobs:
     environment: main-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     if: needs.configuration.outputs.with_monitoring == 'true' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:
@@ -598,7 +591,7 @@ jobs:
     environment: main-build
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     if: needs.configuration.outputs.with_integration_tests != '' && needs.configuration.outputs.is_scheduled_run != 'true'
     concurrency:

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
     name: Configuration
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     outputs:
       name: ${{ steps.configuration.outputs.name }}
@@ -93,7 +93,7 @@ jobs:
     needs: [configuration]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
@@ -126,7 +126,7 @@ jobs:
     needs: [configuration, infrastructure]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
       volumes:
         - /var/tmp:/var/tmp
@@ -216,7 +216,7 @@ jobs:
     if: github.event.inputs.skip_delete != 'true' && always()
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -15,7 +15,7 @@ jobs:
   update-jetbrains:
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # pin@v2

--- a/.github/workflows/jetbrains-integration-test.yml
+++ b/.github/workflows/jetbrains-integration-test.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   jetbrains-smoke-test-linux:
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -60,7 +60,7 @@ jobs:
     needs: [configuration]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
@@ -93,7 +93,7 @@ jobs:
     if: ${{ needs.configuration.outputs.skip == 'false' }}
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
       volumes:
         - /var/tmp:/var/tmp
@@ -171,7 +171,7 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/preview-env-delete.yml
+++ b/.github/workflows/preview-env-delete.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event.ref_type == 'branch' || github.event.inputs.name != ''
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.github/workflows/preview-env-gc.yml
+++ b/.github/workflows/preview-env-gc.yml
@@ -11,7 +11,7 @@ jobs:
     name: "Find stale preview environments"
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     outputs:
       names: ${{ steps.set-matrix.outputs.names }}
@@ -43,7 +43,7 @@ jobs:
     needs: [stale]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     if: ${{ needs.stale.outputs.count > 0 }}
     strategy:

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -52,7 +52,7 @@ jobs:
     name: Configuration
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     outputs:
       name: ${{ steps.configuration.outputs.name }}
@@ -126,7 +126,7 @@ jobs:
     needs: [configuration]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     concurrency:
       group: ${{ needs.configuration.outputs.name }}-infrastructure
@@ -159,7 +159,7 @@ jobs:
     needs: [configuration, infrastructure]
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4
@@ -183,7 +183,7 @@ jobs:
     if: inputs.skip_delete != 'true' && always()
     runs-on: ubuntu-latest
     container:
-      image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+      image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
       options: --user root
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # pin@v4

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/gitpod-dev-artifact/dev/dev-environment:ona-clc-2243-fix-cve-2026-27143-bump-go-gha.275
+image: eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488
 workspaceLocation: gitpod/gitpod-ws.code-workspace
 checkoutLocation: gitpod
 ports:


### PR DESCRIPTION
## Description

Updates all active repository references to the newly published development image:

`eu.gcr.io/gitpod-core-dev/dev/dev-environment:main-gha.34488`

This replaces the previous branch-built image across GitHub workflows and `.gitpod.yml`. Fixture and test references are intentionally unchanged.

The temporary Leeway v0.10.9 bootstrap steps are also removed from the main and branch build workflows because the new dev-environment image includes that version.

## Related Issue(s)

[CLC-2259](https://linear.app/ona-team/issue/CLC-2259/resolve-critical-vulnerabilities-from-daily-scan)

## How to test

- Confirmed exactly 30 active references use `main-gha.34488`.
- Confirmed no active references retain the previous dev-artifact image.
- Confirmed fixture and test data remain unchanged.
- Ran repository pre-commit checks successfully.

## Documentation

No documentation update is required.

#### Preview status

gitpod:summary

## Build Options

<details>
<summary>Build</summary>

- [ ] /werft with-werft
- [ ] leeway-no-cache
- [ ] /werft no-test

</details>

/hold