### PR TITLE
Handle GitLab ref lookup rejections immediately

### DIFF
--- a/components/server/src/gitlab/gitlab-context-parser.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.ts
@@ -214,8 +214,10 @@ export class GitlabContextParser extends AbstractContextParser implements IConte
         try {
             const branchOrTagPromise =
                 segments.length > 0 ? this.getBranchOrTag(user, owner, repoName, segments) : undefined;
-            const repository = await this.fetchRepo(user, `${owner}/${repoName}`);
-            const branchOrTag = await branchOrTagPromise;
+            const [repository, branchOrTag] = await Promise.all([
+                this.fetchRepo(user, `${owner}/${repoName}`),
+                branchOrTagPromise,
+            ]);
             const context = <NavigatorContext>{
                 isFile: false,
                 path: "",

--- a/components/server/src/gitlab/gitlab-context-parser.unit.spec.ts
+++ b/components/server/src/gitlab/gitlab-context-parser.unit.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Copyright (c) 2026 Gitpod GmbH. All rights reserved.
+ * Licensed under the GNU Affero General Public License (AGPL).
+ * See License.AGPL.txt in the project root for license information.
+ */
+
+import { expect } from "chai";
+import { suite, test } from "@testdeck/mocha";
+import { Repository, User } from "@gitpod/gitpod-protocol";
+import { GitLabApi, GitLab } from "./api";
+import { GitlabContextParser } from "./gitlab-context-parser";
+
+class TestableGitlabContextParser extends GitlabContextParser {
+    private resolveRepositoryLookup!: (repository: Repository) => void;
+    private readonly repositoryLookup = new Promise<Repository>((resolve) => {
+        this.resolveRepositoryLookup = resolve;
+    });
+
+    protected override fetchRepo(): Promise<Repository> {
+        return this.repositoryLookup;
+    }
+
+    public handleTreeContextForTest(segments: string[]) {
+        return this.handleTreeContext({} as User, "gitlab.example.com", "foo/bar/f/develop-b", "topic", segments);
+    }
+
+    public finishRepositoryLookup() {
+        this.resolveRepositoryLookup({} as Repository);
+    }
+}
+
+@suite
+class GitlabContextParserUnitSpec {
+    @test
+    public async handlesMissingRefRejectionWhileRepositoryLookupIsPending() {
+        const encodedMissingRef = "distribution%E2%80%8B_lettuce_v1";
+        const parser = new TestableGitlabContextParser();
+        (parser as any).gitlabApi = {
+            run: async () => new GitLab.ApiError("not found", 404),
+        } as unknown as GitLabApi;
+
+        const unhandledRejections: unknown[] = [];
+        const onUnhandledRejection = (reason: unknown) => unhandledRejections.push(reason);
+        process.on("unhandledRejection", onUnhandledRejection);
+
+        try {
+            const result = parser.handleTreeContextForTest([encodedMissingRef]).then(
+                () => undefined,
+                (error) => error,
+            );
+
+            await new Promise<void>((resolve) => setImmediate(resolve));
+
+            expect(unhandledRejections).to.be.empty;
+            const error = await result;
+            expect(error).to.be.instanceOf(Error);
+            expect(error.message).to.include(encodedMissingRef);
+        } finally {
+            parser.finishRepositoryLookup();
+            process.off("unhandledRejection", onUnhandledRejection);
+        }
+    }
+}
+
+module.exports = new GitlabContextParserUnitSpec();


### PR DESCRIPTION
## Summary

- await the GitLab repository and ref lookups together so both promises receive rejection handlers immediately
- preserve the existing missing-ref error semantics
- add a regression test using a percent-encoded zero-width character in the missing ref while the repository lookup remains pending

## Root cause

The ref lookup started before the repository lookup completed, but its promise was not awaited until afterward. When ref resolution failed first, Node reported an unhandled rejection before the request eventually observed and propagated the same error.

## Validation

- `yarn workspace @gitpod/server build`
- `yarn workspace @gitpod/server test:unit -- --grep 'GitlabContextParserUnitSpec'`
- `pre-commit run --files components/server/src/gitlab/gitlab-context-parser.ts components/server/src/gitlab/gitlab-context-parser.unit.spec.ts`
- regression check: the focused test fails with the previous sequential await ordering because it observes the unhandled rejection, and passes with `Promise.all()`