### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/branch-build.yml
+++ b/.github/workflows/branch-build.yml
@@ -494,7 +494,7 @@ jobs:
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
           image_repo_base: ${{needs.configuration.outputs.image_repo_base}}/build
-      - uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # pin@v6
         if: needs.configuration.outputs.pr_number != '' && contains(needs.configuration.outputs.pr_body, 'gitpod:summary')
         with:
           script: |
@@ -621,7 +621,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.WORKSPACE_SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":x:"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -480,7 +480,7 @@ jobs:
           app-id: 308947
           installation-id: 35574470
       - name: trigger installation
-        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # pin@v6
         with:
           github-token: ${{ steps.auth.outputs.token }}
           script: |
@@ -532,7 +532,7 @@ jobs:
           analytics: ${{needs.configuration.outputs.analytics}}
           workspace_feature_flags: ${{needs.configuration.outputs.workspace_feature_flags}}
           image_repo_base: ${{needs.configuration.outputs.image_repo_base}}/build
-      - uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
+      - uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # pin@v6
         if: needs.configuration.outputs.pr_number != '' && contains(needs.configuration.outputs.pr_body, 'gitpod:summary')
         with:
           script: |
@@ -659,7 +659,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.WORKSPACE_SLACK_WEBHOOK }}
           SLACK_ICON_EMOJI: ":x:"

--- a/.github/workflows/code-build.yaml
+++ b/.github/workflows/code-build.yaml
@@ -92,7 +92,7 @@ jobs:
         uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/code-nightly.yml
+++ b/.github/workflows/code-nightly.yml
@@ -46,7 +46,7 @@ jobs:
         uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/code-updates.yml
+++ b/.github/workflows/code-updates.yml
@@ -104,7 +104,7 @@ jobs:
             team-experience
       - name: Slack notification (code)
         if: ${{ steps.code-update-pr.outputs.pull-request-url }}
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}
@@ -124,7 +124,7 @@ jobs:
           app-id: 308947
           installation-id: 35574470
       - name: Trigger Open VS Code Server Release
-        uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325 # pin@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # pin@v6
         with:
           github-token: ${{ steps.auth.outputs.token }}
           script: |

--- a/.github/workflows/ide-integration-tests.yml
+++ b/.github/workflows/ide-integration-tests.yml
@@ -80,7 +80,7 @@ jobs:
               } >> $GITHUB_OUTPUT
           fi
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
@@ -202,7 +202,7 @@ jobs:
           paths: "test/tests/**/TEST-*.xml"
         if: always()
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         if: success() || failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}

--- a/.github/workflows/jetbrains-auto-update-template.yml
+++ b/.github/workflows/jetbrains-auto-update-template.yml
@@ -66,7 +66,7 @@ jobs:
         uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.find-target.outputs.buildNumber && steps.leeway-build.outputs.leewayUsingCache == 'false') || failure() }}
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/jetbrains-update-plugin-platform-template.yml
+++ b/.github/workflows/jetbrains-update-plugin-platform-template.yml
@@ -151,7 +151,7 @@ jobs:
               uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
             - name: Slack Notification
               if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-              uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+              uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
               env:
                   SLACK_WEBHOOK: ${{ secrets.slackWebhook }}
                   SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/jetbrains-updates.yml
+++ b/.github/workflows/jetbrains-updates.yml
@@ -95,7 +95,7 @@ jobs:
               uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
             - name: Slack Notification
               if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-              uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+              uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
               env:
                   SLACK_WEBHOOK: ${{ secrets.IDE_SLACK_WEBHOOK }}
                   SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/preview-env-check-regressions.yml
+++ b/.github/workflows/preview-env-check-regressions.yml
@@ -152,12 +152,12 @@ jobs:
         if: always()
       - id: auth
         if: failure()
-        uses: google-github-actions/auth@955352c3b43196640b567e4646256d2fbb4aa1c7 # pin@v1
+        uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69 # pin@v1
         with:
           token_format: access_token
           credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         if: failure()
         env:
           SLACK_WEBHOOK: "${{ secrets.DEVX_SLACK_WEBHOOK }}"

--- a/.github/workflows/update-image-digest.yml
+++ b/.github/workflows/update-image-digest.yml
@@ -164,7 +164,7 @@ jobs:
         uses: filiptronicek/get-last-job-status@1c211ff20d1706ff0bc3fc8022f7bd6518b88bc4 # pin@main
       - name: Slack Notification
         if: ${{ (success() && steps.lastrun.outputs.status == 'failed') || failure() }}
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         env:
           SLACK_WEBHOOK: ${{ secrets.RELEASE_SLACK_WEBHOOK }}
           SLACK_COLOR: ${{ job.status }}

--- a/.github/workflows/workspace-integration-tests.yml
+++ b/.github/workflows/workspace-integration-tests.yml
@@ -112,7 +112,7 @@ jobs:
               } >> $GITHUB_OUTPUT
           fi
       - name: Slack Notification
-        uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36 # pin@v2
+        uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661 # pin@v2
         if: failure()
         env:
           SLACK_WEBHOOK: ${{ secrets.WORKSPACE_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/branch-build.yml`

**Current (invalid):**

```yaml
uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325
```

**Why this is wrong:**

- `00f12e3e20659f42342b1c0226afda7f7c042325` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `d7906e4ad0b1822421a7e6a35d5ca353c962f410`.

**Correct pin:**

```yaml
uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
```

### 2. `.github/workflows/branch-build.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 3. `.github/workflows/build.yml`

**Current (invalid):**

```yaml
uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325
```

**Why this is wrong:**

- `00f12e3e20659f42342b1c0226afda7f7c042325` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `d7906e4ad0b1822421a7e6a35d5ca353c962f410`.

**Correct pin:**

```yaml
uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
```

### 4. `.github/workflows/build.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 5. `.github/workflows/code-build.yaml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 6. `.github/workflows/code-nightly.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 7. `.github/workflows/code-updates.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 8. `.github/workflows/code-updates.yml`

**Current (invalid):**

```yaml
uses: actions/github-script@00f12e3e20659f42342b1c0226afda7f7c042325
```

**Why this is wrong:**

- `00f12e3e20659f42342b1c0226afda7f7c042325` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `d7906e4ad0b1822421a7e6a35d5ca353c962f410`.

**Correct pin:**

```yaml
uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
```

### 9. `.github/workflows/ide-integration-tests.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 10. `.github/workflows/jetbrains-auto-update-template.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 11. `.github/workflows/jetbrains-update-plugin-platform-template.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 12. `.github/workflows/jetbrains-updates.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 13. `.github/workflows/preview-env-check-regressions.yml`

**Current (invalid):**

```yaml
uses: google-github-actions/auth@955352c3b43196640b567e4646256d2fbb4aa1c7
```

**Why this is wrong:**

- `955352c3b43196640b567e4646256d2fbb4aa1c7` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69`.

**Correct pin:**

```yaml
uses: google-github-actions/auth@3a3c4c57d294ef65efaaee4ff17b22fa88dd3c69
```

### 14. `.github/workflows/preview-env-check-regressions.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 15. `.github/workflows/update-image-digest.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

### 16. `.github/workflows/workspace-integration-tests.yml`

**Current (invalid):**

```yaml
uses: rtCamp/action-slack-notify@cdf0a2130cbcdfd82ba5fcac8e076370bf381b36
```

**Why this is wrong:**

- `cdf0a2130cbcdfd82ba5fcac8e076370bf381b36` is **not a commit SHA**. It is the Git object SHA of an **annotated tag**.
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the peeled commit SHA: `e31e87e03dd19038e411e38ae27cbad084a90661`.

**Correct pin:**

```yaml
uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
