### PR TITLE
Fix critical CVEs from daily vulnerability scan

### DIFF
--- a/components/dashboard/leeway.Dockerfile
+++ b/components/dashboard/leeway.Dockerfile
@@ -24,7 +24,7 @@ RUN xcaddy build v2.11.4 \
   --replace github.com/smallstep/certificates=github.com/smallstep/certificates@v0.30.1 \
   --output /caddy
 
-FROM caddy/caddy:2.11.4-alpine
+FROM caddy/caddy:2.11.4-alpine@sha256:ef2ad799652965da62f0548e15e00ebcef221dd6f29623d3455df6273ca39f46
 RUN apk upgrade --no-cache
 
 COPY --from=caddy-builder /caddy /usr/bin/caddy

--- a/components/gitpod-db/leeway.Dockerfile
+++ b/components/gitpod-db/leeway.Dockerfile
@@ -14,8 +14,11 @@ WORKDIR /app
 RUN /installer/install.sh
 
 FROM node:22.22.3-alpine
+# npm is not used by the runtime entrypoint; omit its bundled dependency tree.
 RUN apk upgrade --no-cache \
-    && apk add --no-cache bash
+    && apk add --no-cache bash \
+    && rm -rf /usr/local/lib/node_modules/npm \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx
 
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 COPY migrate.sh /app/migrate.sh

--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -23,7 +23,7 @@ RUN xcaddy build v2.11.4 \
   --replace github.com/smallstep/certificates=github.com/smallstep/certificates@v0.30.1 \
   --output /caddy
 
-FROM caddy/caddy:2.11.4-alpine
+FROM caddy/caddy:2.11.4-alpine@sha256:ef2ad799652965da62f0548e15e00ebcef221dd6f29623d3455df6273ca39f46
 
 # Ensure latest packages are present, like security updates.
 RUN apk upgrade --no-cache

--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -23,7 +23,7 @@ RUN xcaddy build v2.11.4 \
   --with github.com/gitpod-io/gitpod/proxy/plugins/sshtunnel=/plugins/sshtunnel \
   --with github.com/gitpod-io/gitpod/proxy/plugins/frontend_dev=/plugins/frontend_dev
 
-FROM caddy/caddy:2.11.4-alpine
+FROM caddy/caddy:2.11.4-alpine@sha256:ef2ad799652965da62f0548e15e00ebcef221dd6f29623d3455df6273ca39f46
 
 # Ensure latest packages are present, like security updates.
 RUN apk upgrade --no-cache \

--- a/components/server/leeway.Dockerfile
+++ b/components/server/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:22.22.0-alpine AS builder
+FROM node:22.22.3-alpine AS builder
 
 # Install Python, make, gcc and g++ for node-gyp
 RUN apk update && \
@@ -14,8 +14,11 @@ COPY components-server--app /installer/
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM node:22.22.1-alpine
-RUN apk upgrade --no-cache
+FROM node:22.22.3-alpine
+# npm is not used by the runtime entrypoint; omit its bundled dependency tree.
+RUN apk upgrade --no-cache \
+    && rm -rf /usr/local/lib/node_modules/npm \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx
 ENV NODE_OPTIONS="--unhandled-rejections=warn --max_old_space_size=2048"
 
 EXPOSE 3000

--- a/components/ws-manager-bridge/leeway.Dockerfile
+++ b/components/ws-manager-bridge/leeway.Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the GNU Affero General Public License (AGPL).
 # See License.AGPL.txt in the project root for license information.
 
-FROM node:22.22.0-alpine AS builder
+FROM node:22.22.3-alpine AS builder
 
 # Install bash for the installer script
 RUN apk update && \
@@ -14,8 +14,11 @@ COPY components-ws-manager-bridge--app /installer/
 WORKDIR /app
 RUN /installer/install.sh
 
-FROM node:22.22.1-alpine
-RUN apk upgrade --no-cache
+FROM node:22.22.3-alpine
+# npm is not used by the runtime entrypoint; omit its bundled dependency tree.
+RUN apk upgrade --no-cache \
+    && rm -rf /usr/local/lib/node_modules/npm \
+    && rm -f /usr/local/bin/npm /usr/local/bin/npx
 ENV NODE_OPTIONS=--unhandled-rejections=warn
 EXPOSE 3000
 COPY --from=builder --chown=node:node /app /app/


### PR DESCRIPTION
## Summary

Fixes the critical findings from the July 23 daily vulnerability scan by rebuilding the affected Caddy images on a pinned runtime base and removing npm's unused vulnerable dependency tree from production Node images.

## Remediation

| Affected images | Package | From | To | Advisory |
| --- | --- | --- | --- | --- |
| `dashboard`, `ide-proxy`, `proxy` | `caddy/caddy` runtime / Alpine OpenSSL | floating `2.11.4-alpine`; cached `libcrypto3` / `libssl3` | `2.11.4-alpine@sha256:ef2ad799…`; rebuilt packages at `3.5.7-r0` | OpenSSL critical set, including `CVE-2026-34182` |
| `server`, `ws-manager-bridge` | Node.js | builder `22.22.0`, runtime `22.22.1` | `22.22.3` | Base refresh |
| `server`, `ws-manager-bridge` | npm-bundled `tar` | `6.2.1` / `7.4.3` (3 vulnerable copies per image) | removed from runtime | `GHSA-23hp-3jrh-7fpw` |
| `gitpod-db` | npm-bundled `tar` | `7.5.11` | removed from runtime | `GHSA-23hp-3jrh-7fpw` |

npm/npx are not used by these production entrypoints: server and ws-manager-bridge invoke Node directly, while gitpod-db uses Yarn.

## Validation

- Built the proxy Docker image through leeway and generated its SBOM; the resulting image has zero critical Grype findings.
- Built the server, ws-manager-bridge, and gitpod-db final Docker stages.
- Scanned flattened final Node filesystems with Grype: zero unignored critical findings.
- Verified all three Node images retain Node `v22.22.3` and Yarn `1.22.22`.
- Ran `pre-commit run --files` for all six changed Dockerfiles.

Local leeway SBOM export for Node images is limited by Docker failing to read an `npx` file from the upstream base layer while saving parent layers. The final filesystems were flattened and scanned successfully; CI uses a separate Docker environment.

Fixes CLC-2263

Workflow: https://github.com/gitpod-io/gitpod/actions/runs/29968804580