### PR TITLE
Fix critical CVEs from daily vulnerability scan

### DIFF
--- a/components/dashboard/leeway.Dockerfile
+++ b/components/dashboard/leeway.Dockerfile
@@ -25,7 +25,10 @@ RUN xcaddy build v2.11.4 \
   --output /caddy
 
 FROM caddy/caddy:2.11.4-alpine@sha256:ef2ad799652965da62f0548e15e00ebcef221dd6f29623d3455df6273ca39f46
-RUN apk upgrade --no-cache
+
+# Keep runtime packages current and remove the unused curl client inherited from Caddy.
+RUN apk upgrade --no-cache \
+  && apk del curl
 
 COPY --from=caddy-builder /caddy /usr/bin/caddy
 COPY components-dashboard--static/conf/Caddyfile /etc/caddy/Caddyfile

--- a/components/ide-proxy/Dockerfile
+++ b/components/ide-proxy/Dockerfile
@@ -25,8 +25,9 @@ RUN xcaddy build v2.11.4 \
 
 FROM caddy/caddy:2.11.4-alpine@sha256:ef2ad799652965da62f0548e15e00ebcef221dd6f29623d3455df6273ca39f46
 
-# Ensure latest packages are present, like security updates.
-RUN apk upgrade --no-cache
+# Keep runtime packages current and remove the unused curl client inherited from Caddy.
+RUN apk upgrade --no-cache \
+  && apk del curl
 
 COPY --from=caddy-builder /caddy /usr/bin/caddy
 COPY conf/Caddyfile /etc/caddy/Caddyfile

--- a/components/proxy/Dockerfile
+++ b/components/proxy/Dockerfile
@@ -25,8 +25,9 @@ RUN xcaddy build v2.11.4 \
 
 FROM caddy/caddy:2.11.4-alpine@sha256:ef2ad799652965da62f0548e15e00ebcef221dd6f29623d3455df6273ca39f46
 
-# Ensure latest packages are present, like security updates.
+# Keep runtime packages current and remove the unused curl client inherited from Caddy.
 RUN apk upgrade --no-cache \
+  && apk del curl \
   && apk add --no-cache ca-certificates bash
 
 # Debug convenience


### PR DESCRIPTION
## Summary

- remove the unused `curl` package inherited from the Caddy runtime in dashboard, IDE proxy, and proxy images
- retain the existing Alpine security upgrade and required runtime packages
- reduce the shared runtime attack surface by removing `curl` and its now-unused libraries

## Vulnerability remediation

| Package | From | To | Critical vulnerabilities |
| --- | --- | --- | --- |
| `curl` | `8.19.0-r0` | removed | CVE-2026-8924, CVE-2026-8925, CVE-2026-8926, CVE-2026-8927, CVE-2026-9079, CVE-2026-10536, CVE-2026-11564, CVE-2026-11856 |

The daily scan reported the same eight critical findings in `components/ide-proxy:docker`, `components/proxy:docker`, and `components/dashboard:docker`. All three inherit `curl` from the same pinned Caddy Alpine runtime, but none use it in the final image.

## Validation

- `leeway build components/proxy:docker` completed successfully using a temporary local registry
- the built custom Caddy binary reports v2.11.4 and starts successfully
- Grype reports 0 critical vulnerabilities in the rebuilt proxy image
- Dockerfile checks pass for all three affected images
- `pre-commit run --files components/dashboard/leeway.Dockerfile components/ide-proxy/Dockerfile components/proxy/Dockerfile`

Fixes CLC-2264

Workflow: https://github.com/gitpod-io/gitpod/actions/runs/30055829473